### PR TITLE
[eudsl-python-extras] Fix bb() with explicit branch targets by skipping redundant terminator

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/func.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/func.py
@@ -23,13 +23,14 @@ from ...ir import (
     FlatSymbolRefAttr,
     FunctionType,
     InsertionPoint,
+    IsTerminatorTrait,
+    OpResultList,
     OpView,
     Operation,
-    OpResultList,
+    ShapedType,
     Type,
     TypeAttr,
-    Value,
-    ShapedType,
+    Value
 )
 
 _call = call
@@ -455,8 +456,19 @@ class FuncBase:
             return self._func_op
 
         self._func_op.regions[0].blocks.append(*input_types, arg_locs=self.arg_locs)
+
+        # TODO(max): upstream this into op_region_builder so it checks
+        # IsTerminatorTrait before inserting the terminator.
+        def _safe_terminator(res):
+            block = InsertionPoint.current.block
+            if len(list(block.operations)) > 0:
+                last_op = list(block.operations)[-1]
+                if last_op.operation.has_trait(IsTerminatorTrait):
+                    return
+            self.return_op_ctor(res)
+
         builder_wrapper = op_region_builder(
-            self._func_op, self._func_op.regions[0], terminator=self.return_op_ctor
+            self._func_op, self._func_op.regions[0], terminator=_safe_terminator
         )
 
         return_types = []

--- a/projects/eudsl-python-extras/tests/test_regions.py
+++ b/projects/eudsl-python-extras/tests/test_regions.py
@@ -512,10 +512,6 @@ def test_successor_ctx_manager(ctx: MLIRContext):
     filecheck_with_comments(ctx.module)
 
 
-@pytest.mark.xfail(
-    reason="bb() context manager inserts branch terminators that prevent subsequent insertion; "
-    "need raw block API to create target blocks before the cond_br"
-)
 def test_cond_br_explicit_dest(ctx: MLIRContext):
     """Branches 47->49, 49->51: cond_br with explicit true_dest and false_dest"""
 


### PR DESCRIPTION
## Summary
- Wrap `return_op_ctor` in a guard that checks whether the target block already has a terminator before inserting `func.return`.
- This fixes the case where `bb()` is used to create blocks with explicit terminators (e.g., `return_([])`) and then a `cond_br` is inserted in the entry block — previously `op_region_builder` would try to add a second terminator to the last block.
- Remove `@pytest.mark.xfail` from `test_cond_br_explicit_dest`.

## Test plan
- [x] `pytest tests/test_regions.py::test_cond_br_explicit_dest -xvs` passes
- [x] All 18 region tests pass
- [x] Full test suite: 587 passed, 99.23% coverage