### PR TITLE
[jupyter] Catch the LLVMSupport loader abort in the install cell

### DIFF
--- a/pages/jupyter/contents/mlir-python-starter.ipynb
+++ b/pages/jupyter/contents/mlir-python-starter.ipynb
@@ -24,7 +24,7 @@
     {
       "id": "37e7b57b-06eb-4249-a88b-dfbb7dba510e",
       "cell_type": "code",
-      "source": "%%capture\n\nimport piplite\nawait piplite.install('numpy')\nawait piplite.install('mlir-python-bindings')",
+      "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\n\n# The wheel links LLVMSupport into every extension, so the second one Pyodide\n# dlopens re-registers LLVM's command-line options and aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
       "metadata": {
         "trusted": true
       },

--- a/pages/jupyter/contents/mlir-webgpu.ipynb
+++ b/pages/jupyter/contents/mlir-webgpu.ipynb
@@ -11,7 +11,7 @@
   {
    "id": "4b9fa246-12ec-4b1a-be59-c1c9b1f6e378",
    "cell_type": "code",
-   "source": "%%capture\n\nimport piplite\nawait piplite.install('numpy')\nawait piplite.install('eudsl-python-extras')\nawait piplite.install('mlir-python-bindings')",
+   "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\nawait piplite.install('eudsl-python-extras')\n\n# The wheel links LLVMSupport into every extension, so the second one Pyodide\n# dlopens re-registers LLVM's command-line options and aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
    "metadata": {
     "trusted": true
    },


### PR DESCRIPTION
The wheel links a copy of LLVMSupport into every extension module, so the second one Pyodide
dlopens re-registers LLVM's command-line options and the registration calls `abort()` (#502).
`micropip`'s `loadDynlibsFromPackage` surfaces that as

```
JsException: RuntimeError: Aborted(). Build with -sASSERTIONS for more info.
```

Both install cells were behind `%%capture`, which does not help here: `%%capture` redirects
stdout/stderr/display and does not suppress exceptions, so the traceback appeared anyway.

So catch that abort specifically:

```python
with capture_output() as install_output:
    try:
        await piplite.install('mlir-python-bindings')
    except JsException as e:
        if "Aborted()" not in str(e):
            raise

print(install_output.stdout, end="")
for line in install_output.stderr.splitlines():
    if not any(noise in line for noise in LOADER_NOISE):
        print(line, file=sys.stderr)
```

Any other `JsException` is re-raised, and stderr is filtered to the two known lines instead of
being discarded wholesale, so a real install failure still surfaces.

Caveat worth recording: the abort fires *inside* `loadDynlibsFromPackage`, so swallowing it can
leave later side modules in the wheel unloaded. That is the origin of the
`ImportError: dynamic module does not define module export function (PyInit__mlir)` seen with a
bad install order. This suppresses the symptom; #502 is the cause, and the upstream half of it
is llvm/llvm-project#213509, which removes 19 of the 21 copies of LLVMSupport from the wheel.

Not verified in a browser yet.