### PR TITLE
Add 'split-file' to llvm_cache.cmake

### DIFF
--- a/scripts/cmake/llvm_cache.cmake
+++ b/scripts/cmake/llvm_cache.cmake
@@ -97,6 +97,7 @@ set(LLVM_MlirDevelopment_DISTRIBUTION_COMPONENTS
     llvm-libraries
     llvm-tblgen
 
+    split-file
     count
     FileCheck
     not


### PR DESCRIPTION
circt depends on split-file, this change should hopefully make it possible to use the wheel to build circt against.