### PR TITLE
[tensor] Add TensorCanonicalizer for AST-based setitem rebinding

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
@@ -1,6 +1,8 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ast
+import copy
 import inspect
 from typing import List, Optional, Tuple, Union, Sequence
 
@@ -15,6 +17,8 @@ from ._shaped_value import (
 )
 from .arith import ArithValue, ScalarValue, constant
 from .. import types as T
+from ..ast.canonicalize import Canonicalizer, FunctionPatcher, StrictTransformer
+from ..ast.util import ast_call
 from ..util import (
     _unpack_sizes_element_type,
     _update_caller_vars,
@@ -170,56 +174,16 @@ class TensorValue(ArithValue):
             return expand_dims(out, indexer.newaxis_dims, loc=loc, ip=None)
 
     def __setitem__(self, idx, source):
-        loc = get_user_code_loc()
-
-        assert self.has_rank(), "only ranked tensor slicing/indexing supported"
-        assert source.has_rank(), "only ranked tensor slicing/indexing supported"
-
-        if (
-            idx == Ellipsis
-            or idx == slice(None)
-            or (isinstance(idx, tuple) and all(i == slice(None) for i in idx))
-        ):
-            assert (
-                self.shape == source.shape
-            ), f"Expected matching shape for dest slice {self.shape=} and source {source.shape=}"
-            return self
-
-        if isinstance(idx, Value) and not isinstance(idx, ScalarValue):
-            raise ValueError("indexing by tensor is not currently supported")
-
-        idx = list((idx,) if isinstance(idx, (int, ScalarValue, slice)) else idx)
-        for i, d in enumerate(idx):
-            if isinstance(d, int):
-                idx[i] = constant(d, index=True, loc=loc)
-
-        if all(isinstance(d, ScalarValue) and d.fold() for d in idx) and len(
-            idx
-        ) == len(self.shape):
-            assert isinstance(
-                source, ScalarValue
-            ), "coordinate insert requires scalar element"
-            res = tensor.insert(source, self, idx, loc=loc)
-        else:
-            if any(_is_index_tensor(i) or _is_int_arraylike(i) for i in idx):
-                raise ValueError("indexing by tensor is not currently supported")
-            indexer = _indices_to_indexer(tuple(idx), self.shape)
-            if indexer.is_constant():
-                assert (
-                    indexer.static_sizes() == source.shape
-                ), f"Expected matching shape for dest slice {indexer.static_sizes()=} and source {source.shape=}"
-                res = insert_slice(
-                    source,
-                    self,
-                    static_offsets=indexer.static_offsets(),
-                    static_sizes=indexer.static_sizes(),
-                    static_strides=indexer.static_strides(),
-                    loc=loc,
-                    ip=None,
-                )
-            else:
-                raise ValueError(f"non-constant indices not supported {indexer}")
-
+        res = _setitem(self, idx, source)
+        # early-return cases (full-slice/ellipsis) leave the tensor untouched, so
+        # there's nothing to rebind in the caller.
+        if res is self:
+            return
+        # Fallback for code that isn't rewritten by TensorCanonicalizer (e.g. an
+        # undecorated function or the REPL): reach into the caller and rebind the
+        # variable(s) that pointed at `self` to the new SSA value. Inside a
+        # @canonicalize(using=tensor.canonicalizer) function this path isn't taken
+        # because `t[idx] = source` is rewritten to `t = __mlir_extras_setitem__(...)`.
         previous_frame = inspect.currentframe().f_back
         _update_caller_vars(previous_frame, [self], [res])
 
@@ -408,3 +372,156 @@ pad = region_op(pad_, terminator=lambda args: tensor.YieldOp(args[0]))
 generate = region_op(
     lambda result, dynamic_extents: tensor.GenerateOp(result, dynamic_extents)
 )
+
+
+def _setitem(dest: "TensorValue", idx, source) -> "TensorValue":
+    """Functional core of ``TensorValue.__setitem__``.
+
+    Emits the ``tensor.insert``/``tensor.insert_slice`` op and returns the *new*
+    SSA value (tensors are immutable). Returns ``dest`` unchanged for full-slice/
+    ellipsis writes (nothing to do). Unlike ``__setitem__`` this does no caller-frame
+    rebinding -- the caller is responsible for binding the result.
+    """
+    loc = get_user_code_loc()
+
+    assert dest.has_rank(), "only ranked tensor slicing/indexing supported"
+    assert source.has_rank(), "only ranked tensor slicing/indexing supported"
+
+    if (
+        idx == Ellipsis
+        or idx == slice(None)
+        or (isinstance(idx, tuple) and all(i == slice(None) for i in idx))
+    ):
+        assert (
+            dest.shape == source.shape
+        ), f"Expected matching shape for dest slice {dest.shape=} and source {source.shape=}"
+        return dest
+
+    if isinstance(idx, Value) and not isinstance(idx, ScalarValue):
+        raise ValueError("indexing by tensor is not currently supported")
+
+    idx = list((idx,) if isinstance(idx, (int, ScalarValue, slice)) else idx)
+    for i, d in enumerate(idx):
+        if isinstance(d, int):
+            idx[i] = constant(d, index=True, loc=loc)
+
+    if all(isinstance(d, ScalarValue) and d.fold() for d in idx) and len(idx) == len(
+        dest.shape
+    ):
+        assert isinstance(
+            source, ScalarValue
+        ), "coordinate insert requires scalar element"
+        res = tensor.insert(source, dest, idx, loc=loc)
+    else:
+        if any(_is_index_tensor(i) or _is_int_arraylike(i) for i in idx):
+            raise ValueError("indexing by tensor is not currently supported")
+        indexer = _indices_to_indexer(tuple(idx), dest.shape)
+        if indexer.is_constant():
+            assert (
+                indexer.static_sizes() == source.shape
+            ), f"Expected matching shape for dest slice {indexer.static_sizes()=} and source {source.shape=}"
+            res = insert_slice(
+                source,
+                dest,
+                static_offsets=indexer.static_offsets(),
+                static_sizes=indexer.static_sizes(),
+                static_strides=indexer.static_strides(),
+                loc=loc,
+                ip=None,
+            )
+        else:
+            raise ValueError(f"non-constant indices not supported {indexer}")
+
+    return res
+
+
+def __mlir_extras_setitem__(dest, idx, source):
+    """Runtime dispatch target that ``CanonicalizeSetItem`` rewrites ``dest[idx] = source`` into.
+
+    Because the rewrite is purely syntactic it fires on *every* subscript assignment
+    inside a canonicalized function, so this dispatches at runtime: tensors get the
+    functional insert (and the new SSA value is returned to be rebound), while plain
+    Python containers / mutable MLIR values (e.g. ``memref``) keep normal in-place
+    ``__setitem__`` semantics and rebind to themselves (a harmless no-op).
+    """
+    if isinstance(dest, TensorValue):
+        return _setitem(dest, idx, source)
+    dest[idx] = source
+    return dest
+
+
+def _reconstruct_index(slice_node: ast.expr) -> ast.expr:
+    """Turn a ``Subscript.slice`` AST node back into an ordinary index expression.
+
+    An ``ast.Slice`` is only valid inside a subscript, so to pass it as a call
+    argument it must be rebuilt as a ``slice(...)`` call -- mirroring what CPython
+    hands to ``__setitem__`` at runtime. Tuples (extended indexing) are rebuilt
+    element-wise; everything else (names, constants, ...) passes through unchanged.
+    """
+    if isinstance(slice_node, ast.Slice):
+        return ast.Call(
+            func=ast.Name(id="slice", ctx=ast.Load()),
+            args=[
+                slice_node.lower or ast.Constant(value=None),
+                slice_node.upper or ast.Constant(value=None),
+                slice_node.step or ast.Constant(value=None),
+            ],
+            keywords=[],
+        )
+    if isinstance(slice_node, ast.Tuple):
+        return ast.Tuple(
+            elts=[_reconstruct_index(e) for e in slice_node.elts], ctx=ast.Load()
+        )
+    return slice_node
+
+
+class CanonicalizeSetItem(StrictTransformer):
+    """Rewrite ``t[idx] = source`` into ``t = __mlir_extras_setitem__(t, idx, source)``.
+
+    This replaces the caller-frame rebinding hack (``_update_caller_vars``) with a
+    lexical rebinding performed by the compiler, so it also works through attribute
+    and container aliases (``obj.t[i] = x``, ``lst[k][i] = x``) that identity-based
+    frame rewriting can't reach.
+    """
+
+    def visit_Assign(self, updated_node: ast.Assign) -> ast.Assign:
+        updated_node = self.generic_visit(updated_node)
+        # Only plain single-target subscript assignments; skip chained/tuple targets.
+        if len(updated_node.targets) != 1:
+            return updated_node
+        target = updated_node.targets[0]
+        if not isinstance(target, ast.Subscript):
+            return updated_node
+        base = target.value
+        # The base has to be a valid assignment target so we can rebind it; e.g.
+        # `foo()[i] = x` can't become `foo() = ...`.
+        if not isinstance(base, (ast.Name, ast.Attribute, ast.Subscript)):
+            return updated_node
+
+        base_load = copy.deepcopy(base)
+        base_load.ctx = ast.Load()
+        base_store = copy.deepcopy(base)
+        base_store.ctx = ast.Store()
+
+        call = ast_call(
+            __mlir_extras_setitem__.__name__,
+            args=[base_load, _reconstruct_index(target.slice), updated_node.value],
+        )
+        new_node = ast.Assign(targets=[base_store], value=call)
+        new_node = ast.copy_location(new_node, updated_node)
+        new_node = ast.fix_missing_locations(new_node)
+        return new_node
+
+
+class TensorPatchFunction(FunctionPatcher):
+    def patch_function(self, f):
+        f.__globals__[__mlir_extras_setitem__.__name__] = __mlir_extras_setitem__
+        return f
+
+
+class TensorCanonicalizer(Canonicalizer):
+    cst_transformers = [CanonicalizeSetItem]
+    function_patchers = [TensorPatchFunction]
+
+
+canonicalizer = TensorCanonicalizer()

--- a/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
@@ -120,6 +120,67 @@ def _is_index_tensor(x):
     )
 
 
+def _setitem(dest: "TensorValue", idx, source) -> "TensorValue":
+    """Functional core of ``TensorValue.__setitem__``.
+
+    Emits the ``tensor.insert``/``tensor.insert_slice`` op and returns the *new*
+    SSA value (tensors are immutable). Returns ``dest`` unchanged for full-slice/
+    ellipsis writes (nothing to do). Unlike ``__setitem__`` this does no caller-frame
+    rebinding -- the caller is responsible for binding the result.
+    """
+    loc = get_user_code_loc()
+
+    assert dest.has_rank(), "only ranked tensor slicing/indexing supported"
+    assert source.has_rank(), "only ranked tensor slicing/indexing supported"
+
+    if (
+        idx == Ellipsis
+        or idx == slice(None)
+        or (isinstance(idx, tuple) and all(i == slice(None) for i in idx))
+    ):
+        assert (
+            dest.shape == source.shape
+        ), f"Expected matching shape for dest slice {dest.shape=} and source {source.shape=}"
+        return dest
+
+    if isinstance(idx, Value) and not isinstance(idx, ScalarValue):
+        raise ValueError("indexing by tensor is not currently supported")
+
+    idx = list((idx,) if isinstance(idx, (int, ScalarValue, slice)) else idx)
+    for i, d in enumerate(idx):
+        if isinstance(d, int):
+            idx[i] = constant(d, index=True, loc=loc)
+
+    if all(isinstance(d, ScalarValue) and d.fold() for d in idx) and len(idx) == len(
+        dest.shape
+    ):
+        assert isinstance(
+            source, ScalarValue
+        ), "coordinate insert requires scalar element"
+        res = tensor.insert(source, dest, idx, loc=loc)
+    else:
+        if any(_is_index_tensor(i) or _is_int_arraylike(i) for i in idx):
+            raise ValueError("indexing by tensor is not currently supported")
+        indexer = _indices_to_indexer(tuple(idx), dest.shape)
+        if indexer.is_constant():
+            assert (
+                indexer.static_sizes() == source.shape
+            ), f"Expected matching shape for dest slice {indexer.static_sizes()=} and source {source.shape=}"
+            res = insert_slice(
+                source,
+                dest,
+                static_offsets=indexer.static_offsets(),
+                static_sizes=indexer.static_sizes(),
+                static_strides=indexer.static_strides(),
+                loc=loc,
+                ip=None,
+            )
+        else:
+            raise ValueError(f"non-constant indices not supported {indexer}")
+
+    return res
+
+
 # TODO(max): unify vector/memref/tensor
 @register_value_caster(RankedTensorType.static_typeid)
 @ShapedValue
@@ -374,67 +435,6 @@ generate = region_op(
 )
 
 
-def _setitem(dest: "TensorValue", idx, source) -> "TensorValue":
-    """Functional core of ``TensorValue.__setitem__``.
-
-    Emits the ``tensor.insert``/``tensor.insert_slice`` op and returns the *new*
-    SSA value (tensors are immutable). Returns ``dest`` unchanged for full-slice/
-    ellipsis writes (nothing to do). Unlike ``__setitem__`` this does no caller-frame
-    rebinding -- the caller is responsible for binding the result.
-    """
-    loc = get_user_code_loc()
-
-    assert dest.has_rank(), "only ranked tensor slicing/indexing supported"
-    assert source.has_rank(), "only ranked tensor slicing/indexing supported"
-
-    if (
-        idx == Ellipsis
-        or idx == slice(None)
-        or (isinstance(idx, tuple) and all(i == slice(None) for i in idx))
-    ):
-        assert (
-            dest.shape == source.shape
-        ), f"Expected matching shape for dest slice {dest.shape=} and source {source.shape=}"
-        return dest
-
-    if isinstance(idx, Value) and not isinstance(idx, ScalarValue):
-        raise ValueError("indexing by tensor is not currently supported")
-
-    idx = list((idx,) if isinstance(idx, (int, ScalarValue, slice)) else idx)
-    for i, d in enumerate(idx):
-        if isinstance(d, int):
-            idx[i] = constant(d, index=True, loc=loc)
-
-    if all(isinstance(d, ScalarValue) and d.fold() for d in idx) and len(idx) == len(
-        dest.shape
-    ):
-        assert isinstance(
-            source, ScalarValue
-        ), "coordinate insert requires scalar element"
-        res = tensor.insert(source, dest, idx, loc=loc)
-    else:
-        if any(_is_index_tensor(i) or _is_int_arraylike(i) for i in idx):
-            raise ValueError("indexing by tensor is not currently supported")
-        indexer = _indices_to_indexer(tuple(idx), dest.shape)
-        if indexer.is_constant():
-            assert (
-                indexer.static_sizes() == source.shape
-            ), f"Expected matching shape for dest slice {indexer.static_sizes()=} and source {source.shape=}"
-            res = insert_slice(
-                source,
-                dest,
-                static_offsets=indexer.static_offsets(),
-                static_sizes=indexer.static_sizes(),
-                static_strides=indexer.static_strides(),
-                loc=loc,
-                ip=None,
-            )
-        else:
-            raise ValueError(f"non-constant indices not supported {indexer}")
-
-    return res
-
-
 def __mlir_extras_setitem__(dest, idx, source):
     """Runtime dispatch target that ``CanonicalizeSetItem`` rewrites ``dest[idx] = source`` into.
 
@@ -475,6 +475,51 @@ def _reconstruct_index(slice_node: ast.expr) -> ast.expr:
     return slice_node
 
 
+def _hoist_expr(expr: ast.expr, mk_tmp):
+    """Bind ``expr`` to a temporary so it is evaluated exactly once.
+
+    Returns ``(load_ref, prelude)`` where ``load_ref`` is an expression that reads
+    the (now-cached) value and ``prelude`` is the list of statements that compute it.
+    Side-effect-free atoms (names, constants) are returned as-is with no prelude.
+    """
+    if isinstance(expr, (ast.Name, ast.Constant)):
+        ref = copy.deepcopy(expr)
+        ref.ctx = ast.Load()
+        return ref, []
+    tmp = mk_tmp()
+    prelude = [ast.Assign(targets=[ast.Name(id=tmp, ctx=ast.Store())], value=expr)]
+    return ast.Name(id=tmp, ctx=ast.Load()), prelude
+
+
+def _split_assignable_base(base: ast.expr, mk_tmp):
+    """Split a subscript base into ``(prelude, load_expr, store_expr)``.
+
+    The base is emitted twice by the rewrite -- once read (to pass the current value
+    to ``__mlir_extras_setitem__``) and once written (to rebind it) -- so any
+    side-effecting sub-expression (a call, a mutating index, ...) is hoisted into a
+    temporary and evaluated once, matching CPython's ``a.b[i] = x`` / ``a[i][j] = x``
+    semantics. A bare ``Name`` needs no hoisting since reading it twice is free.
+    """
+    if isinstance(base, ast.Name):
+        return [], ast.Name(base.id, ast.Load()), ast.Name(base.id, ast.Store())
+    if isinstance(base, ast.Attribute):
+        obj_ref, prelude = _hoist_expr(base.value, mk_tmp)
+        load = ast.Attribute(value=obj_ref, attr=base.attr, ctx=ast.Load())
+        store = ast.Attribute(
+            value=copy.deepcopy(obj_ref), attr=base.attr, ctx=ast.Store()
+        )
+        return prelude, load, store
+    if isinstance(base, ast.Subscript):
+        obj_ref, prelude_obj = _hoist_expr(base.value, mk_tmp)
+        idx_ref, prelude_idx = _hoist_expr(_reconstruct_index(base.slice), mk_tmp)
+        load = ast.Subscript(value=obj_ref, slice=idx_ref, ctx=ast.Load())
+        store = ast.Subscript(
+            value=copy.deepcopy(obj_ref), slice=copy.deepcopy(idx_ref), ctx=ast.Store()
+        )
+        return prelude_obj + prelude_idx, load, store
+    raise AssertionError(f"unexpected assignable base {ast.dump(base)}")
+
+
 class CanonicalizeSetItem(StrictTransformer):
     """Rewrite ``t[idx] = source`` into ``t = __mlir_extras_setitem__(t, idx, source)``.
 
@@ -484,7 +529,7 @@ class CanonicalizeSetItem(StrictTransformer):
     frame rewriting can't reach.
     """
 
-    def visit_Assign(self, updated_node: ast.Assign) -> ast.Assign:
+    def visit_Assign(self, updated_node: ast.Assign) -> Union[ast.Assign, List[ast.AST]]:
         updated_node = self.generic_visit(updated_node)
         # Only plain single-target subscript assignments; skip chained/tuple targets.
         if len(updated_node.targets) != 1:
@@ -498,19 +543,24 @@ class CanonicalizeSetItem(StrictTransformer):
         if not isinstance(base, (ast.Name, ast.Attribute, ast.Subscript)):
             return updated_node
 
-        base_load = copy.deepcopy(base)
-        base_load.ctx = ast.Load()
-        base_store = copy.deepcopy(base)
-        base_store.ctx = ast.Store()
+        def mk_tmp():
+            n = getattr(self.context, "_setitem_tmp_count", 0)
+            self.context._setitem_tmp_count = n + 1
+            return f"__mlir_extras_setitem_tmp_{n}"
+
+        # Hoist side-effecting sub-expressions of the base so it's evaluated once.
+        prelude, base_load, base_store = _split_assignable_base(base, mk_tmp)
 
         call = ast_call(
             __mlir_extras_setitem__.__name__,
             args=[base_load, _reconstruct_index(target.slice), updated_node.value],
         )
-        new_node = ast.Assign(targets=[base_store], value=call)
-        new_node = ast.copy_location(new_node, updated_node)
-        new_node = ast.fix_missing_locations(new_node)
-        return new_node
+        assign = ast.Assign(targets=[base_store], value=call)
+        stmts = [
+            ast.fix_missing_locations(ast.copy_location(s, updated_node))
+            for s in (*prelude, assign)
+        ]
+        return stmts if len(stmts) > 1 else stmts[0]
 
 
 class TensorPatchFunction(FunctionPatcher):

--- a/projects/eudsl-python-extras/tests/dialect/test_tensor.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_tensor.py
@@ -9,7 +9,7 @@ import pytest
 
 import mlir.extras.types as T
 from mlir.extras.ast.canonicalize import canonicalize
-from mlir.extras.dialects import arith
+from mlir.extras.dialects import arith, tensor
 from mlir.extras.dialects._shaped_value import _Indexer
 from mlir.extras.dialects.arith import ScalarValue, constant
 from mlir.extras.dialects.scf import (
@@ -272,6 +272,54 @@ def test_nontrivial_slices_insertion(ctx: MLIRContext):
     # CHECK:  %[[VAL_6:.*]] = tensor.insert_slice %[[VAL_5]] into %[[VAL_4]][0, 0, 0, 0] [7, 11, 11, 11] [1, 2, 30, 400] : tensor<7x11x11x11xi32> into tensor<7x22x333x4444xi32>
     # CHECK:  %[[VAL_7:.*]] = tensor.extract_slice %[[VAL_6]][0, 0, 100, 1000] [7, 22, 20, 20] [1, 1, 5, 50] : tensor<7x22x333x4444xi32> to tensor<7x22x20x20xi32>
     # CHECK:  %[[VAL_8:.*]] = tensor.insert_slice %[[VAL_7]] into %[[VAL_6]][0, 0, 100, 1000] [7, 22, 20, 20] [1, 1, 5, 50] : tensor<7x22x20x20xi32> into tensor<7x22x333x4444xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_nontrivial_slices_insertion_canonicalized(ctx: MLIRContext):
+    # Same as test_nontrivial_slices_insertion, but the tensor rebinding
+    # (`ten[...] = w`  ->  `ten = insert_slice(...)`) is done by the
+    # TensorCanonicalizer AST rewrite instead of the caller-frame hack. The
+    # insert_slice result must be threaded into the next extract_slice, exactly
+    # as in the frame-hack version.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        ten = empty(7, 22, 333, 4444, T.i32())
+        w = ten[:, 0:22:2]
+        ten[:, 0:22:2] = w
+        w = ten[:, 0:22:2, 0:330:30]
+        ten[:, 0:22:2, 0:330:30] = w
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x333x4444xi32>
+    # CHECK:  %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0, 0, 0] [7, 11, 333, 4444] [1, 2, 1, 1] : tensor<7x22x333x4444xi32> to tensor<7x11x333x4444xi32>
+    # CHECK:  %[[VAL_2:.*]] = tensor.insert_slice %[[VAL_1]] into %[[VAL_0]][0, 0, 0, 0] [7, 11, 333, 4444] [1, 2, 1, 1] : tensor<7x11x333x4444xi32> into tensor<7x22x333x4444xi32>
+    # CHECK:  %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_2]][0, 0, 0, 0] [7, 11, 11, 4444] [1, 2, 30, 1] : tensor<7x22x333x4444xi32> to tensor<7x11x11x4444xi32>
+    # CHECK:  %[[VAL_4:.*]] = tensor.insert_slice %[[VAL_3]] into %[[VAL_2]][0, 0, 0, 0] [7, 11, 11, 4444] [1, 2, 30, 1] : tensor<7x11x11x4444xi32> into tensor<7x22x333x4444xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_setitem_through_attribute_alias_canonicalized(ctx: MLIRContext):
+    # The caller-frame hack can only rebind a bare local; an attribute alias like
+    # `holder.ten` is out of reach. The AST rewrite turns this into
+    # `holder.ten = insert_slice(...)`, so the update is actually observed.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        holder = type("H", (), {})()
+        holder.ten = empty(8, 8, T.i32())
+        w = holder.ten[0:4, 0:4]
+        holder.ten[4:8, 4:8] = w
+        # read back through the alias: must see the insert_slice result
+        return holder.ten[4:8, 4:8]
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+    # CHECK:  %[[VAL_2:.*]] = tensor.insert_slice %[[VAL_1]] into %[[VAL_0]][4, 4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
+    # CHECK:  %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_2]][4, 4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
 
     filecheck_with_comments(ctx.module)
 

--- a/projects/eudsl-python-extras/tests/dialect/test_tensor.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_tensor.py
@@ -1,7 +1,9 @@
 # Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ast
 import platform
+import types
 from textwrap import dedent
 
 import numpy as np
@@ -322,6 +324,160 @@ def test_setitem_through_attribute_alias_canonicalized(ctx: MLIRContext):
     # CHECK:  %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_2]][4, 4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
 
     filecheck_with_comments(ctx.module)
+
+
+def test_setitem_nested_subscript_alias_canonicalized(ctx: MLIRContext):
+    # `lst[k][i] = w` -> `lst[k] = insert_slice(...)`. The container element must be
+    # rebound so the read-back extracts from the insert_slice result -- another alias
+    # the caller-frame hack can't reach.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        lst = [empty(8, 8, T.i32())]
+        w = lst[0][0:4, 0:4]
+        lst[0][4:8, 4:8] = w
+        return lst[0][4:8, 4:8]
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+    # CHECK:  %[[VAL_2:.*]] = tensor.insert_slice %[[VAL_1]] into %[[VAL_0]][4, 4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
+    # CHECK:  %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_2]][4, 4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_setitem_reconstruct_index_shapes_canonicalized(ctx: MLIRContext):
+    # Exercise _reconstruct_index for open-ended slices (`:2`, `6:`) and a mixed
+    # slice/full-slice tuple (`0:4, :`); the reconstructed slice(...) calls must
+    # produce the same offsets/sizes as native subscripting, and each write must
+    # thread into the next read.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        ten = empty(8, 8, T.i32())
+        w = ten[:2]
+        ten[:2] = w
+        w2 = ten[6:]
+        ten[6:] = w2
+        w3 = ten[0:4, :]
+        ten[0:4, :] = w3
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0] [2, 8] [1, 1] : tensor<8x8xi32> to tensor<2x8xi32>
+    # CHECK:  %[[VAL_2:.*]] = tensor.insert_slice %[[VAL_1]] into %[[VAL_0]][0, 0] [2, 8] [1, 1] : tensor<2x8xi32> into tensor<8x8xi32>
+    # CHECK:  %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_2]][6, 0] [2, 8] [1, 1] : tensor<8x8xi32> to tensor<2x8xi32>
+    # CHECK:  %[[VAL_4:.*]] = tensor.insert_slice %[[VAL_3]] into %[[VAL_2]][6, 0] [2, 8] [1, 1] : tensor<2x8xi32> into tensor<8x8xi32>
+    # CHECK:  %[[VAL_5:.*]] = tensor.extract_slice %[[VAL_4]][0, 0] [4, 8] [1, 1] : tensor<8x8xi32> to tensor<4x8xi32>
+    # CHECK:  %[[VAL_6:.*]] = tensor.insert_slice %[[VAL_5]] into %[[VAL_4]][0, 0] [4, 8] [1, 1] : tensor<4x8xi32> into tensor<8x8xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_setitem_full_slice_canonicalized(ctx: MLIRContext):
+    # Under the canonicalizer a full-slice write routes through _setitem (which
+    # returns `dest`), NOT __setitem__ (which returns None). So `ten` must stay
+    # bound to a live tensor and no insert_slice is emitted.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        ten = empty(8, 8, T.i32())
+        source = empty(8, 8, T.i32())
+        ten[:] = source
+        # `ten` must still be a usable TensorValue (not None) here:
+        assert isinstance(ten, TensorValue)
+        return ten[0:4, 0:4]
+
+    build()
+
+    mod = str(ctx.module)
+    assert "tensor.insert_slice" not in mod, mod
+    assert mod.count("tensor.empty") == 2, mod
+    assert "tensor.extract_slice" in mod, mod
+
+
+def test_setitem_augassign_bare_local_canonicalized(ctx: MLIRContext):
+    # Augmented subscript assignment isn't rewritten (only visit_Assign is), so it
+    # falls back to __getitem__ + __setitem__ + the frame hack. For a bare local
+    # that still works: the read-back must see the insert_slice result.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        ten = empty(8, 8, T.i32())
+        w = ten[0:4, 0:4]
+        ten[0:4, 0:4] += w
+        return ten[0:4, 0:4]
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+    # CHECK:  %[[VAL_2:.*]] = tensor.extract_slice %[[VAL_0]][0, 0] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+    # CHECK:  %[[VAL_3:.*]] = arith.addi %[[VAL_2]], %[[VAL_1]] : tensor<4x4xi32>
+    # CHECK:  %[[VAL_4:.*]] = tensor.insert_slice %[[VAL_3]] into %[[VAL_0]][0, 0] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
+    # CHECK:  %[[VAL_5:.*]] = tensor.extract_slice %[[VAL_4]][0, 0] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_setitem_dispatch_fallback_preserves_container_semantics():
+    # __mlir_extras_setitem__ fires on EVERY subscript assignment in a canonicalized
+    # function, so for non-tensors it must keep normal in-place semantics and rebind
+    # the object to itself.
+    d = {}
+    assert tensor.__mlir_extras_setitem__(d, "k", 5) is d
+    assert d["k"] == 5
+    lst = [0, 1, 2]
+    assert tensor.__mlir_extras_setitem__(lst, 1, 9) is lst
+    assert lst[1] == 9
+
+    @canonicalize(using=tensor.canonicalizer)
+    def containers():
+        dd = {}
+        dd["a"] = 1
+        xs = [0, 0, 0]
+        xs[0:2] = [7, 8]
+        return dd, xs
+
+    assert containers() == ({"a": 1}, [7, 8, 0])
+
+
+def test_setitem_hoists_side_effecting_base_once():
+    # The base is emitted for both a read and a write; a side-effecting sub-expression
+    # (here a call) must be hoisted so it's evaluated exactly once, matching CPython.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        calls = []
+        holder = {"data": [0, 0, 0]}
+
+        def get():
+            calls.append(1)
+            return holder
+
+        get()["data"][1] = 99
+        return len(calls), holder["data"]
+
+    n_calls, data = build()
+    assert n_calls == 1, f"receiver evaluated {n_calls} times, expected 1"
+    assert data == [0, 99, 0]
+
+
+def test_canonicalize_setitem_skips_non_rewritable():
+    # The rewrite must only fire on single-target subscript assignments with an
+    # assignable base; everything else is left for the normal (frame-hack) path.
+    tr = tensor.CanonicalizeSetItem(context=types.SimpleNamespace(), first_lineno=0)
+
+    def rewritten(src):
+        out = tr.visit(ast.fix_missing_locations(ast.parse(src).body[0]))
+        nodes = out if isinstance(out, list) else [out]
+        return "; ".join(ast.unparse(ast.fix_missing_locations(n)) for n in nodes)
+
+    # rewritten:
+    assert "__mlir_extras_setitem__" in rewritten("t[0:2] = source")
+    # NOT rewritten:
+    assert rewritten("foo()[i] = x") == "foo()[i] = x"  # non-assignable base
+    assert "__mlir_extras_setitem__" not in rewritten("a[i] = b[j] = v")  # chained
+    assert "__mlir_extras_setitem__" not in rewritten("x, y = 1, 2")  # tuple target
+    assert "__mlir_extras_setitem__" not in rewritten("z = w")  # not a subscript
 
 
 def test_move_slice(ctx: MLIRContext):


### PR DESCRIPTION
## Summary

`TensorValue.__setitem__` makes immutable SSA tensors feel mutable by reaching into the caller frame and rebinding the variable that pointed at the old value to the `tensor.insert`/`insert_slice` result (`_update_caller_vars`). That identity-based frame rewrite only works for a bare local in the immediate caller — it can't follow attribute or container aliases — and depends on `PyFrame_LocalsToFast`.

This PR adds **`TensorCanonicalizer`**, an AST rewrite (mirroring arith's `CanonicalizeFMA`) that turns `t[idx] = source` into `t = __mlir_extras_setitem__(t, idx, source)` so the compiler performs the rebinding lexically. This also handles `obj.t[i] = x` and `lst[k][i] = x`, which the frame hack cannot.

Usage: `@canonicalize(using=tensor.canonicalizer)` (composes with the `arith`/`scf` canonicalizers).