### PR TITLE
[mlir-python-bindings-wasm] Build 32b_mlir_runner_utils STANDALONE

### DIFF
--- a/projects/mlir-python-bindings-wasm/CMakeLists.txt
+++ b/projects/mlir-python-bindings-wasm/CMakeLists.txt
@@ -129,12 +129,21 @@ add_mlir_python_modules(MLIRPythonWasmModules
     MLIRPythonWasmCAPI
 )
 
+# Without STANDALONE, add_mlir_library appends `LINK_COMPONENTS Support`, which pulls
+# LLVMSupport (and with it CommandLine.cpp) into this side module. Its file-scope
+# static cl::opt objects then re-register options that libMLIRPythonWasmCAPI.so already
+# owns, and cl::Option::addArgument aborts the moment Pyodide dlopens this library:
+#   CommandLine Error: Option 'print-inst-addrs' registered more than once!
+# 32bRunnerUtils.cpp only needs the C++ stdlib, so drop the dependency entirely. This
+# mirrors upstream's own mlir_runner_utils, which is also declared STANDALONE.
 add_mlir_library(32b_mlir_runner_utils
   SHARED
   32bRunnerUtils.cpp
 
   PARTIAL_SOURCES_INTENDED
   EXCLUDE_FROM_LIBMLIR
+
+  STANDALONE
 )
 
 set(_runtimes


### PR DESCRIPTION
Fixes #499.

The WASM console aborts while loading the wheel:

```
Loading mlir_python_bindings
: CommandLine Error: Option 'print-inst-addrs' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
Aborted()
Failed to load mlir_python_bindings
```

## Cause

LLVM registers command-line options through file-scope static `cl::opt` objects, and `cl::Option::addArgument` aborts on a duplicate name. Two libraries in the wheel each carry their own copy, so the second one dlopened re-registers options the first already owns.

From the deployed wheel, both carry the CommandLine machinery:

```
libMLIRPythonWasmCAPI.so       ~25973 llvm syms   has "print-inst-addrs"
lib32b_mlir_runner_utils.so    ~ 2603 llvm syms
```

The `dylink.0` section (where an Emscripten side module lists needed libraries) settles which is at fault:

```
_mlir.cpython-312-wasm32-emscripten.so  ->  libMLIRPythonSupport-mlir.so,
                                            libnanobind-mlir.so,
                                            libMLIRPythonWasmCAPI.so
lib32b_mlir_runner_utils.so             ->  (none)
```

Every extension module links against the aggregate CAPI dylib. `lib32b_mlir_runner_utils.so` declares nothing — it statically linked its own LLVM support code, so its `__wasm_call_ctors` runs a second registration pass under `loadDynlibsFromPackage`. That matches the reported stack, which reaches `addArgument` from `__wasm_call_ctors` inside `loadDynlib`.

The dependency is implicit. `AddMLIR.cmake:384`:

```cmake
# Most MLIR libraries depend on LLVMSupport.  Just specify it once here.
if(NOT ARG_STANDALONE)
  list(APPEND ARG_LINK_COMPONENTS Support)
endif()
```

`LLVMSupport` contains `CommandLine.cpp`. `32bRunnerUtils.cpp` does not want any of it: it includes only `32bCRunnerUtils.h` and `<iostream>` and has zero uses of `llvm::`.

## The fix

Declare it `STANDALONE`, matching what upstream already does for its own `mlir_runner_utils` (`mlir/lib/ExecutionEngine/CMakeLists.txt:229`).

`print-inst-addrs` (`llvm/lib/IR/AsmWriter.cpp:95`) is just the first name to collide. The option string lives in the CAPI dylib; the abort fires when the runner-utils copy re-registers over it.

## Testing

Compiling `32bRunnerUtils.cpp` into a shared library with nothing but the C++ stdlib succeeds:

```
$ c++ -std=c++17 -fPIC -shared -o rt_test.so 32bRunnerUtils.cpp -I.
$ nm -u rt_test.so | grep -c llvm
0
$ nm -g rt_test.so | c++filt | grep myPrint
... T _mlir_ciface_myPrintMemrefShapeF32
```

Zero undefined llvm symbols, and it still exports `_mlir_ciface_myPrintMemrefShapeF32` — the symbol `testSharedLibLoad` in `test_wasm_execution_engine.py` and the starter notebook resolve when they pass `lib32b_mlir_runner_utils.so` through `WasmExecutionEngine(shared_libs=[...])`. That path is the reason to be careful here, and it is unaffected.

Also confirmed against `AddMLIR.cmake`'s own argument parsing that `STANDALONE` drops `Support` from `LINK_COMPONENTS` and changes nothing else (it appears at lines 326, 330, 384 only).

**Not verified locally:** an actual emscripten build of the wheel, which needs the pyodide toolchain. CI builds it, and the real check is that the console terminal comes up after this deploys.

## Related

Third in a chain, each exposing the next: #496 (Pages deploy race), #497 (wasm wheel platform tag), #498 (jquery 4 removed `isFunction`). With #498 merged, this abort is the last thing standing between the console and a working terminal.
