### PR TITLE
[eudsl-python-extras] Fix mlir_type_to_ctype wrong dictionary lookup

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/util.py
+++ b/projects/eudsl-python-extras/mlir/extras/util.py
@@ -175,7 +175,7 @@ _mlir_type_to_ctype = {
 
 def mlir_type_to_ctype(mlir_type):
     __mlir_type_to_ctype = {k(): v for k, v in _mlir_type_to_ctype.items()}
-    return _mlir_type_to_ctype.get(mlir_type)
+    return __mlir_type_to_ctype.get(mlir_type)
 
 
 def infer_mlir_type(

--- a/projects/eudsl-python-extras/tests/test_runtime.py
+++ b/projects/eudsl-python-extras/tests/test_runtime.py
@@ -900,10 +900,6 @@ def test_refbackend_get_ctype_func_memref(ctx: MLIRContext):
     assert legal_ret_types[0] == unranked_memref_type
 
 
-@pytest.mark.xfail(
-    reason="mlir_type_to_ctype has a bug: line 176 lookups use _mlir_type_to_ctype (keys are constructors like T.f32) "
-    "instead of __mlir_type_to_ctype (keys are instances like T.f32()). Scalar ctype path is unreachable."
-)
 def test_refbackend_get_ctype_func_scalar(ctx: MLIRContext):
     """Lines 97-98: get_ctype_func with scalar type returns (ctype path)"""
     from mlir.extras.runtime.refbackend import get_ctype_func


### PR DESCRIPTION
## Summary
- Fix bug in `mlir_type_to_ctype` where the lookup used `_mlir_type_to_ctype` (constructor-keyed) instead of `__mlir_type_to_ctype` (instance-keyed), making the scalar ctype path unreachable.
- Remove `@pytest.mark.xfail` from `test_refbackend_get_ctype_func_scalar` which now passes.

## Test plan
- [x] `pytest tests/test_runtime.py::test_refbackend_get_ctype_func_scalar -xvs` passes