### PR TITLE
[eudsl-python-extras] Fix CanonicalizeWhile non-walrus NamedExpr missing ctx=Store()

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/scf.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/scf.py
@@ -488,7 +488,10 @@ class CanonicalizeWhile(StrictTransformer):
             updated_node.test.value = next_
         else:
             new_test = ast.NamedExpr(
-                target=ast.Name(f"__init__{updated_node.lineno}"), value=next_
+                target=ast.Name(
+                    f"__init__{updated_node.lineno}", ctx=ast.Store()
+                ),
+                value=next_,
             )
             new_test = ast.copy_location(new_test, updated_node)
             updated_node.test = new_test

--- a/projects/eudsl-python-extras/tests/dialect/test_scf.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_scf.py
@@ -2839,9 +2839,6 @@ def test_if_results_none(ctx: MLIRContext):
     filecheck_with_comments(ctx.module)
 
 
-@pytest.mark.xfail(
-    reason="non-walrus while (line 466/486-490) causes 'Invalid CFG, inconsistent stackdepth' in compile()"
-)
 def test_while_canonicalize_no_walrus(ctx: MLIRContext):
     """Lines 466, 486-490: while without walrus operator (not a NamedExpr)"""
     one = constant(1)


### PR DESCRIPTION
## Summary
- Add `ctx=ast.Store()` to `ast.Name` target in `CanonicalizeWhile` when creating a `NamedExpr` for non-walrus while loops.
- Without this, `compile()` fails with "Invalid CFG, inconsistent stackdepth".
- Remove `@pytest.mark.xfail` from `test_while_canonicalize_no_walrus`.

## Test plan
- [x] `pytest tests/dialect/test_scf.py::test_while_canonicalize_no_walrus -xvs` passes