### PR TITLE
[pages] Pin jquery to 3.7.1 on the console page

### DIFF
--- a/pages/console/index.html
+++ b/pages/console/index.html
@@ -4,7 +4,11 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <script src="https://cdn.jsdelivr.net/npm/jquery"></script>
+    <!-- Pinned: jquery.terminal 2.35.2 requires jquery ^3.6.0, and it calls
+         jQuery.isFunction, which jQuery 4 removed. An unpinned `npm/jquery`
+         resolves to `latest`, which became 4.0.0 on 2026-01-18 and broke this
+         page with "jQuery.isFunction is not a function". Bump both together. -->
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/jquery.terminal.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery.terminal@2.35.2/js/unix_formatting.min.js"></script>
     <link


### PR DESCRIPTION
The WASM console terminal never initializes:

```
jquery.terminal.js:639 Uncaught (in promise) TypeError: jQuery.isFunction is not a function
```

## What's wrong

`pages/console/index.html:7` loaded jquery from an unpinned URL:

```html
<script src="https://cdn.jsdelivr.net/npm/jquery"></script>
```

That resolves to the `latest` dist-tag, which became **jQuery 4.0.0 on 2026-01-18**. jQuery 4 removed the long-deprecated `jQuery.isFunction`.

The very next line pins `jquery.terminal@2.35.2`, which declares `"jquery": "^3.6.0"` and still calls `jQuery.isFunction` at `jquery.terminal.js:639` — the exact frame in the report.

Nothing in this repo changed. The floating dist-tag rolled under us in January and the console broke that day.

## The fix

Pin to 3.7.1, the latest 3.x, which satisfies the terminal's `^3.6.0`. Added a comment so the two get bumped together next time.