### PR TITLE
[jupyter] Point the install-cell comment at the loader, not LLVMSupport

### DIFF
--- a/pages/jupyter/contents/mlir-python-starter.ipynb
+++ b/pages/jupyter/contents/mlir-python-starter.ipynb
@@ -24,7 +24,7 @@
     {
       "id": "37e7b57b-06eb-4249-a88b-dfbb7dba510e",
       "cell_type": "code",
-      "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\n\n# The wheel links LLVMSupport into every extension, so the second one Pyodide\n# dlopens re-registers LLVM's command-line options and aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
+      "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\n\n# Pyodide 0.27's loader keys loaded libraries by path but resolves dylink\n# dependencies by basename, so it instantiates libMLIRPythonWasmCAPI.so twice\n# and LLVM's command-line options register twice, which aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
       "metadata": {
         "trusted": true
       },

--- a/pages/jupyter/contents/mlir-webgpu.ipynb
+++ b/pages/jupyter/contents/mlir-webgpu.ipynb
@@ -11,7 +11,7 @@
   {
    "id": "4b9fa246-12ec-4b1a-be59-c1c9b1f6e378",
    "cell_type": "code",
-   "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\nawait piplite.install('eudsl-python-extras')\n\n# The wheel links LLVMSupport into every extension, so the second one Pyodide\n# dlopens re-registers LLVM's command-line options and aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
+   "source": "import sys\n\nimport piplite\nfrom IPython.utils.capture import capture_output\nfrom pyodide.ffi import JsException\n\nawait piplite.install('numpy')\nawait piplite.install('eudsl-python-extras')\n\n# Pyodide 0.27's loader keys loaded libraries by path but resolves dylink\n# dependencies by basename, so it instantiates libMLIRPythonWasmCAPI.so twice\n# and LLVM's command-line options register twice, which aborts (llvm/eudsl#502).\nwith capture_output() as install_output:\n    try:\n        await piplite.install('mlir-python-bindings')\n    except JsException as e:\n        if \"Aborted()\" not in str(e):\n            raise\n\nprint(install_output.stdout, end=\"\")\nfor line in install_output.stderr.splitlines():\n    if not any(n in line for n in (\"CommandLine Error: Option\", \"Aborted(\")):\n        print(line, file=sys.stderr)",
    "metadata": {
     "trusted": true
    },


### PR DESCRIPTION
Follow-up to #506, which attributed the abort in the install cells to the wheel linking LLVMSupport
into every extension module. That was wrong.

llvm/llvm-project#213509 removed those copies and it did work — measured on the wheel from the #504
bump (`20260803+2450b7e17`):

| | before | after |
|---|---|---|
| libraries defining `cl::Option::addArgument` | 21 | **1** (`libMLIRPythonWasmCAPI.so`) |
| wheel size | 38 MB | **23.5 MB** |
| `_mlirAsyncPasses` | 1.73 MB | 0.00 MB |

And the abort is still printed, so LLVMSupport duplication was never the cause.

The cause is the Pyodide 0.27 loader. `get_dynlibs` returns the `.so` paths in zip namelist order,
unsorted, which puts `libMLIRPythonWasmCAPI.so` at entry 24 of 25 — after all 21 extensions that
name it by bare basename in their `dylink.0` NEEDED list. The first extension loads it under that
basename; when the loop later reaches the aggregate's own entry it passes an **absolute path**, which
misses the basename key in `LDSO.loadedLibsByName` and instantiates the library a second time. Its
`cl::opt` constructors run twice and the second registration aborts. 0.27.7's `loadDynlib` aliases
path → basename *after* loading but never checks basename → path *before*, so the guard is
one-directional.

Fixed upstream by pyodide/pyodide#5610 ("replace `loadDynamicLibrary` with `emscripten_dlopen`"),
which is in Pyodide 0.28.0. We pin 0.27.7. Full analysis in #502.

Comment only — the code in #506 is unchanged and still correct, since the symptom is real regardless
of which layer causes it.