### PR TITLE
[jupyter] Build the WebGPU notebook's kernel with the bindings, not MLIR text

### DIFF
--- a/pages/jupyter/contents/mlir-python-starter.ipynb
+++ b/pages/jupyter/contents/mlir-python-starter.ipynb
@@ -24,7 +24,7 @@
     {
       "id": "37e7b57b-06eb-4249-a88b-dfbb7dba510e",
       "cell_type": "code",
-      "source": "%%capture\n\nimport piplite\nawait piplite.install('mlir-python-bindings')\nawait piplite.install('numpy')",
+      "source": "%%capture\n\nimport piplite\nawait piplite.install('numpy')\nawait piplite.install('mlir-python-bindings')",
       "metadata": {
         "trusted": true
       },

--- a/pages/jupyter/contents/mlir-webgpu.ipynb
+++ b/pages/jupyter/contents/mlir-webgpu.ipynb
@@ -1,17 +1,17 @@
 {
  "cells": [
   {
-   "id": "eddc82d6-5f95-4855-99f6-66b79dabffae",
+   "id": "669131b4-a8aa-498f-bb28-a6ebf4bd64a4",
    "cell_type": "markdown",
-   "source": "# MLIR \u2192 SPIR-V \u2192 WGSL \u2192 WebGPU\n\nAuthor a GPU kernel in MLIR, compile it in this tab, and run it on your GPU.\n\nEvery step happens client-side. There is no server and nothing is precompiled:\nthe MLIR pass pipeline and the SPIR-V\u2192WGSL translator (Tint) are both compiled\nto WebAssembly and shipped in the `mlir-python-bindings` wheel, and the dispatch\ngoes straight to the browser's own WebGPU implementation.\n\n**Requires a WebGPU-capable browser.** Recent Chrome and Edge work; Safari and\nFirefox need it enabled. `navigator.gpu` has to exist.",
+   "source": "# MLIR \u2192 SPIR-V \u2192 WGSL \u2192 WebGPU\n\nWrite a GPU kernel in Python, compile it in this tab, and run it on your GPU.\n\nEvery step happens client-side. There is no server and nothing is precompiled:\nMLIR, its pass pipeline, and the SPIR-V\u2192WGSL translator (Tint) are all compiled\nto WebAssembly and shipped in the `mlir-python-bindings` wheel. The dispatch goes\nstraight to the browser's own WebGPU implementation.\n\nThe kernel is authored with `eudsl-python-extras`, so there is no MLIR text\nanywhere below \u2014 the IR is built through the Python bindings.\n\n**Requires a WebGPU-capable browser.** Recent Chrome and Edge work; Safari and\nFirefox need it enabled.",
    "metadata": {
     "trusted": true
    }
   },
   {
-   "id": "7d274f88-fe3b-4569-be8e-343847d06cbd",
+   "id": "4b9fa246-12ec-4b1a-be59-c1c9b1f6e378",
    "cell_type": "code",
-   "source": "%%capture\n\nimport piplite\nawait piplite.install('mlir-python-bindings')\nawait piplite.install('numpy')",
+   "source": "%%capture\n\nimport piplite\n\n# numpy FIRST, and this order matters. mlir-python-bindings declares\n# `Requires-Dist: numpy`, so installing it first makes micropip resolve two\n# wheels and install them concurrently (micropip/install.py does an\n# asyncio.gather over them). The dynamic libraries then load interleaved, and\n# because 20 side modules in the wheel each carry their own copy of LLVM's\n# cl::opt registry, whichever registers second aborts the whole module:\n#     LLVM ERROR: inconsistency in registered CommandLine options\n# which surfaces here as `JsException: RuntimeError: Aborted()`. Satisfying the\n# dependency up front keeps it to one wheel at a time. See llvm/eudsl#502.\nawait piplite.install('numpy')\nawait piplite.install('mlir-python-bindings')\nawait piplite.install('eudsl-python-extras')",
    "metadata": {
     "trusted": true
    },
@@ -19,7 +19,7 @@
    "execution_count": null
   },
   {
-   "id": "64a51ddc-2182-4341-9577-487c82ec72f8",
+   "id": "46d5b331-f111-4d83-863c-b103033ed55f",
    "cell_type": "code",
    "source": "from mlir.webgpu import get_device\n\n# Raises with a clear message if this browser has no WebGPU.\ndevice = await get_device()\nprint(\"WebGPU adapter acquired\")",
    "metadata": {
@@ -29,17 +29,17 @@
    "execution_count": null
   },
   {
-   "id": "d3ed0cc8-8d83-43fb-a74b-bec7346ee8bb",
+   "id": "5b6b4e6c-1cf9-4334-8116-e5b4bcd1b93a",
    "cell_type": "markdown",
-   "source": "## 1. The kernel\n\nA 32\u00d732 matmul as a `gpu.func`. Two things here are load-bearing for what follows:\n\n- `spirv.target_env` with the `Shader` capability, `Logical` addressing and the\n  `GLSL450` memory model. That is the Vulkan flavour of SPIR-V, which is what\n  WebGPU accepts. The `Kernel`/OpenCL flavour used for CPU and Level Zero targets\n  will not translate.\n- `spirv.entry_point_abi` carries the workgroup size, which becomes\n  `@workgroup_size` in the generated WGSL.",
+   "source": "## 1. The kernel\n\nA 32\u00d732 matmul, written with the `eudsl-python-extras` GPU dialect helpers:\n`@gpu.func` builds a `gpu.func`, `block_dim`/`block_idx`/`thread_idx` become the\ncorresponding `gpu` ops, and `scf.range_` becomes an `scf.for` carrying the\naccumulator as an iteration argument.\n\nTwo attributes matter for what follows:\n\n- `spirv.entry_point_abi` carries the workgroup size, which becomes\n  `@workgroup_size` in the generated WGSL.\n- `TARGET_ENV`, attached to the `gpu.module`, uses the `Shader` capability,\n  giving a `Logical`/`GLSL450` module. That is the Vulkan flavour of\n  SPIR-V, which is what WebGPU accepts \u2014 the `Kernel`/OpenCL flavour used for CPU\n  and Level Zero targets will not translate.",
    "metadata": {
     "trusted": true
    }
   },
   {
-   "id": "2bf4ac79-12aa-49f8-887d-c02b5b60e715",
+   "id": "bfd16936-8ce0-4bc5-9d10-3cd7e9d99394",
    "cell_type": "code",
-   "source": "MATMUL = \"\"\"\nmodule attributes {\n  gpu.container_module,\n  spirv.target_env = #spirv.target_env<\n    #spirv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]>, #spirv.resource_limits<>>\n} {\n  gpu.module @kernels {\n    gpu.func @matmul(%A: memref<32x32xf32>, %B: memref<32x32xf32>, %C: memref<32x32xf32>)\n      kernel attributes {spirv.entry_point_abi = #spirv.entry_point_abi<workgroup_size = [8, 8, 1]>} {\n      %row = gpu.global_id x\n      %col = gpu.global_id y\n      %c0 = arith.constant 0 : index\n      %c1 = arith.constant 1 : index\n      %c32 = arith.constant 32 : index\n      %zero = arith.constant 0.0 : f32\n      %sum = scf.for %k = %c0 to %c32 step %c1 iter_args(%acc = %zero) -> (f32) {\n        %a = memref.load %A[%row, %k] : memref<32x32xf32>\n        %b = memref.load %B[%k, %col] : memref<32x32xf32>\n        %m = arith.mulf %a, %b : f32\n        %n = arith.addf %acc, %m : f32\n        scf.yield %n : f32\n      }\n      memref.store %sum, %C[%row, %col] : memref<32x32xf32>\n      gpu.return\n    }\n  }\n}\n\"\"\"\n\nprint(MATMUL)",
+   "source": "import mlir.extras.types as T\nfrom mlir.extras.context import RAIIMLIRContextModule\n# memref is imported for its side effect: it registers a value caster\n# (memref.py, register_value_caster) that gives memref-typed block\n# arguments __getitem__, which is what makes A[row, k] work below.\nfrom mlir.extras.dialects import arith, gpu, memref, scf\nfrom mlir.extras.dialects.gpu import (\n    block_dim,\n    block_idx,\n    module,\n    set_container_module,\n    thread_idx,\n)\nfrom mlir.ir import Attribute\n\nctx = RAIIMLIRContextModule()\nset_container_module(ctx.module)\n\nM = N = K = 32\nWG = 8\ndtype = T.f32()\n\nWORKGROUP_SIZE = Attribute.parse(\n    f\"#spirv.entry_point_abi<workgroup_size = [{WG}, {WG}, 1]>\"\n)\n\n# Vulkan flavour: the Shader capability gives a Logical/GLSL450 module, which is\n# what WebGPU accepts. SPV_KHR_storage_buffer_storage_class is not optional --\n# convert-gpu-to-spirv maps the memref arguments to StorageBuffer, and without\n# the extension named here `memref.load` fails to legalize.\nTARGET_ENV = (\n    \"#spirv.target_env<#spirv.vce<v1.0, [Shader],\"\n    \" [SPV_KHR_storage_buffer_storage_class]>, api=Vulkan,\"\n    \" #spirv.resource_limits<>>\"\n)\n\n\n@gpu.func(func_attrs={\"spirv.entry_point_abi\": WORKGROUP_SIZE})\ndef matmul(\n    A: T.memref(M, K, dtype), B: T.memref(K, N, dtype), C: T.memref(M, N, dtype)\n):\n    row = block_dim.x * block_idx.x + thread_idx.x\n    col = block_dim.y * block_idx.y + thread_idx.y\n\n    acc = arith.constant(0.0, type=dtype)\n    for k, acc, _ in scf.range_(K, iter_args=[acc]):\n        acc += A[row, k] * B[k, col]\n        acc = scf.yield_(acc)\n\n    C[row, col] = acc\n\n\n@module(\"kernels\", [TARGET_ENV])\ndef kernels():\n    matmul.emit()\n\n\nprint(ctx.module)",
    "metadata": {
     "trusted": true
    },
@@ -47,17 +47,17 @@
    "execution_count": null
   },
   {
-   "id": "87cc28b6-0e37-43ab-b5e5-18754aae2159",
+   "id": "8e4645be-7b81-4266-9147-01377438214e",
    "cell_type": "markdown",
-   "source": "## 2. Lower to the SPIR-V dialect\n\n`convert-gpu-to-spirv` rewrites the kernel body, then `spirv-lower-abi-attrs`\nturns the `memref` arguments into `spirv.GlobalVariable`s with `bind(set,\nbinding)` decorations \u2014 Vulkan requires entry points to be `void(void)`, so\narguments become interface variables. `spirv-update-vce` computes the\n`vce_triple` the serializer requires, and `spirv-webgpu-prepare` expands the ops\nWebGPU does not allow.\n\nThe pipeline is `mlir.webgpu.LOWER_PIPELINE`; running it by hand here so the\nintermediate is visible.",
+   "source": "## 2. Lower to the SPIR-V dialect\n\n`convert-gpu-to-spirv` rewrites the kernel body. Then `spirv-lower-abi-attrs`\nturns the `memref` arguments into `spirv.GlobalVariable`s with `bind(set,\nbinding)` decorations \u2014 Vulkan requires entry points to be `void(void)`, so\narguments become interface variables. `spirv-update-vce` computes the\n`vce_triple` the serializer needs, and `spirv-webgpu-prepare` expands the ops\nWebGPU does not allow.\n\nThe pipeline is built with `Pipeline()` rather than a pass-pipeline string.",
    "metadata": {
     "trusted": true
    }
   },
   {
-   "id": "5f3d692e-0cd7-439d-b6f2-d02d86fd6667",
+   "id": "ef09bc73-10fb-4254-ab18-3a8152cd0fd0",
    "cell_type": "code",
-   "source": "from mlir.ir import Context, Module\nfrom mlir.passmanager import PassManager\nfrom mlir.webgpu import LOWER_PIPELINE\n\nwith Context():\n    module = Module.parse(MATMUL)\n    PassManager.parse(LOWER_PIPELINE).run(module.operation)\n    lowered = str(module)\n\n# just the spirv.module, the emptied gpu.module below it is noise here\nprint(lowered[lowered.index(\"spirv.module\"):lowered.index(\"gpu.module\")])",
+   "source": "from mlir.extras.runtime.passes import Pipeline, run_pipeline\n\n# No spirv-attach-target here: the gpu.module already carries TARGET_ENV, and\n# that pass does not replace a target that is already present.\nlower = (\n    Pipeline()\n    .convert_gpu_to_spirv()\n    .Spirv(\n        Pipeline()\n        .spirv_lower_abi_attrs()\n        .spirv_update_vce()\n        .spirv_webgpu_prepare()\n    )\n)\nprint(lower, end=\"\\n\\n\")\n\nlowered = run_pipeline(ctx.module, lower)\n\nasm = str(lowered)\nprint(asm[asm.index(\"spirv.module\") : asm.index(\"gpu.module\")])",
    "metadata": {
     "trusted": true
    },
@@ -65,17 +65,17 @@
    "execution_count": null
   },
   {
-   "id": "7dfdb06e-8332-4b86-aca0-2d59860137fd",
+   "id": "b04f0544-8a59-4167-bec2-9d2c3343f386",
    "cell_type": "markdown",
-   "source": "Note the `bind(0, 0)`, `bind(0, 1)`, `bind(0, 2)` on the global variables. Those\nbecome `@group(0) @binding(N)` in WGSL and decide how the host binds buffers, in\nkernel argument order.\n\n## 3. Serialize to a SPIR-V binary\n\n`gpu-module-to-binary` calls `spirv::serialize` internally and stores the result\nin a `gpu.binary` op, so no extra binding is needed to get the bytes out.\n\nOne wart, handled by `mlir.webgpu.nest_spirv_module`: `convert-gpu-to-spirv`\nhoists the generated `spirv.module` to the top level as a *sibling* of the\nemptied `gpu.module`, while the serializer only looks *inside* one. Upstream's\nVulkan runner pipeline avoids this with\n`test-convert-to-spirv{nest-in-gpu-module=true}`, but that pass is test-only and\nis not in this wheel.",
+   "source": "Note the `bind(0, 0)`, `bind(0, 1)`, `bind(0, 2)` on the global variables. Those\nbecome `@group(0) @binding(N)` in WGSL and decide how the host binds buffers, in\nkernel-argument order.\n\n## 3. Serialize to a SPIR-V binary\n\n`gpu-module-to-binary` calls `spirv::serialize` internally and stores the result\nin a `gpu.binary` op, which `get_compile_object_bytes` reads back out.\n\nOne wart, handled by `mlir.webgpu.nest_spirv_module`: `convert-gpu-to-spirv`\nhoists the generated `spirv.module` to the top level as a *sibling* of the\nemptied `gpu.module`, while the serializer only looks *inside* one. Upstream's\nVulkan runner pipeline avoids this with\n`test-convert-to-spirv{nest-in-gpu-module=true}`, but that pass is test-only and\nis not in this wheel.",
    "metadata": {
     "trusted": true
    }
   },
   {
-   "id": "52c70320-353d-4587-938e-52862fe6956f",
+   "id": "1a034a7e-7d3f-45fc-aac4-4faf87d622fb",
    "cell_type": "code",
-   "source": "from mlir.webgpu import extract_binary, nest_spirv_module, SERIALIZE_PIPELINE\n\nwith Context():\n    module = Module.parse(nest_spirv_module(lowered))\n    PassManager.parse(SERIALIZE_PIPELINE).run(module.operation)\n    spirv = extract_binary(str(module))\n\nmagic = int.from_bytes(spirv[:4], \"little\")\nprint(f\"{len(spirv)} bytes, magic {magic:#010x} (SPIR-V is 0x07230203)\")\n\n# steps 2 and 3 in one call, for when you do not need the intermediates:\n#     from mlir.webgpu import compile_to_spirv\n#     spirv = compile_to_spirv(MATMUL)",
+   "source": "from mlir.extras.dialects.gpu import get_compile_object_bytes\nfrom mlir.ir import Module\nfrom mlir.webgpu import nest_spirv_module\n\nnested = Module.parse(nest_spirv_module(str(lowered)))\nbinary = run_pipeline(nested, Pipeline().gpu_module_to_binary())\n\nspirv = bytes(get_compile_object_bytes(binary))\nmagic = int.from_bytes(spirv[:4], \"little\")\nprint(f\"{len(spirv)} bytes, magic {magic:#010x} (SPIR-V is 0x07230203)\")",
    "metadata": {
     "trusted": true
    },
@@ -83,7 +83,7 @@
    "execution_count": null
   },
   {
-   "id": "1d25aabd-1ff7-442a-90a0-56d8394fef55",
+   "id": "48a8cfa9-93f6-4c07-a665-b7e376c5df2c",
    "cell_type": "markdown",
    "source": "## 4. SPIR-V \u2192 WGSL\n\n`mlir.wgsl` wraps Tint's SPIR-V reader and WGSL writer, compiled into the wheel.\nWebGPU only accepts WGSL, so this step is unavoidable \u2014 but note it is *only* the\ntranslator. Dawn's runtime is not here; the browser already implements WebGPU.",
    "metadata": {
@@ -91,7 +91,7 @@
    }
   },
   {
-   "id": "a77069f8-5fba-430a-a195-d08c2ac93498",
+   "id": "d38369ee-ae40-4642-806f-90b29a5a3205",
    "cell_type": "code",
    "source": "from mlir.wgsl import spirv_to_wgsl\n\nwgsl = spirv_to_wgsl(spirv)\nprint(wgsl)",
    "metadata": {
@@ -101,7 +101,7 @@
    "execution_count": null
   },
   {
-   "id": "ea3c02a7-86d0-473e-b3df-ef201c7c09dc",
+   "id": "fcad0698-42cb-458b-b421-385fb38f7bf3",
    "cell_type": "markdown",
    "source": "## 5. Dispatch\n\n`mlir.webgpu.dispatch` uploads the inputs, runs the shader, and reads the result\nback. Buffers bind at `@group(0) @binding(i)` \u2014 inputs in order, output last \u2014\nwhich lines up with the `bind(0, N)` decorations from step 2 without either side\nbeing adjusted to fit the other.",
    "metadata": {
@@ -109,9 +109,9 @@
    }
   },
   {
-   "id": "2f7602f7-294f-4629-8d3a-e210f851e5d7",
+   "id": "6fd12b46-f2a7-4e22-9975-4a00188b4cdb",
    "cell_type": "code",
-   "source": "import numpy as np\nfrom mlir.webgpu import dispatch\n\nM = N = K = 32\nrng = np.random.default_rng(0)\nA = rng.standard_normal((M, K), dtype=np.float32)\nB = rng.standard_normal((K, N), dtype=np.float32)\n\nC = await dispatch(\n    wgsl,\n    inputs=[A, B],\n    out_shape=(M, N),\n    entry_point=\"matmul\",\n    workgroup=(8, 8, 1),\n    device=device,\n)\n\nexpected = A @ B\nprint(\"max abs err:\", float(np.max(np.abs(C - expected))))\nprint(\"MATCH\" if np.allclose(C, expected, rtol=1e-4, atol=1e-4) else \"MISMATCH\")",
+   "source": "import numpy as np\nfrom mlir.webgpu import dispatch\n\nrng = np.random.default_rng(0)\nA = rng.standard_normal((M, K), dtype=np.float32)\nB = rng.standard_normal((K, N), dtype=np.float32)\n\nC = await dispatch(\n    wgsl,\n    inputs=[A, B],\n    out_shape=(M, N),\n    entry_point=\"matmul\",\n    workgroup=(WG, WG, 1),\n    device=device,\n)\n\nexpected = A @ B\nprint(\"max abs err:\", float(np.max(np.abs(C - expected))))\nprint(\"MATCH\" if np.allclose(C, expected, rtol=1e-4, atol=1e-4) else \"MISMATCH\")",
    "metadata": {
     "trusted": true
    },
@@ -119,9 +119,9 @@
    "execution_count": null
   },
   {
-   "id": "b89c7735-3c7f-4918-9550-3ce32bf52988",
+   "id": "bdc18323-d538-4ff2-89e6-66984edf11e9",
    "cell_type": "markdown",
-   "source": "The error is float32 accumulation noise over a K=32 dot product, not a\ncorrectness problem.\n\n## Try your own\n\nEdit `MATMUL` and re-run from step 2. Things worth knowing:\n\n- Kernel arguments must be `memref` of a type WebGPU can store (`f32` and `i32`\n  are safe; `f64` is not available).\n- Keep the `Shader` capability. Adding capabilities the browser lacks makes Tint\n  reject the module, usually with a message about an unsupported SPIR-V feature.\n- Buffers bind at `@group(0) @binding(i)` in argument order.\n- If `spirv_to_wgsl` raises, the message carries Tint's own diagnostics plus a\n  SPIR-V header summary, which is normally enough to see which op it choked on.",
+   "source": "The error is float32 accumulation noise over a K=32 dot product, not a\ncorrectness problem.\n\n## Try your own\n\nEdit the `@gpu.func` in step 1 and re-run from there. Things worth knowing:\n\n- Argument types come from `mlir.extras.types`; `T.memref(...)` of `f32` or `i32`\n  is safe. WebGPU has no `f64`.\n- Keep the capability set to `Shader`. Adding capabilities the browser lacks makes\n  Tint reject the module, usually with a message about an unsupported SPIR-V\n  feature.\n- Buffers bind at `@group(0) @binding(i)` in argument order, so keep the output\n  last if you use `dispatch` as-is.\n- If `spirv_to_wgsl` raises, the message carries Tint's own diagnostics plus a\n  SPIR-V header summary, which is normally enough to see which op it choked on.\n- `run_pipeline` prints a reproducer if a pass fails, including the pipeline and\n  the offending module.",
    "metadata": {
     "trusted": true
    }

--- a/pages/jupyter/contents/mlir-webgpu.ipynb
+++ b/pages/jupyter/contents/mlir-webgpu.ipynb
@@ -11,7 +11,7 @@
   {
    "id": "4b9fa246-12ec-4b1a-be59-c1c9b1f6e378",
    "cell_type": "code",
-   "source": "%%capture\n\nimport piplite\n\n# numpy FIRST, and this order matters. mlir-python-bindings declares\n# `Requires-Dist: numpy`, so installing it first makes micropip resolve two\n# wheels and install them concurrently (micropip/install.py does an\n# asyncio.gather over them). The dynamic libraries then load interleaved, and\n# because 20 side modules in the wheel each carry their own copy of LLVM's\n# cl::opt registry, whichever registers second aborts the whole module:\n#     LLVM ERROR: inconsistency in registered CommandLine options\n# which surfaces here as `JsException: RuntimeError: Aborted()`. Satisfying the\n# dependency up front keeps it to one wheel at a time. See llvm/eudsl#502.\nawait piplite.install('numpy')\nawait piplite.install('mlir-python-bindings')\nawait piplite.install('eudsl-python-extras')",
+   "source": "%%capture\n\nimport piplite\nawait piplite.install('numpy')\nawait piplite.install('eudsl-python-extras')\nawait piplite.install('mlir-python-bindings')",
    "metadata": {
     "trusted": true
    },


### PR DESCRIPTION
The WebGPU notebook pasted a 25-line MLIR string for its kernel and pass-pipeline strings for the lowering. Both are now Python — there is no MLIR source text in any code cell.

```python
@gpu.func(func_attrs={"spirv.entry_point_abi": WORKGROUP_SIZE})
def matmul(A: T.memref(M, K, dtype), B: T.memref(K, N, dtype), C: T.memref(M, N, dtype)):
    row = block_dim.x * block_idx.x + thread_idx.x
    col = block_dim.y * block_idx.y + thread_idx.y

    acc = arith.constant(0.0, type=dtype)
    for k, acc, _ in scf.range_(K, iter_args=[acc]):
        acc += A[row, k] * B[k, col]
        acc = scf.yield_(acc)

    C[row, col] = acc
```

Modelled on `tests/dialect/test_gpu.py` `test_amdgpu`, which is the same matmul with the same `scf.range_`/`iter_args` idiom. The pipeline is a `Pipeline()` builder, and `get_compile_object_bytes` from extras replaces the hand-rolled `\XX` blob decoder — it reads the `ObjectAttr` instead of re-parsing printed IR.