### PR TITLE
[eudsl-python-extras] Fix subview rank_reduce crash on non-StridedLayoutAttr

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
@@ -368,7 +368,7 @@ def subview(
     if rank_reduce:
         result_shape = list(result_type.shape)
         layout_strides = None
-        if result_type.layout:
+        if result_type.layout and isinstance(result_type.layout, StridedLayoutAttr):
             layout_strides = result_type.layout.strides
         for i, (s, ss) in reversed(
             list(enumerate(list(zip_longest(sizes, static_sizes))))

--- a/projects/eudsl-python-extras/tests/dialect/test_memref.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_memref.py
@@ -1373,10 +1373,6 @@ def test_subview_rank_reduce(ctx: MLIRContext):
     ctx.module.operation.verify()
 
 
-@pytest.mark.xfail(
-    reason="subview rank_reduce without strided layout hits AffineMapAttr which doesn't have .strides — "
-    "the code should check isinstance(layout, StridedLayoutAttr)"
-)
 def test_subview_rank_reduce_no_layout(ctx: MLIRContext):
     """Branch 369->371: subview with rank_reduce=True and no layout (layout is None)"""
 


### PR DESCRIPTION
## Summary
- Add `isinstance(result_type.layout, StridedLayoutAttr)` check before accessing `.strides` in the `subview` rank_reduce path.
- Previously crashed with `AttributeError` when layout was an `AffineMapAttr`.
- Remove `@pytest.mark.xfail` from `test_subview_rank_reduce_no_layout`.

## Test plan
- [x] `pytest tests/dialect/test_memref.py::test_subview_rank_reduce_no_layout -xvs` passes