### PR TITLE
[tensor] Fix coordinate scalar insert (t[i, j] = scalar)

### DIFF
--- a/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
+++ b/projects/eudsl-python-extras/mlir/extras/dialects/tensor.py
@@ -131,7 +131,10 @@ def _setitem(dest: "TensorValue", idx, source) -> "TensorValue":
     loc = get_user_code_loc()
 
     assert dest.has_rank(), "only ranked tensor slicing/indexing supported"
-    assert source.has_rank(), "only ranked tensor slicing/indexing supported"
+    # A scalar `source` is only valid for a coordinate insert (handled below); every
+    # other write requires a ranked source, so defer that check to the slice path.
+    if not isinstance(source, ScalarValue):
+        assert source.has_rank(), "only ranked tensor slicing/indexing supported"
 
     if (
         idx == Ellipsis
@@ -151,9 +154,7 @@ def _setitem(dest: "TensorValue", idx, source) -> "TensorValue":
         if isinstance(d, int):
             idx[i] = constant(d, index=True, loc=loc)
 
-    if all(isinstance(d, ScalarValue) and d.fold() for d in idx) and len(idx) == len(
-        dest.shape
-    ):
+    if all(isinstance(d, ScalarValue) for d in idx) and len(idx) == len(dest.shape):
         assert isinstance(
             source, ScalarValue
         ), "coordinate insert requires scalar element"

--- a/projects/eudsl-python-extras/tests/dialect/test_tensor.py
+++ b/projects/eudsl-python-extras/tests/dialect/test_tensor.py
@@ -480,6 +480,49 @@ def test_canonicalize_setitem_skips_non_rewritable():
     assert "__mlir_extras_setitem__" not in rewritten("z = w")  # not a subscript
 
 
+def test_coordinate_scalar_insert(ctx: MLIRContext):
+    # A scalar source with a point index per dimension is a coordinate insert
+    # (tensor.insert), not a slice insert. The read-back must observe the result.
+    ten = empty(8, 8, T.i32())
+    s = constant(5, type=T.i32())
+    ten[2, 4] = s
+    w = ten[2, 4]
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = arith.constant 5 : i32
+    # CHECK:  %[[VAL_2:.*]] = arith.constant 2 : index
+    # CHECK:  %[[VAL_3:.*]] = arith.constant 4 : index
+    # CHECK:  %[[VAL_4:.*]] = tensor.insert %[[VAL_1]] into %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_3]]] : tensor<8x8xi32>
+    # CHECK:  %[[VAL_5:.*]] = arith.constant 2 : index
+    # CHECK:  %[[VAL_6:.*]] = arith.constant 4 : index
+    # CHECK:  %[[VAL_7:.*]] = tensor.extract %[[VAL_4]]{{\[}}%[[VAL_5]], %[[VAL_6]]] : tensor<8x8xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
+def test_coordinate_scalar_insert_canonicalized(ctx: MLIRContext):
+    # Same coordinate insert, but rebinding via the TensorCanonicalizer AST rewrite.
+    @canonicalize(using=tensor.canonicalizer)
+    def build():
+        ten = empty(8, 8, T.i32())
+        s = constant(5, type=T.i32())
+        ten[2, 4] = s
+        w = ten[2, 4]
+
+    build()
+
+    # CHECK:  %[[VAL_0:.*]] = tensor.empty() : tensor<8x8xi32>
+    # CHECK:  %[[VAL_1:.*]] = arith.constant 5 : i32
+    # CHECK:  %[[VAL_2:.*]] = arith.constant 2 : index
+    # CHECK:  %[[VAL_3:.*]] = arith.constant 4 : index
+    # CHECK:  %[[VAL_4:.*]] = tensor.insert %[[VAL_1]] into %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_3]]] : tensor<8x8xi32>
+    # CHECK:  %[[VAL_5:.*]] = arith.constant 2 : index
+    # CHECK:  %[[VAL_6:.*]] = arith.constant 4 : index
+    # CHECK:  %[[VAL_7:.*]] = tensor.extract %[[VAL_4]]{{\[}}%[[VAL_5]], %[[VAL_6]]] : tensor<8x8xi32>
+
+    filecheck_with_comments(ctx.module)
+
+
 def test_move_slice(ctx: MLIRContext):
     ten = empty(8, 8, T.i32())
     w = ten[0:4, 0:4]


### PR DESCRIPTION
> **Stacked on #488** (`users/makslevental/tensor-canonicalizer`). Review/merge that first; this PR's diff is against that branch.

## Summary

Fixes `t[i, j] = scalar` (coordinate scalar insert), which crashed on both the frame-hack and canonicalizer paths. Two bugs in `_setitem`:

1. The unconditional `assert source.has_rank()` raised `AttributeError` because a `ScalarValue` has no `has_rank`. Now skipped when `source` is a `ScalarValue` (the coordinate-insert case); other writes still require a ranked source.
2. The coordinate-insert branch was gated on `d.fold()`, which is `False` for the index constants `_setitem` creates internally (they aren't constructed with `fold=True`), so the branch was never taken — a scalar source fell through to the slice path and crashed on `source.shape`. Dropped the `d.fold()` requirement so the gate matches the symmetric, working coordinate-*extract* path in `__getitem__` (`all(isinstance(d, ScalarValue) ...)`).

Now `t[i, j] = scalar` emits `tensor.insert`, symmetric with `w = t[i, j]` → `tensor.extract`.