### PR TITLE
[ci] Trigger the bindings build on mlir-python-bindings-wasm changes

### DIFF
--- a/.github/workflows/build_mlir_python_bindings_wheel.yml
+++ b/.github/workflows/build_mlir_python_bindings_wheel.yml
@@ -41,12 +41,14 @@ on:
     paths:
       - ".github/workflows/build_mlir_python_bindings_wheel.yml"
       - "projects/mlir-python-bindings/**"
+      - "projects/mlir-python-bindings-wasm/**"
   push:
     branches:
       - main
     paths:
       - ".github/workflows/build_mlir_python_bindings_wheel.yml"
       - "projects/mlir-python-bindings/**"
+      - "projects/mlir-python-bindings-wasm/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}-build_mlir_python_bindings_wheel


### PR DESCRIPTION
`build_mlir_python_bindings_wheel.yml` filters on `projects/mlir-python-bindings/**`, which does **not** match `projects/mlir-python-bindings-wasm/**`. They are sibling directories, and the glob is not a prefix match.

The wasm wheel is built from `projects/mlir-python-bindings-wasm`:

```yaml
pyodide build "$PWD/projects/mlir-python-bindings-wasm" -o wheelhouse --compression-level 10
```

so edits there never rebuilt it.

#500 hit exactly this. Merging it ran only the pip page deploy, which redeployed the site from the *previously released* wheel, so the fix did not reach the live console until the build was dispatched by hand. A change that looks merged but silently never ships is a bad failure mode to leave in place.

`mlir-python-bindings-wasm` was the only directory under `projects/` not covered by any workflow's paths filter.