### PR TITLE
[eudsl-python-extras] Fix reinterpret_cast with None offsets/sizes

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
@@ -620,9 +620,9 @@ def reinterpret_cast(
     ip=None,
 ) -> Value:
     if offsets is None:
-        offsets = []
+        offsets = [0]
     if sizes is None:
-        sizes = []
+        sizes = list(source.type.shape)
 
     offsets_, _packed_offsets, static_offsets = _dispatch_mixed_values(offsets)
     sizes_, _packed_sizes, static_sizes = _dispatch_mixed_values(sizes)

--- a/projects/eudsl-python-extras/tests/dialect/test_memref.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_memref.py
@@ -1265,12 +1265,8 @@ def test_view_default_dtype(ctx: MLIRContext):
     filecheck_with_comments(ctx.module)
 
 
-@pytest.mark.xfail(
-    reason="reinterpret_cast with offsets=None produces empty static_offsets which causes "
-    "'expected the number of strides to match the rank' verification failure"
-)
 def test_reinterpret_cast_none_offsets(ctx: MLIRContext):
-    """Line 616-617: reinterpret_cast with offsets=None (defaults to [])"""
+    """Line 616-617: reinterpret_cast with offsets=None (defaults to [0])"""
 
     @func_decorator
     def reinterpret_test(mem: T.memref(16, T.f32())):
@@ -1286,12 +1282,8 @@ def test_reinterpret_cast_none_offsets(ctx: MLIRContext):
     ctx.module.operation.verify()
 
 
-@pytest.mark.xfail(
-    reason="reinterpret_cast with sizes=None produces empty static_sizes which causes "
-    "result type construction to fail"
-)
 def test_reinterpret_cast_none_sizes(ctx: MLIRContext):
-    """Line 618-619: reinterpret_cast with sizes=None (defaults to [])"""
+    """Line 618-619: reinterpret_cast with sizes=None (defaults to source shape)"""
 
     @func_decorator
     def reinterpret_test(mem: T.memref(16, T.f32())):


### PR DESCRIPTION
## Summary
- When `offsets=None`, default to `[0]` instead of `[]` (empty list produced invalid zero-length attributes).
- When `sizes=None`, default to `list(source.type.shape)` instead of `[]` (empty list produced a 0-D result type).
- Remove `@pytest.mark.xfail` from `test_reinterpret_cast_none_offsets` and `test_reinterpret_cast_none_sizes`.

## Test plan
- [x] `pytest tests/dialect/test_memref.py::test_reinterpret_cast_none_offsets -xvs` passes
- [x] `pytest tests/dialect/test_memref.py::test_reinterpret_cast_none_sizes -xvs` passes