### PR TITLE
[extras] Add llvm.func decorator (mirror of func / GPUFunc)

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/func.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/func.py
@@ -30,7 +30,7 @@ from ...ir import (
     ShapedType,
     Type,
     TypeAttr,
-    Value
+    Value,
 )
 
 _call = call
@@ -386,6 +386,14 @@ class FuncBase:
     def __str__(self):
         return str(f"{self.__class__} {self.__dict__}")
 
+    def _make_function_type(self, input_types, result_types) -> TypeAttr:
+        """Build the (builtin) function type attr for the func op.
+
+        Overridden by subclasses (e.g. for llvm.func) that need a
+        dialect-specific function type.
+        """
+        return TypeAttr.get(FunctionType.get(inputs=input_types, results=result_types))
+
     def _build_input_types(self) -> Union[list[Type], OpView]:
         """Either build all input types (if no generics or all generics reified) or return a further specialized funcop thing (the return of __getitem__)."""
         locals = {}
@@ -447,11 +455,8 @@ class FuncBase:
         if self.function_type is not None:
             function_type = TypeAttr.get(self.function_type)
         else:
-            function_type = TypeAttr.get(
-                FunctionType.get(
-                    inputs=input_types,
-                    results=list(map(evaluate_type_annotation, self.return_types)),
-                )
+            function_type = self._make_function_type(
+                input_types, list(map(evaluate_type_annotation, self.return_types))
             )
 
         self._func_op = self.func_op_ctor(
@@ -499,8 +504,9 @@ class FuncBase:
 
         if self.function_type is None:
             builder_wrapper(grab_results)
-            function_type = FunctionType.get(inputs=input_types, results=return_types)
-            self._func_op.attributes["function_type"] = TypeAttr.get(function_type)
+            self._func_op.attributes["function_type"] = self._make_function_type(
+                input_types, return_types
+            )
         else:
             builder_wrapper(self.body_builder)
 
@@ -545,7 +551,7 @@ class FuncBase:
                 v = v.__name__
             name_mangled_generics.append(f"{tvar}_{v}")
 
-        return FuncBase(
+        return type(self)(
             body_builder,
             self.func_op_ctor,
             self.return_op_ctor,

--- a/projects/eudsl-python-extras/mlir/extras/dialects/llvm/__init__.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/llvm/__init__.py
@@ -1,14 +1,26 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from functools import update_wrapper
 from typing import Union, Optional
 
-from ...util import infer_mlir_type
+from ..func import FuncBase
+from ...util import infer_mlir_type, make_maybe_no_args_decorator
 from ....dialects._ods_common import get_op_result_or_op_results
 
 # noinspection PyUnresolvedReferences
 from ....dialects.llvm import *
-from ....ir import Type, Value, IntegerAttr, FloatAttr
+
+# noinspection PyUnresolvedReferences
+from ....dialects.llvm import FunctionType as LLVMFunctionType
+from ....ir import (
+    FlatSymbolRefAttr,
+    FloatAttr,
+    IntegerAttr,
+    Type,
+    TypeAttr,
+    Value,
+)
 
 ValueRef = Value
 
@@ -17,10 +29,87 @@ def llvm_ptr_t():
     return Type.parse("!llvm.ptr")
 
 
+def llvm_void_t():
+    return Type.parse("!llvm.void")
+
+
 try:
     from . import amdgcn
 except ImportError:
     pass
+
+
+class _ReturnOp:
+    """Adapts ``FuncBase``'s positional-list return convention to
+    ``llvm.ReturnOp(arg=...)`` (which takes a single, optional, keyword value).
+
+    Kept a class so it satisfies ``FuncBase.__init__``'s ``isclass`` assertion.
+    """
+
+    def __init__(self, operands, *, loc=None, ip=None):
+        ReturnOp(arg=operands[0] if operands else None, loc=loc, ip=ip)
+
+
+class LLVMFunc(FuncBase):
+    def _make_function_type(self, input_types, result_types) -> TypeAttr:
+        if len(result_types) == 0:
+            ret = llvm_void_t()
+        elif len(result_types) == 1:
+            ret = result_types[0]
+        else:
+            raise ValueError(
+                f"llvm.func supports at most one result type, got {result_types}"
+            )
+        return TypeAttr.get(LLVMFunctionType.get(ret, list(input_types)))
+
+    def __call__(self, *call_args):
+        op = self.emit(*call_args)
+        ftype = LLVMFunctionType(op.function_type.value)
+        result = None if ftype.return_type == llvm_void_t() else ftype.return_type
+        return get_op_result_or_op_results(
+            self.call_op_ctor(
+                result,
+                list(call_args),
+                [],
+                [],
+                callee=FlatSymbolRefAttr.get(self.func_name),
+            )
+        )
+
+
+@make_maybe_no_args_decorator
+def func(
+    f,
+    *,
+    sym_visibility=None,
+    sym_name=None,
+    arg_attrs=None,
+    res_attrs=None,
+    func_attrs=None,
+    function_type=None,
+    emit=False,
+    loc=None,
+    ip=None,
+) -> LLVMFunc:
+    func_ = LLVMFunc(
+        body_builder=f,
+        func_op_ctor=LLVMFuncOp,
+        return_op_ctor=_ReturnOp,
+        call_op_ctor=CallOp,
+        sym_visibility=sym_visibility,
+        sym_name=sym_name,
+        arg_attrs=arg_attrs,
+        res_attrs=res_attrs,
+        func_attrs=func_attrs,
+        function_type=function_type,
+        generics=getattr(f, "__type_params__", None),
+        loc=loc,
+        ip=ip,
+    )
+    func_ = update_wrapper(func_, f)
+    if emit:
+        func_.emit()
+    return func_
 
 
 def mlir_constant(

--- a/projects/eudsl-python-extras/tests/dialect/test_llvm.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_llvm.py
@@ -1,6 +1,7 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import inspect
 from textwrap import dedent
 
 import pytest
@@ -8,10 +9,16 @@ import pytest
 import mlir.extras.types as T
 from mlir.extras.dialects import llvm
 from mlir.extras.dialects.func import func
-from mlir.extras.dialects.llvm import mlir_constant
+from mlir.extras.dialects.llvm import mlir_constant, llvm_ptr_t, func as llvm_func
 
 # noinspection PyUnresolvedReferences
-from mlir.extras.testing import MLIRContext, filecheck, mlir_ctx as ctx
+from mlir.extras.testing import (
+    MLIRContext,
+    filecheck,
+    filecheck_with_comments,
+    mlir_ctx as ctx,
+)
+from mlir.ir import Attribute, FunctionType, IndexType, IntegerType
 from util import llvm_bindings_not_installed, llvm_amdgcn_bindings_not_installed
 
 # needed since the fix isn't defined here nor conftest.py
@@ -80,3 +87,227 @@ def test_mlir_constant_unsupported_type(ctx: MLIRContext):
     # Need to pass type explicitly to bypass infer_mlir_type
     with pytest.raises(NotImplementedError, match="is not a valid type"):
         mlir_constant("hello", type=T.i32())
+
+
+def test_llvm_emit(ctx: MLIRContext):
+    @llvm_func
+    def demo_fun1() -> T.i32():
+        one = mlir_constant(1, T.i32())
+        return one
+
+    assert hasattr(demo_fun1, "emit")
+    assert inspect.ismethod(demo_fun1.emit)
+    demo_fun1.emit()
+
+    # CHECK:  llvm.func @demo_fun1() -> i32 {
+    # CHECK:    %[[VAL_0:.*]] = llvm.mlir.constant(1 : i32) : i32
+    # CHECK:    llvm.return %[[VAL_0]] : i32
+    # CHECK:  }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_declare(ctx: MLIRContext):
+    @llvm_func
+    def demo_fun1() -> T.i32(): ...
+
+    @llvm_func
+    def demo_fun2(x: T.i32()) -> T.i32(): ...
+
+    @llvm_func
+    def demo_fun3(x: T.i32(), p: llvm_ptr_t()) -> T.i32(): ...
+
+    ctx.module.operation.verify()
+
+    # CHECK:  llvm.func @demo_fun1() -> i32 attributes {sym_visibility = "private"}
+    # CHECK:  llvm.func @demo_fun2(i32) -> i32 attributes {sym_visibility = "private"}
+    # CHECK:  llvm.func @demo_fun3(i32, !llvm.ptr) -> i32 attributes {sym_visibility = "private"}
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_void_return(ctx: MLIRContext):
+    @llvm_func
+    def no_result(x: T.i32()):
+        one = mlir_constant(1, T.i32())
+        return
+
+    no_result.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK:  llvm.func @no_result(%[[VAL_0:.*]]: i32) {
+    # CHECK:    %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+    # CHECK:    llvm.return
+    # CHECK:  }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_integer_index_type_annotations(ctx: MLIRContext):
+    @llvm_func
+    def f_i32(x: IntegerType[32]) -> IntegerType[32]: ...
+
+    @llvm_func
+    def f_i64(x: IntegerType[64]) -> IntegerType[64]: ...
+
+    @llvm_func
+    def f_index(x: IndexType) -> IndexType: ...
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @f_i32(i32) -> i32 attributes {sym_visibility = "private"}
+    # CHECK: llvm.func @f_i64(i64) -> i64 attributes {sym_visibility = "private"}
+    # CHECK: llvm.func @f_index(index) -> index attributes {sym_visibility = "private"}
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_float_type_annotations(ctx: MLIRContext):
+    @llvm_func
+    def f_f32(x: T.f32()) -> T.f32(): ...
+
+    @llvm_func
+    def f_f64(x: T.f64()) -> T.f64(): ...
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @f_f32(f32) -> f32 attributes {sym_visibility = "private"}
+    # CHECK: llvm.func @f_f64(f64) -> f64 attributes {sym_visibility = "private"}
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_pointer_type_annotation(ctx: MLIRContext):
+    @llvm_func
+    def f_ptr(p: llvm_ptr_t()) -> llvm_ptr_t(): ...
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @f_ptr(!llvm.ptr) -> !llvm.ptr attributes {sym_visibility = "private"}
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_multiple_arg_with_body(ctx: MLIRContext):
+    @llvm_func
+    def add_first(a: T.i32(), b: T.i32(), c: T.i32()) -> T.i32():
+        return a
+
+    add_first.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @add_first(%[[A:.*]]: i32, %[[B:.*]]: i32, %[[C:.*]]: i32) -> i32 {
+    # CHECK:   llvm.return %[[A]] : i32
+    # CHECK: }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_explicit_function_type(ctx: MLIRContext):
+    func_type = llvm.FunctionType.get(T.i32(), [T.i32(), T.i32()])
+
+    @llvm_func(function_type=func_type)
+    def demo_fun1(a, b):
+        one = mlir_constant(1, T.i32())
+        return one
+
+    demo_fun1.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK:  llvm.func @demo_fun1(%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) -> i32 {
+    # CHECK:    %[[VAL_2:.*]] = llvm.mlir.constant(1 : i32) : i32
+    # CHECK:    llvm.return %[[VAL_2]] : i32
+    # CHECK:  }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_func_with_func_attrs(ctx: MLIRContext):
+    @llvm_func(func_attrs={"llvm.emit_c_interface": Attribute.parse("unit")})
+    def with_attrs() -> T.i32():
+        one = mlir_constant(1, T.i32())
+        return one
+
+    with_attrs.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @with_attrs() -> i32 attributes {llvm.emit_c_interface}
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_func_emit_true(ctx: MLIRContext):
+    @llvm_func(emit=True)
+    def emitted_immediately() -> T.i32():
+        one = mlir_constant(1, T.i32())
+        return one
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @emitted_immediately() -> i32
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_multiple_results_unsupported(ctx: MLIRContext):
+    with pytest.raises(ValueError, match="llvm.func supports at most one result type"):
+
+        @llvm_func
+        def two_results() -> (T.i32(), T.i32()): ...
+
+
+def test_llvm_call(ctx: MLIRContext):
+    @llvm_func
+    def callee(a: T.i32(), b: T.i32()) -> T.i32():
+        return a
+
+    callee.emit()
+
+    @llvm_func
+    def caller() -> T.i32():
+        one = mlir_constant(1, T.i32())
+        return callee(one, one)
+
+    caller.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK:  llvm.func @callee(%[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32) -> i32 {
+    # CHECK:    llvm.return %[[VAL_0]] : i32
+    # CHECK:  }
+    # CHECK:  llvm.func @caller() -> i32 {
+    # CHECK:    %[[VAL_2:.*]] = llvm.mlir.constant(1 : i32) : i32
+    # CHECK:    %[[VAL_3:.*]] = llvm.call @callee(%[[VAL_2]], %[[VAL_2]]) : (i32, i32) -> i32
+    # CHECK:    llvm.return %[[VAL_3]] : i32
+    # CHECK:  }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_call_void(ctx: MLIRContext):
+    @llvm_func
+    def sink(a: T.i32()):
+        one = mlir_constant(1, T.i32())
+        return
+
+    sink.emit()
+
+    @llvm_func
+    def driver():
+        one = mlir_constant(1, T.i32())
+        sink(one)
+        return
+
+    driver.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK:  llvm.func @driver() {
+    # CHECK:    %[[VAL_0:.*]] = llvm.mlir.constant(1 : i32) : i32
+    # CHECK:    llvm.call @sink(%[[VAL_0]]) : (i32) -> ()
+    # CHECK:    llvm.return
+    # CHECK:  }
+
+    filecheck_with_comments(ctx.module)

--- a/projects/eudsl-python-extras/tests/test_generics.py
+++ b/projects/eudsl-python-extras/tests/test_generics.py
@@ -12,6 +12,7 @@ from mlir.extras.ast.py_type import PyTypeVarObject
 from mlir.extras.dialects import linalg, arith, scf, memref, gpu
 from mlir.extras.dialects.func import func
 from mlir.extras.dialects.gpu import block_idx
+from mlir.extras.dialects.llvm import func as llvm_func, mlir_constant
 from mlir.extras.dialects.gpu import (
     set_container_module,
     module,
@@ -903,3 +904,85 @@ def test_reified_type_param_no_bound_type_infer(ctx: MLIRContext):
     # Pass an int as concrete_val - should set type_name to "int"
     r2 = ReifiedTypeParam(tvar, concrete_val=42)
     assert r2.type_name == "int"
+
+
+def test_llvm_generics_type_param(ctx: MLIRContext):
+    """llvm.func generic where a type param is used as an argument type."""
+
+    @llvm_func
+    def gen_ty[dtype](a: "dtype"):
+        one = mlir_constant(1, T.i32())
+
+    gen_ty[T.i32()].emit()
+    gen_ty[T.i64()].emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @gen_ty_type_i32(%[[A:.*]]: i32) {
+    # CHECK:   llvm.mlir.constant(1 : i32) : i32
+    # CHECK:   llvm.return
+    # CHECK: }
+    # CHECK: llvm.func @gen_ty_type_i64(%[[B:.*]]: i64) {
+    # CHECK:   llvm.mlir.constant(1 : i32) : i32
+    # CHECK:   llvm.return
+    # CHECK: }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_generics_dimension(ctx: MLIRContext):
+    """llvm.func generic where a dimension param is reified into the body."""
+
+    @llvm_func
+    def gen_dim[N](a: "T.i32()"):
+        c = mlir_constant(N, T.i32())
+
+    gen_dim[8].emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @gen_dim_int_8(%[[A:.*]]: i32) {
+    # CHECK:   llvm.mlir.constant(8 : i32) : i32
+    # CHECK:   llvm.return
+    # CHECK: }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_generics_partial_specialization(ctx: MLIRContext):
+    """llvm.func generic specialized one type param at a time via chained __getitem__."""
+
+    @llvm_func
+    def gen_two[A_t, B_t](a: "A_t", b: "B_t"):
+        one = mlir_constant(1, T.i32())
+
+    # Specialize A_t, then B_t
+    partial = gen_two[T.i32()]
+    partial[T.i64()].emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @gen_two_type_i32_type_i64(%[[A:.*]]: i32, %[[B:.*]]: i64) {
+    # CHECK:   llvm.mlir.constant(1 : i32) : i32
+    # CHECK:   llvm.return
+    # CHECK: }
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_llvm_generics_preserves_subclass(ctx: MLIRContext):
+    """Specializing an LLVMFunc via __getitem__ must return an LLVMFunc (not FuncBase)."""
+    from mlir.extras.dialects.llvm import LLVMFunc
+
+    @llvm_func
+    def gen[N](a: "T.i32()"):
+        c = mlir_constant(N, T.i32())
+
+    specialized = gen[4]
+    assert isinstance(specialized, LLVMFunc)
+    specialized.emit()
+
+    ctx.module.operation.verify()
+
+    # CHECK: llvm.func @gen_int_4(%[[A:.*]]: i32) {
+    filecheck_with_comments(ctx.module)


### PR DESCRIPTION
Adds an `@llvm.func` decorator mirroring `func` and `GPUFunc`. It provides the same ergonomics for `llvm.func`: type-annotated args, return-type inference, external declarations, generics / `__getitem__` specialization, `func_attrs`, `emit=True`, and a callable `__call__` that emits `llvm.call`.