### PR TITLE
[eudsl-python-extras] Implement generic type parameter validation

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/func.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/func.py
@@ -203,8 +203,22 @@ class ReifiedTypeParam:
             self.concrete_val = concrete_val
 
         self.type_name = type_var_bound
-        # TODO(max): implement _some_ kind of type checking to make sure
-        # self.concrete_val matches either the type bound or the type of the default
+        # Reject concrete values that don't match the type bound.
+        # e.g., for `def foo[A_t = T.memref(M, K, dtype)](A: A_t)`,
+        # A_t's bound is "MemRefType" — passing an int like `foo[..., 8]`
+        # should fail. MLIR Type instances are exempt from the name check
+        # because subclass names (e.g., "F32Type") won't string-match
+        # bounds like "type" or "MemRefType".
+        if (
+            self.concrete_val is not None
+            and isinstance(type_var_bound, str)
+            and type(self.concrete_val).__name__ != type_var_bound
+            and not isinstance(self.concrete_val, Type)
+        ):
+            raise TypeError(
+                f"Generic parameter '{self.name}' expects '{type_var_bound}', "
+                f"got '{type(self.concrete_val).__name__}' (value: {self.concrete_val})"
+            )
 
     def add_replace_in_closure(self, fn):
         # only in the closure if used in the body

--- a/projects/eudsl-python-extras/tests/test_generics.py
+++ b/projects/eudsl-python-extras/tests/test_generics.py
@@ -729,9 +729,6 @@ def test_pooling_ncdhw_max_parallel(ctx: MLIRContext):
     filecheck_with_comments(module)
 
 
-@pytest.mark.xfail(
-    reason="type checking between self.concrete_val and type_bound/type_var_default not implemented"
-)
 def test_wrong_generics_types(ctx: MLIRContext):
     # fmt: off
     @gpu.func
@@ -754,7 +751,8 @@ def test_wrong_generics_types(ctx: MLIRContext):
         c_col = block_idx.x * BN
 
     # the last 8 sets the reified param for A_t (which is wrong)
-    sgemm_shared_mem_1d_block_tiling[128, 128, 128, T.f32(), 64, 64, 8, 8, 8].emit()
+    with pytest.raises(TypeError, match="Generic parameter 'A_t'"):
+        sgemm_shared_mem_1d_block_tiling[128, 128, 128, T.f32(), 64, 64, 8, 8, 8].emit()
 
 
 def test_generics_basic(ctx: MLIRContext):


### PR DESCRIPTION
## Summary
- Implement type checking in `ReifiedTypeParam` (resolves the TODO at line 205).
- When `type_var_bound` is `"type"`, validates the concrete value is an MLIR `Type` instance.
- For other bounds (e.g., `"MemRefType"`), rejects non-Type values like plain ints.
- Change test from `@pytest.mark.xfail` to `pytest.raises(TypeError)`.

## Test plan
- [x] `pytest tests/test_generics.py::test_wrong_generics_types -xvs` passes (raises TypeError)
- [x] All 23 generics tests pass (no regression)