### PR TITLE
[ci] Fix jupyterlite page being wiped by a racing Pages deploy

### DIFF
--- a/.github/workflows/build_llvm.yml
+++ b/.github/workflows/build_llvm.yml
@@ -391,11 +391,14 @@ jobs:
       workflow_call: true
       workflow_caller_run_id: ${{ github.run_id }}
 
+  # build_mlir_python_bindings_wheel.yml and build_test_release_eudsl.yml each end in
+  # their own deploy, so deploying off [build] alone would race them for the single
+  # "pages" concurrency slot. Wait for those chains so this deploy lands last.
   call-deploy-pip-page:
 
     if: (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
 
-    needs: [build]
+    needs: [build, call-build-python-bindings, call-build-eudsl]
 
     permissions:
       contents: read

--- a/.github/workflows/build_mlir_python_bindings_wheel.yml
+++ b/.github/workflows/build_mlir_python_bindings_wheel.yml
@@ -478,11 +478,13 @@ jobs:
       workflow_call: true
       workflow_caller_run_id: ${{ github.run_id }}
 
+  # build_test_release_eudsl_python_extras.yml ends in its own deploy; wait for it so the
+  # two don't race for the single "pages" concurrency slot.
   call-deploy-pip-page:
 
     if: (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
 
-    needs: [release-mlir-python-bindings]
+    needs: [release-mlir-python-bindings, call-build-eudsl-python-extras]
 
     permissions:
       contents: read

--- a/.github/workflows/deploy_pip_page.yml
+++ b/.github/workflows/deploy_pip_page.yml
@@ -5,12 +5,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
   workflow_call:
-    inputs:
-      workflow_call:
-        description: 'To distinguish workflow_call from regular push'
-        type: boolean
-        required: false
-        default: true
   pull_request:
     paths:
       - ".github/workflows/deploy_pip_page.yml"
@@ -30,7 +24,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -43,6 +37,7 @@ jobs:
       - name: Download pip links
         shell: bash
         run: |
+          set -euxo pipefail
 
           wget https://github.com/llvm/eudsl/releases/expanded_assets/mlir-python-bindings
           wget https://github.com/llvm/eudsl/releases/expanded_assets/eudsl
@@ -57,43 +52,47 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Pip download latest WASM wheel
-        if: ${{ !inputs.workflow_call }}
-        run: |
-          
-          pip download mlir-python-bindings --plat pyemscripten_2024_0_wasm32 --no-deps --python-version 3.12 -f https://llvm.github.io/eudsl
-
+      # Resolve both wheels out of the pip index we just built from the releases,
+      # so this job never depends on an artifact belonging to some other run.
       - name: Download latest WASM wheel
-        if: ${{ inputs.workflow_call }}
-        uses: dawidd6/action-download-artifact@v11
-        with:
-          name: mlir_python_bindings_ubuntu_wasm32_artifact
-          path: "./"
-          run_id: ${{ inputs.workflow_caller_run_id }}
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          pip download mlir-python-bindings --plat pyemscripten_2024_0_wasm32 --no-deps --python-version 3.12 -f page/index.html
 
       - name: Get eudsl-python-extras
+        shell: bash
         run: |
-          
-          pip wheel eudsl-python-extras -f https://llvm.github.io/eudsl --no-deps -w .
+          set -euxo pipefail
+
+          pip wheel eudsl-python-extras -f page/index.html --no-deps -w .
 
       - name: Create WASM console page
+        shell: bash
         run: |
-          
+          set -euxo pipefail
+
           mkdir -p page/console
 
-          export MLIR_PYTHON_WHEEL_NAME="$(ls mlir_python_bindings*)"
-          export EUDSL_PYTHON_EXTRAS_WHEEL_NAME="$(ls eudsl_python_extras*)"
-          
+          MLIR_PYTHON_WHEEL_NAME="$(ls mlir_python_bindings*.whl)"
+          EUDSL_PYTHON_EXTRAS_WHEEL_NAME="$(ls eudsl_python_extras*.whl)"
+          # `ls` returns one line per match, so this also catches an ambiguous glob.
+          test -f "$MLIR_PYTHON_WHEEL_NAME"
+          test -f "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME"
+
           cp pages/console/index.html page/console/index.html
-          cp $MLIR_PYTHON_WHEEL_NAME page/console/mlir_python_bindings-0.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl
-          cp $EUDSL_PYTHON_EXTRAS_WHEEL_NAME page/console/eudsl_python_extras-0.0.1-py3-none-any.whl
-          
+          cp "$MLIR_PYTHON_WHEEL_NAME" page/console/mlir_python_bindings-0.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl
+          cp "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME" page/console/eudsl_python_extras-0.0.1-py3-none-any.whl
+
           echo "MLIR_PYTHON_WHEEL_NAME=$MLIR_PYTHON_WHEEL_NAME" >> $GITHUB_ENV
           echo "EUDSL_PYTHON_EXTRAS_WHEEL_NAME=$EUDSL_PYTHON_EXTRAS_WHEEL_NAME" >> $GITHUB_ENV
 
       - name: Create WASM jupyterlite page
+        shell: bash
         run: |
-          
+          set -euxo pipefail
+
           mkdir -p page/jupyter
 
           python -m pip install -r pages/jupyter/requirements.txt
@@ -103,18 +102,42 @@ jobs:
             --piplite-wheels $MLIR_PYTHON_WHEEL_NAME \
             --piplite-wheels $EUDSL_PYTHON_EXTRAS_WHEEL_NAME
 
+      # A half-built `page/` must never reach the upload step: Pages serves whatever
+      # the last deployment contained, so publishing a partial tree silently deletes
+      # /console and /jupyter from the live site.
+      - name: Verify page contents
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          test -f page/index.html
+          test -f page/console/index.html
+          test -f page/jupyter/index.html
+          test -f page/jupyter/pypi/all.json
+
+          python - <<'PY'
+          import json
+
+          with open("page/jupyter/pypi/all.json") as f:
+              index = json.load(f)
+          missing = [p for p in ("mlir-python-bindings", "eudsl-python-extras") if p not in index]
+          if missing:
+              raise SystemExit(f"piplite index is missing {missing}; got {sorted(index)}")
+          PY
+
       - uses: geekyeggo/delete-artifact@v5
+        if: success() && github.event_name != 'pull_request'
         with:
           name: github-pages
           failOnError: false
 
       - name: Upload artifact
-        if: (!cancelled())
+        if: success() && github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: page
 
       - name: Deploy to GitHub Pages
-        if: (!cancelled())
+        if: success() && github.event_name != 'pull_request'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes #473.

## What's wrong

`piplite.install('mlir-python-bindings')` fails in the JupyterLite notebook because https://llvm.github.io/eudsl/jupyter/ isn't on the live site at all. Every path under it 404s, so the `import mlir` in the next cell raises `ModuleNotFoundError`. The `%%capture` on the install cell hides the piplite failure, which is why it surfaces as a confusing import error one cell later.

```
$ curl -o /dev/null -w '%{http_code}\n' https://llvm.github.io/eudsl/jupyter/
404
$ curl -o /dev/null -w '%{http_code}\n' https://llvm.github.io/eudsl/console/
404
$ curl -o /dev/null -w '%{http_code}\n' https://llvm.github.io/eudsl/
200
```

## Root cause

Five workflows call `deploy_pip_page.yml`, and two of them can run concurrently on a push to main. On the last push, [run 30673686943](https://github.com/llvm/eudsl/actions/runs/30673686943) built the full 96MB page and deployed it, then a second deploy from `build_test_release_eudsl_python_extras` overwrote it ~30 seconds later with a tree containing **only `index.html`**. Pages serves whatever the last deployment contained, so `/console` and `/jupyter` were deleted from the live site.

Confirmed by downloading both artifacts and diffing: the live `index.html` is byte-identical to the 116KB stub, not the 96MB full page.

```
2f70bb6055505a4ac2e8908ec766569a  live index.html
2f70bb6055505a4ac2e8908ec766569a  stub artifact  (index.html only)
50b12ec9a76101297bde322c351a6817  full artifact  (console/ + jupyter/)
```

The second deploy produced a stub because its `Download latest WASM wheel` step looks for `mlir_python_bindings_ubuntu_wasm32_artifact` in a run that never publishes it:

```
==> (not found) Artifact: mlir_python_bindings_ubuntu_wasm32_artifact
==> Found the following artifacts instead:
	==> (found) Artifact: eudsl_python_extras_sdist_artifact
##[error]no artifacts found
```

Everything downstream then quietly no-op'd, `tar` archived a single file, and `if: (!cancelled())` on the upload/deploy steps let the failed job publish anyway. `(!cancelled())` is **true** for a failed job; only cancellation makes it false. The job reported `success` while its Pages deployment reported `failure`.

That step was also unreachable as written: it keys off `inputs.workflow_call`, but no caller passes any inputs, and `inputs.workflow_caller_run_id` was never declared in this workflow, so it always evaluated to empty.

## The fix

- Resolve both wheels from the pip index this job already builds from the releases, dropping the cross-run artifact dependency and the unused input.
- Add a **Verify page contents** gate so a partial `page/` can never be uploaded. It checks the console and jupyter trees exist and that the piplite index really lists both wheels.
- Replace `if: (!cancelled())` with `if: success()` so a failed build stops before publishing. Also skip publishing on `pull_request`, so the existing PR trigger validates the build without deploying.
- Serialize the nested deploys behind their child chains so two runs of the same commit stop racing for the single `pages` concurrency slot.
- Add `set -euxo pipefail` and quote the wheel globs so failures in these steps actually fail the job.