### PR TITLE
[eudsl-python-extras] Fix subview with None offsets/sizes/strides

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/memref.py
@@ -343,11 +343,11 @@ def subview(
     ip=None,
 ):
     if offsets is None:
-        offsets = []
+        offsets = [0] * len(source.type.shape)
     if sizes is None:
-        sizes = []
+        sizes = list(source.type.shape)
     if strides is None:
-        strides = []
+        strides = [1] * len(source.type.shape)
 
     for s in [offsets, sizes, strides]:
         for idx, i in enumerate(s):

--- a/projects/eudsl-python-extras/tests/dialect/test_memref.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_memref.py
@@ -1224,11 +1224,6 @@ def test_dynamic_dim(ctx: MLIRContext):
     filecheck_with_comments(ctx.module)
 
 
-@pytest.mark.xfail(
-    reason="subview with all None offsets/sizes/strides produces empty lists which results in "
-    "'expected 2 offset values, got 0' verification failure — the None defaults only make sense "
-    "when _dispatch_mixed_values receives actual int values to split into static/dynamic"
-)
 def test_subview_with_none_args(ctx: MLIRContext):
     """Lines 346, 348, 350: subview called with None offsets/sizes/strides"""
     from mlir.extras.dialects.memref import subview as extras_subview


### PR DESCRIPTION
## Summary
- When `None` is passed for offsets/sizes/strides in `subview()`, infer defaults from the source memref shape instead of using empty lists.
- `offsets=None` → `[0] * rank`, `sizes=None` → `source.shape`, `strides=None` → `[1] * rank`
- Remove `@pytest.mark.xfail` from `test_subview_with_none_args`.

## Test plan
- [x] `pytest tests/dialect/test_memref.py::test_subview_with_none_args -xvs` passes