### PR TITLE
[eudsl-python-extras] Replace bare except with Exception, fix find_ops type hint

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/util.py
+++ b/projects/eudsl-python-extras/mlir/extras/util.py
@@ -110,7 +110,7 @@ def shlib_prefix():
     return shlib_pref
 
 
-def find_ops(op, pred: Callable[[OpView, Operation, Module], bool], single=False):
+def find_ops(op, pred: Callable[[Operation], bool], single=False):
     if isinstance(op, (OpView, Module)):
         op = op.operation
 
@@ -405,7 +405,7 @@ def _get_sym_name(previous_frame, check_func_call=None):
             else:
                 maybe_unique_sym_name = f"{maybe_unique_sym_name}_0"
         return maybe_unique_sym_name
-    except:
+    except Exception:
         return None
 
 


### PR DESCRIPTION
## Summary
- Replace bare `except:` in `_get_sym_name()` with `except Exception:` to avoid catching `KeyboardInterrupt`/`SystemExit`.
- Fix `find_ops()` type hint: predicate takes a single `Operation` arg, not `(OpView, Operation, Module)`.

## Test plan
- [x] Full test suite: 599 passed, 99.34% coverage