### PR TITLE
[ci] Fix wasm wheel platform tag the pinned Pyodide can't install

### DIFF
--- a/.github/workflows/deploy_pip_page.yml
+++ b/.github/workflows/deploy_pip_page.yml
@@ -18,6 +18,11 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+# Platform tag the Pyodide runtime pinned by pages/jupyter/requirements.txt accepts.
+# Keep in sync with pages/console/index.html.
+env:
+  PYODIDE_PLATFORM_TAG: pyodide_2024_0_wasm32
+
 jobs:
   deploy:
     environment:
@@ -54,12 +59,24 @@ jobs:
 
       # Resolve both wheels out of the pip index we just built from the releases,
       # so this job never depends on an artifact belonging to some other run.
+      #
+      # pyodide-build >=0.28 tags wasm wheels `pyemscripten_*_wasm32` (PEP 783), but the
+      # runtime that consumes them here does not understand that tag yet: jupyterlite-
+      # pyodide-kernel 0.6.1 pins Pyodide 0.27.6, which ships micropip 0.9.0, and micropip
+      # only learned `pyemscripten_*` in 0.11.1. Under 0.9.0 the piplite index resolves the
+      # package fine and then rejects every wheel in it, so `piplite.install` fails with
+      # "Can't find a pure Python 3 wheel". Download by the tag the release actually
+      # carries, then retag to the one this Pyodide accepts. Drop the retag once the
+      # kernel pin moves past micropip 0.11.1.
       - name: Download latest WASM wheel
         shell: bash
         run: |
           set -euxo pipefail
 
           pip download mlir-python-bindings --plat pyemscripten_2024_0_wasm32 --no-deps --python-version 3.12 -f page/index.html
+
+          python -m pip install wheel
+          python -m wheel tags --platform-tag "$PYODIDE_PLATFORM_TAG" --remove mlir_python_bindings-*-pyemscripten_*_wasm32.whl
 
       - name: Get eudsl-python-extras
         shell: bash
@@ -82,7 +99,7 @@ jobs:
           test -f "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME"
 
           cp pages/console/index.html page/console/index.html
-          cp "$MLIR_PYTHON_WHEEL_NAME" page/console/mlir_python_bindings-0.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl
+          cp "$MLIR_PYTHON_WHEEL_NAME" "page/console/mlir_python_bindings-0.0.1-cp312-cp312-$PYODIDE_PLATFORM_TAG.whl"
           cp "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME" page/console/eudsl_python_extras-0.0.1-py3-none-any.whl
 
           echo "MLIR_PYTHON_WHEEL_NAME=$MLIR_PYTHON_WHEEL_NAME" >> $GITHUB_ENV
@@ -117,12 +134,40 @@ jobs:
 
           python - <<'PY'
           import json
+          import os
+          import pathlib
+          import re
+
+          platform_tag = os.environ["PYODIDE_PLATFORM_TAG"]
 
           with open("page/jupyter/pypi/all.json") as f:
               index = json.load(f)
           missing = [p for p in ("mlir-python-bindings", "eudsl-python-extras") if p not in index]
           if missing:
               raise SystemExit(f"piplite index is missing {missing}; got {sorted(index)}")
+
+          # Naming the package is not enough. The pinned Pyodide only installs wheels whose
+          # platform tag it recognises, so an index full of wheels tagged for a newer ABI
+          # resolves and then fails at install time with "Can't find a pure Python 3 wheel".
+          for filename in (
+              f["filename"]
+              for pkg in index.values()
+              for files in pkg["releases"].values()
+              for f in files
+          ):
+              tag = re.sub(r"\.whl$", "", filename).rsplit("-", 1)[-1]
+              if tag not in (platform_tag, "any"):
+                  raise SystemExit(
+                      f"{filename} is tagged {tag}, which the pinned Pyodide cannot install; "
+                      f"expected {platform_tag} or a pure-Python wheel"
+                  )
+
+          # The console page hardcodes the wheel filenames it loads, so a rename on either
+          # side silently turns into a 404 at runtime.
+          console = pathlib.Path("page/console/index.html").read_text()
+          for wheel in re.findall(r'loadPackage\("([^"]+\.whl)"\)', console):
+              if not pathlib.Path("page/console", wheel).is_file():
+                  raise SystemExit(f"page/console/index.html loads {wheel}, which is not in page/console/")
           PY
 
       - uses: geekyeggo/delete-artifact@v5


### PR DESCRIPTION
Follow-up to #496, which fixed the Pages deploy race. The page is served correctly now, and this is the separate bug that race was masking.

## What's wrong

With `%%capture` removed from the notebook's install cell, `piplite.install('mlir-python-bindings')` raises:

```
ValueError: Can't find a pure Python 3 wheel for 'mlir-python-bindings'.
See: https://pyodide.org/en/stable/usage/faq.html#why-can-t-micropip-find-a-pure-python-wheel-for-a-package
```

The page itself is healthy: `/jupyter/` and `/console/` are live, and `/jupyter/pypi/all.json` lists both wheels at current versions. In the traceback, `query_package` returns metadata and `find_wheel` then rejects every candidate. That's a platform tag mismatch, not a missing file.

## Root cause

`pyodide-build >=0.28` tags wasm wheels `pyemscripten_*_wasm32` per PEP 783. The runtime that consumes them doesn't understand that tag.

`jupyterlite-pyodide-kernel==0.6.1` pins `PYODIDE_VERSION = "0.27.6"`, which ships micropip 0.9.0. Its `sys_tags()` synthesizes exactly one wasm platform tag:

```python
abi_version = get_config_var("PYODIDE_ABI_VERSION")
pyodide_platform_tag = f"pyodide_{abi_version}_wasm32"
```

micropip only learned `pyemscripten_*` in 0.11.1. I checked 0.6.0 through 0.11.0; none of them know it. The reported traceback matches micropip 0.9.0 line for line, including the `return wheel` typo at `transaction.py:349` (should be `return best_wheel`).

The regression is #410, which flipped `--plat` from `pyodide_2024_0_wasm32` to `pyemscripten_2024_0_wasm32`, making the build-side tag newer than the runtime consuming it.

## Second break: the console page

#410 updated the workflow's `cp` target to the new tag but not the filename hardcoded at `pages/console/index.html:113`, which still loads `mlir_python_bindings-0.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl`. That URL is a hard 404 on the live site:

```
$ curl -o /dev/null -w '%{http_code}\n' \
    https://llvm.github.io/eudsl/console/mlir_python_bindings-0.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl
404
```

So the console has been broken since May, independently of the jupyter page.

## The fix

Reverting `--plat` alone would not work: the build pins `pyodide-build>=0.28.0`, so the released artifact carries `pyemscripten_*` no matter how it's fetched. Fixing it at the source would change what gets published. Instead, download by the tag the release actually has, then retag the local copy to the one this Pyodide accepts:

```bash
python -m wheel tags --platform-tag "$PYODIDE_PLATFORM_TAG" --remove mlir_python_bindings-*-pyemscripten_*_wasm32.whl
```

The console fix falls out of the same change: the retag produces exactly the filename the HTML already references, so `pages/console/index.html` needed no edit.

The tag now lives in one place, a `PYODIDE_PLATFORM_TAG` workflow env var feeding the retag, the console filename, and the gate, so they can't drift apart the way they did in #410. Drop the retag once the kernel pin moves past micropip 0.11.1.

## Gate

Neither failure was visible to the #496 gate, which only checked that `all.json` names both packages. Both were named. It now also checks that every wheel in the index carries a tag this Pyodide can install, and that every wheel the console page loads actually exists in `page/console/`.

## Testing

Verified locally: `wheel tags --platform-tag pyodide_2024_0_wasm32 --remove` rewrites `WHEEL` and `RECORD` and leaves exactly one wheel on disk, so the existing `ls` plus `test -f` ambiguity check still holds. The retagged filename is accepted by micropip 0.9.0's matcher; the `pyemscripten` one is not. Extracted the gate's embedded Python and ran it against four fixtures: passes a correct build, fails the pyemscripten-tagged index, fails a console page referencing a missing wheel, still allows pure-Python `-any` wheels.

Not verified locally: the real end-to-end run. My sandbox blocks GitHub release assets, so I could not download the actual 38MB wheel or run `jupyter lite build`; the retag was validated against a synthetic wheel with the same tag structure. The `pull_request` trigger on this workflow's own path covers the real build here without deploying.

The micropip version is inferred from the traceback line numbers plus the `PYODIDE_VERSION` pin, not read off the running kernel. The conclusion holds for any micropip below 0.11.1, which is every version Pyodide 0.27.x ships.
