### PR TITLE
[eudsl-python-extras] Convert NVIDIA GPU test from xfail to skipif

### DIFF
--- a/projects/eudsl-python-extras/tests/dialect/test_nvvm_nvgpu.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_nvvm_nvgpu.py
@@ -430,7 +430,7 @@ except Exception:
 
 
 # based on https://github.com/llvm/llvm-project/blob/9cc2122bf5a81f7063c2a32b2cb78c8d615578a1/mlir/test/Integration/GPU/CUDA/TensorCore/sm80/transform-mma-sync-matmul-f16-f16-accum.mlir#L6
-@pytest.mark.xfail
+@pytest.mark.skipif(not NVIDIA_GPU, reason="requires NVIDIA GPU with SM80+")
 def test_transform_mma_sync_matmul_f16_f16_accum_run(ctx: MLIRContext, capfd):
     range_ = scf.range_
 


### PR DESCRIPTION
## Summary
- Convert `@pytest.mark.xfail` to `@pytest.mark.skipif(not NVIDIA_GPU, ...)` for `test_transform_mma_sync_matmul_f16_f16_accum_run`.
- The test isn't broken — it requires SM80+ NVIDIA GPU hardware that isn't available in most environments.

## Test plan
- [x] `pytest tests/dialect/test_nvvm_nvgpu.py` — 4 passed, 1 skipped