### PR TITLE
[eudsl-py] Increase robustness of setting MLIR_INCLUDE_DIR

### DIFF
--- a/projects/eudsl-py/CMakeLists.txt
+++ b/projects/eudsl-py/CMakeLists.txt
@@ -52,7 +52,7 @@ if(EUDSLPY_STANDALONE_BUILD)
   endif()
   # for out-of-tree MLIR_INCLUDE_DIR points to the build dir by default
   # and MLIR_INCLUDE_DIRS points to the correct place
-  set(MLIR_INCLUDE_DIR ${MLIR_INCLUDE_DIRS})
+  list(GET MLIR_INCLUDE_DIRS 0 MLIR_INCLUDE_DIR)
 
   include_directories(${CMAKE_CURRENT_LIST_DIR}/../common)
 endif()


### PR DESCRIPTION
This was set to MLIR_INCLUDE_DIRS which may be a list on systems. `list(GET MLIR_INCLUDE_DIRS 0 MLIR_INCLUDE_DIR)` covers this case as well.

Just noticed this while trying to build this project from scratch. I used the `build_llvm.sh` script and at least on my system (MacOS) I had `MLIR_INCLUDE_DIRS=/Users/timonicolai/github/personal/eudsl/third_party/llvm-project/mlir/include;/Users/timonicolai/github/personal/eudsl/llvm-build/tools/mlir/include`.