### PR TITLE
[eudsl-python-extras] Fix parallel_insert_slice with dynamic sizes/strides

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
@@ -335,23 +335,25 @@ def parallel_insert_slice(
     static_sizes=None,
     static_strides=None,
 ):
-    if static_offsets is None:
-        assert offsets is not None
-        static_offsets = [S, S]
-    if static_sizes is None:
-        assert sizes is not None
-        static_sizes = [S, S]
-    if static_strides is None:
-        assert strides is not None
-        static_strides = [S, S]
+    from ...dialects.memref import _is_constant_int_like
+
+    for s in [offsets, sizes, strides]:
+        if s is not None:
+            for idx, i in enumerate(s):
+                if _is_constant_int_like(i):
+                    s[idx] = i.owner.opview.literal_value
+
+    if offsets is not None and static_offsets is None:
+        offsets, _, static_offsets = _dispatch_mixed_values(offsets)
+    if sizes is not None and static_sizes is None:
+        sizes, _, static_sizes = _dispatch_mixed_values(sizes)
+    if strides is not None and static_strides is None:
+        strides, _, static_strides = _dispatch_mixed_values(strides)
     if offsets is None:
-        assert static_offsets
         offsets = []
     if sizes is None:
-        assert static_sizes
         sizes = []
     if strides is None:
-        assert static_strides
         strides = []
 
     return tensor.parallel_insert_slice(

--- a/projects/eudsl-python-extras/tests/dialect/test_tensor.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_tensor.py
@@ -817,10 +817,6 @@ def test_parallel_insert_slice_with_static_args(ctx: MLIRContext):
     ctx.module.operation.verify()
 
 
-@pytest.mark.xfail(
-    reason="parallel_insert_slice with dynamic sizes/strides creates arith.constant ops inside "
-    "scf.forall.in_parallel which only allows ParallelCombiningOpInterface ops"
-)
 def test_parallel_insert_slice_with_dynamic_args(ctx: MLIRContext):
     """Lines 342-346, 348-352: parallel_insert_slice with dynamic offsets/sizes/strides"""
     from mlir.extras.dialects.scf import forall_


### PR DESCRIPTION
## Summary
- Use `_dispatch_mixed_values` to properly separate static ints from dynamic Values in `parallel_insert_slice`.
- Canonicalize constant-int-like Values (e.g., `arith.constant 10`) to their literal int values before dispatch, matching how `memref.subview` handles this.
- Previously all Values were blindly marked dynamic (`static_sizes=[S,S]`) causing a source/result type mismatch.
- Remove `@pytest.mark.xfail` from `test_parallel_insert_slice_with_dynamic_args`.

## Test plan
- [x] `pytest tests/dialect/test_tensor.py::test_parallel_insert_slice_with_dynamic_args -xvs` passes
- [x] All 48 existing tensor tests pass (no regression)