### PR TITLE
[wasm] Bump Pyodide to 0.29.4 so the CAPI dylib loads once

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -57,6 +57,29 @@ runs:
         timezoneMacos: "Asia/Singapore"
         timezoneWindows: "Singapore Standard Time"
 
+    # Zip stores naive local time with no timezone, and the step above puts the
+    # runners in Asia/Singapore. So a wheel built at 13:09 UTC records 21:09, and
+    # unzipping it anywhere west of Singapore yields files dated hours in the
+    # future -- which makes ninja re-run cmake until it gives up:
+    #   ninja: error: manifest 'build.ninja' still dirty after 100 tries,
+    #   perhaps system time is not set
+    # That bites anyone unpacking a CI artifact to build against locally.
+    # SOURCE_DATE_EPOCH is honoured by scikit-build-core and by pyodide build's
+    # repack, so setting it here covers both scripts/llvm_wasm and
+    # projects/mlir-python-bindings-wasm.
+    #
+    # Midnight UTC *yesterday*, not today: with SOURCE_DATE_EPOCH set the stamp
+    # is rendered in UTC, which removes the Singapore skew, but a naive stamp is
+    # still read back as local time. Midnight-today would still look like the
+    # future to a consumer in UTC-12 unpacking a build made before noon UTC.
+    # Backing off a day beats any real timezone offset while keeping the
+    # timestamp recent and plausible for everything else that reads this.
+    - name: "Set SOURCE_DATE_EPOCH"
+      shell: bash
+      run: |
+
+        echo "SOURCE_DATE_EPOCH=$(( ($(date -u +%s) / 86400 - 1) * 86400 ))" >> $GITHUB_ENV
+
     - name: "Clean ubuntu"
       if: (inputs.container && startsWith(inputs.runs-on, 'ubuntu'))
       shell: bash

--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -250,6 +250,15 @@ runs:
           echo CMAKE_OSX_DEPLOYMENT_TARGET=11.0 >> $GITHUB_ENV
         fi
 
+    # pyodide-build compares the HOST python's major.minor against the cross-build
+    # environment's and refuses a mismatch, so PYODIDE_VERSION below dictates the
+    # host interpreter too -- not inputs.python-version, which defaults to 3.12.
+    - name: Install host Python for the cross-build environment
+      if: inputs.target-arch == 'wasm32'
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
     - name: Install pyodide
       if: inputs.target-arch == 'wasm32'
       shell: bash

--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -259,23 +259,27 @@ runs:
 
         # Pin the cross-build environment. Left unpinned, pyodide-build installs
         # the latest compatible one (xbuildenv.py, _find_latest_version), whose
-        # python version determines the wheel's ABI tag. That has already drifted
-        # ahead of what runs the wheel: the console loads Pyodide
-        # PYODIDE_VERSION and jupyterlite-pyodide-kernel pins a matching one, so
-        # a cp313 wheel from a newer environment simply will not load there.
+        # python version determines the wheel's ABI tag, and that drifts ahead of
+        # the Pyodide that actually runs the wheel. A wheel whose ABI tag does not
+        # match the console's and the jupyterlite kernel's Pyodide will not load.
         #
         # Keep PYODIDE_VERSION in sync with:
         #   pages/console/index.html          (the pyodide CDN url)
         #   pages/jupyter/requirements.txt    (jupyterlite-pyodide-kernel)
-        PYODIDE_VERSION=0.27.7
+        #   scripts/llvm_wasm/Dockerfile
+        #   projects/mlir-python-bindings-wasm/build.sh
+        PYODIDE_VERSION=0.29.4
         pyodide xbuildenv install "$PYODIDE_VERSION"
 
         PY="$(pyodide config get python_version)"
         echo "pyodide $PYODIDE_VERSION -> python $PY"
         case "$PY" in
-          3.12*) ;;
-          *) echo "::error::expected python 3.12 from the $PYODIDE_VERSION cross-build env, got $PY"; exit 1 ;;
+          3.13*) ;;
+          *) echo "::error::expected python 3.13 from the $PYODIDE_VERSION cross-build env, got $PY"; exit 1 ;;
         esac
+
+        echo "PYODIDE_PY_TAG=cp${PY%%.*}$(echo "$PY" | cut -d. -f2)" >> $GITHUB_ENV
+        echo "PYODIDE_PLATFORM_TAG=pyemscripten_$(pyodide config get pyemscripten_platform_version)_wasm32" >> $GITHUB_ENV
 
         echo "EMSCRIPTEN_VERSION=$(pyodide config get emscripten_version)" >> $GITHUB_ENV
 

--- a/.github/workflows/build_mlir_python_bindings_wheel.yml
+++ b/.github/workflows/build_mlir_python_bindings_wheel.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           
           if [[ "${{ matrix.target-arch }}" == "wasm32" ]]; then
-            pip download mlir-wheel --plat pyemscripten_2024_0_wasm32 --no-deps --python-version 3.12 -f https://llvm.github.io/eudsl
+            pip download mlir-wheel --plat "$PYODIDE_PLATFORM_TAG" --no-deps --python-version "${PYODIDE_PY_TAG#cp}" -f https://llvm.github.io/eudsl
           else
             pip download mlir-wheel -f https://llvm.github.io/eudsl
           fi
@@ -413,13 +413,18 @@ jobs:
       - name: "Install Python"
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install pyodide and test
         shell: bash
         run: |
-          
+
           pip install pyodide-build>=0.28.0
+          # Pin the cross-build environment, or `pyodide venv` builds one from the
+          # latest release and the wheel's ABI tag stops matching the interpreter
+          # testing it. Keep in sync with PYODIDE_VERSION in
+          # .github/actions/setup_base/action.yml.
+          pyodide xbuildenv install 0.29.4
           pyodide venv venv
           . venv/bin/activate
           pip install mlir-python-bindings -f wheelhouse

--- a/.github/workflows/deploy_pip_page.yml
+++ b/.github/workflows/deploy_pip_page.yml
@@ -18,16 +18,21 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-# Platform tag the Pyodide runtime pinned by pages/jupyter/requirements.txt accepts.
-# Keep in sync with pages/console/index.html.
+# The Pyodide that runs the deployed pages. Must match the cross-build environment
+# the wheel was built against, or the wheel's ABI tag will not load. Keep in sync
+# with PYODIDE_VERSION in .github/actions/setup_base/action.yml and the CDN url in
+# pages/console/index.html; the "Verify page contents" step checks the latter.
+#
+# PYODIDE_PY_TAG / PYODIDE_PLATFORM_TAG are what that Pyodide's cross-build env
+# reports as python_version and pyemscripten_platform_version. This job does not
+# install the xbuildenv (it is a ~400MB download for two strings), so they are
+# spelled out here. "Verify page contents" below rejects any wheel in the piplite
+# index whose tag disagrees, so a stale value here fails the deploy rather than
+# shipping a wheel the runtime cannot install.
 env:
-  PYODIDE_PLATFORM_TAG: pyodide_2024_0_wasm32
-  # The Pyodide that runs the deployed pages. Must match the cross-build
-  # environment the wheel was built against, or the wheel's ABI tag will not
-  # load. Keep in sync with PYODIDE_VERSION in
-  # .github/actions/setup_base/action.yml and the CDN url in
-  # pages/console/index.html; the "Verify page contents" step checks the latter.
-  PYODIDE_VERSION: 0.27.7
+  PYODIDE_VERSION: 0.29.4
+  PYODIDE_PY_TAG: cp313
+  PYODIDE_PLATFORM_TAG: pyemscripten_2025_0_wasm32
 
 jobs:
   deploy:
@@ -61,28 +66,16 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       # Resolve both wheels out of the pip index we just built from the releases,
       # so this job never depends on an artifact belonging to some other run.
-      #
-      # pyodide-build >=0.28 tags wasm wheels `pyemscripten_*_wasm32` (PEP 783), but the
-      # runtime that consumes them here does not understand that tag yet: jupyterlite-
-      # pyodide-kernel 0.6.1 pins Pyodide 0.27.6, which ships micropip 0.9.0, and micropip
-      # only learned `pyemscripten_*` in 0.11.1. Under 0.9.0 the piplite index resolves the
-      # package fine and then rejects every wheel in it, so `piplite.install` fails with
-      # "Can't find a pure Python 3 wheel". Download by the tag the release actually
-      # carries, then retag to the one this Pyodide accepts. Drop the retag once the
-      # kernel pin moves past micropip 0.11.1.
       - name: Download latest WASM wheel
         shell: bash
         run: |
           set -euxo pipefail
 
-          pip download mlir-python-bindings --plat pyemscripten_2024_0_wasm32 --no-deps --python-version 3.12 -f page/index.html
-
-          python -m pip install wheel
-          python -m wheel tags --platform-tag "$PYODIDE_PLATFORM_TAG" --remove mlir_python_bindings-*-pyemscripten_*_wasm32.whl
+          pip download mlir-python-bindings --plat "$PYODIDE_PLATFORM_TAG" --no-deps --python-version "${PYODIDE_PY_TAG#cp}" -f page/index.html
 
       - name: Get eudsl-python-extras
         shell: bash
@@ -105,7 +98,7 @@ jobs:
           test -f "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME"
 
           cp pages/console/index.html page/console/index.html
-          cp "$MLIR_PYTHON_WHEEL_NAME" "page/console/mlir_python_bindings-0.0.1-cp312-cp312-$PYODIDE_PLATFORM_TAG.whl"
+          cp "$MLIR_PYTHON_WHEEL_NAME" "page/console/mlir_python_bindings-0.0.1-$PYODIDE_PY_TAG-$PYODIDE_PY_TAG-$PYODIDE_PLATFORM_TAG.whl"
           cp "$EUDSL_PYTHON_EXTRAS_WHEEL_NAME" page/console/eudsl_python_extras-0.0.1-py3-none-any.whl
 
           echo "MLIR_PYTHON_WHEEL_NAME=$MLIR_PYTHON_WHEEL_NAME" >> $GITHUB_ENV
@@ -120,7 +113,7 @@ jobs:
 
           python -m pip install -r pages/jupyter/requirements.txt
 
-          # jupyterlite-pyodide-kernel pins its own Pyodide (0.27.6 in 0.6.1),
+          # jupyterlite-pyodide-kernel pins its own Pyodide (0.29.3 in 0.7.2),
           # which is not necessarily the one the wheel was built against.
           # JUPYTERLITE_PYODIDE_URL makes the build vendor a specific
           # distribution instead, so the notebook and the console run the same

--- a/.github/workflows/deploy_pip_page.yml
+++ b/.github/workflows/deploy_pip_page.yml
@@ -75,14 +75,23 @@ jobs:
         run: |
           set -euxo pipefail
 
-          pip download mlir-python-bindings --plat "$PYODIDE_PLATFORM_TAG" --no-deps --python-version "${PYODIDE_PY_TAG#cp}" -f page/index.html
+          # --no-index, or a tag that matches nothing here falls back to PyPI, where
+          # `mlir-python-bindings` is a 6kB name-reservation stub tagged py3-none-any.
+          # That is compatible with every platform, so pip picks it, the tag check
+          # below waves it through as a pure-Python wheel, and the deploy ships a
+          # placeholder in place of the 23MB wasm wheel.
+          pip download mlir-python-bindings --plat "$PYODIDE_PLATFORM_TAG" --no-deps \
+            --python-version "${PYODIDE_PY_TAG#cp}" --no-index -f page/index.html
+
+          # Belt and braces: the wheel that lands must be the wasm one.
+          ls mlir_python_bindings-*-"$PYODIDE_PLATFORM_TAG".whl
 
       - name: Get eudsl-python-extras
         shell: bash
         run: |
           set -euxo pipefail
 
-          pip wheel eudsl-python-extras -f page/index.html --no-deps -w .
+          pip wheel eudsl-python-extras --no-index -f page/index.html --no-deps -w .
 
       - name: Create WASM console page
         shell: bash
@@ -201,18 +210,17 @@ jobs:
           # Naming the package is not enough. The pinned Pyodide only installs wheels whose
           # platform tag it recognises, so an index full of wheels tagged for a newer ABI
           # resolves and then fails at install time with "Can't find a pure Python 3 wheel".
-          for filename in (
-              f["filename"]
-              for pkg in index.values()
-              for files in pkg["releases"].values()
-              for f in files
-          ):
-              tag = re.sub(r"\.whl$", "", filename).rsplit("-", 1)[-1]
-              if tag not in (platform_tag, "any"):
-                  raise SystemExit(
-                      f"{filename} is tagged {tag}, which the pinned Pyodide cannot install; "
-                      f"expected {platform_tag} or a pure-Python wheel"
-                  )
+          for name, pkg in index.items():
+              for filename in (f["filename"] for files in pkg["releases"].values() for f in files):
+                  tag = re.sub(r"\.whl$", "", filename).rsplit("-", 1)[-1]
+                  # mlir-python-bindings is an extension package, so `any` here means a
+                  # placeholder got resolved instead of the wasm wheel.
+                  allowed = (platform_tag,) if name == "mlir-python-bindings" else (platform_tag, "any")
+                  if tag not in allowed:
+                      raise SystemExit(
+                          f"{filename} is tagged {tag}, which the pinned Pyodide cannot install; "
+                          f"expected one of {allowed}"
+                      )
 
           # The console page hardcodes the wheel filenames it loads, so a rename on either
           # side silently turns into a 404 at runtime.

--- a/pages/console/index.html
+++ b/pages/console/index.html
@@ -82,7 +82,7 @@
       }
 
       async function main() {
-        let indexURL = "https://cdn.jsdelivr.net/pyodide/v0.27.7/full/";
+        let indexURL = "https://cdn.jsdelivr.net/pyodide/v0.29.4/full/";
         const urlParams = new URLSearchParams(window.location.search);
         const buildParam = urlParams.get("build");
         if (buildParam) {
@@ -114,7 +114,7 @@
 
         // load additional wheel package
         await pyodide.loadPackage("numpy");
-        await pyodide.loadPackage("mlir_python_bindings-0.0.1-cp312-cp312-pyodide_2024_0_wasm32.whl");
+        await pyodide.loadPackage("mlir_python_bindings-0.0.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl");
         await pyodide.loadPackage("eudsl_python_extras-0.0.1-py3-none-any.whl");
 
         let { repr_shorten, BANNER, PyodideConsole } =

--- a/pages/jupyter/requirements.txt
+++ b/pages/jupyter/requirements.txt
@@ -1,10 +1,10 @@
 # Core modules (mandatory)
-jupyterlite-core==0.6.2
-jupyterlab~=4.4.3
-notebook~=7.4.3
+jupyterlite-core==0.7.6
+jupyterlab~=4.5.7
+notebook~=7.5.7
 
 # Python kernel (optional)
-jupyterlite-pyodide-kernel==0.6.1
+jupyterlite-pyodide-kernel==0.7.2
 
 # JavaScript kernel (optional)
 # jupyterlite-javascript-kernel==0.3.0

--- a/projects/mlir-python-bindings-wasm/build.sh
+++ b/projects/mlir-python-bindings-wasm/build.sh
@@ -7,15 +7,16 @@ then
 fi
 
 # Pin the cross-build environment; its python version becomes the wheel's ABI
-# tag. Unpinned, pyodide-build takes the latest compatible one, which currently
-# yields cp313 -- and the console and jupyterlite kernel both run a Pyodide with
-# cp312, so such a wheel will not load. Keep in sync with the same constant in
+# tag. Unpinned, pyodide-build takes the latest compatible one, which drifts ahead
+# of the Pyodide the console and jupyterlite kernel actually run, and a wheel whose
+# ABI tag does not match will not load. Keep in sync with the same constant in
 # .github/actions/setup_base/action.yml.
 #
-# NOTE this needs a python 3.12 interpreter: the compatibility check compares the
+# NOTE this needs a python 3.13 interpreter: the compatibility check compares the
 # HOST python's major.minor against the cross-build env's and refuses a mismatch,
-# so from 3.13 this fails with "not compatible with the current environment".
-PYODIDE_VERSION=${PYODIDE_VERSION:-0.27.7}
+# so from 3.14 (or on 3.12) this fails with "not compatible with the current
+# environment".
+PYODIDE_VERSION=${PYODIDE_VERSION:-0.29.4}
 pyodide xbuildenv install "$PYODIDE_VERSION"
 echo "pyodide $PYODIDE_VERSION -> python $(pyodide config get python_version)"
 

--- a/projects/mlir-python-bindings-wasm/mlir/wasm_execution_engine.py
+++ b/projects/mlir-python-bindings-wasm/mlir/wasm_execution_engine.py
@@ -1,11 +1,42 @@
 import ctypes
 import random
+import shutil
 import string
+import tempfile
+from pathlib import Path
 
 
 from ._mlir_libs import _mlirWasmExecutionEngine
 from .ir import Module, StringAttr
 from .runtime import np_to_memref as _np_to_memref
+
+
+def _load_global(path):
+    """dlopen `path` with RTLD_GLOBAL, working around Pyodide's load cache.
+
+    Pyodide dlopens every .so inside an installed package with RTLD_LOCAL and no
+    way to ask for anything else -- loadDynlib calls
+    `_emscripten_dlopen_promise(path, 2)`, i.e. RTLD_NOW, hardcoded
+    (pyodide/pyodide#5610 replaced the 0.27 loader, which took a `global` flag).
+    Anything shipped in mlir/_mlir_libs is therefore already loaded and already
+    local by the time this runs, and asking for it again by the same path just
+    returns the cached local handle: RTLD_GLOBAL is silently ignored and its
+    symbols never reach the global table. A module JIT-compiled later then dies
+    at instantiation with
+
+      Dynamic linking error: cannot resolve symbol _mlir_ciface_myPrintMemrefShapeF32
+
+    A path the loader has not seen gets a real dlopen that honours RTLD_GLOBAL,
+    so copy the library somewhere fresh first. The copy is kept alive for the
+    process, since unlinking it out from under the loader is not safe.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="mlir_shared_libs_")
+    fresh = Path(tmp_dir) / Path(path).name
+    shutil.copy(path, fresh)
+    lib = ctypes.CDLL(str(fresh), mode=ctypes.RTLD_GLOBAL)
+    # Anchor the temp path so it outlives this call.
+    lib._mlir_fresh_copy = str(fresh)
+    return lib
 
 
 class WasmExecutionEngine:
@@ -29,13 +60,16 @@ class WasmExecutionEngine:
             # 8 is the max length?
             module_name = "".join(random.choices(string.ascii_uppercase, k=8)).lower()
 
+        # Before link_load_module: the JIT-compiled module resolves its imports
+        # when it is instantiated, so anything it calls into has to be global by
+        # then.
+        for i, sh in enumerate(self.shared_libs):
+            self.shared_libs[i] = _load_global(sh)
+
         object_fn = _mlirWasmExecutionEngine.compile_module(
             module_op, module_name, opt_level
         )
         self.link_load_module(object_fn, module_name)
-
-        for i, sh in enumerate(self.shared_libs):
-            self.shared_libs[i] = ctypes.CDLL(sh, mode=ctypes.RTLD_GLOBAL)
 
     @staticmethod
     def link_load_module(object_fn, module_name):

--- a/projects/mlir-python-bindings-wasm/pyproject.toml
+++ b/projects/mlir-python-bindings-wasm/pyproject.toml
@@ -63,9 +63,18 @@ CMAKE_PLATFORM_NO_VERSIONED_SONAME = "ON"
 CMAKE_VISIBILITY_INLINES_HIDDEN = "ON"
 CMAKE_C_VISIBILITY_PRESET = "hidden"
 CMAKE_CXX_VISIBILITY_PRESET = "hidden"
-CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
-CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
-CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
+# -rpath $ORIGIN so each extension can find the dylibs sitting beside it in
+# mlir/_mlir_libs. Pyodide >= 0.28 loads side modules with emscripten_dlopen
+# (pyodide/pyodide#5610), which resolves a dylink.0 NEEDED entry against
+# RUNTIME_PATH; the hand-rolled filesystem shim that used to find siblings by
+# name is gone. Without this every extension fails with
+#   ImportError: dynamic module does not define module export function (PyInit__mlir)
+# auditwheel-emscripten stamps the same $ORIGIN, but only onto libraries it
+# relocates into <pkg>.libs -- these are installed side by side by MLIR's own
+# CMake, so nothing stamps them and they have to be born with it.
+CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
+CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
+CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
 CMAKE_VERBOSE_MAKEFILE = "ON"
 # De-duplicate static libraries on link lines.
 #

--- a/projects/mlir-python-bindings-wasm/pyproject.toml
+++ b/projects/mlir-python-bindings-wasm/pyproject.toml
@@ -72,9 +72,15 @@ CMAKE_CXX_VISIBILITY_PRESET = "hidden"
 # auditwheel-emscripten stamps the same $ORIGIN, but only onto libraries it
 # relocates into <pkg>.libs -- these are installed side by side by MLIR's own
 # CMake, so nothing stamps them and they have to be born with it.
-CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
-CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
-CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\\\$ORIGIN"
+#
+# The escaping is load bearing and easy to get wrong: the value reaches a shell,
+# so a bare $ORIGIN expands to empty and $$ORIGIN expands to a pid. What ends up
+# in the dylink.0 RUNTIME_PATH is only visible after a build -- check it with
+# auditwheel_emscripten.module.parse_dylink_section, which should report
+# runtime_paths=['$ORIGIN'] rather than [''] or ['\'].
+CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\$ORIGIN"
+CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\$ORIGIN"
+CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT -Wl,-rpath,\\$ORIGIN"
 CMAKE_VERBOSE_MAKEFILE = "ON"
 # De-duplicate static libraries on link lines.
 #

--- a/scripts/llvm_wasm/Dockerfile
+++ b/scripts/llvm_wasm/Dockerfile
@@ -1,10 +1,14 @@
-FROM ubuntu
+# Pinned rather than `ubuntu`: the venv below must be the same python major.minor
+# as the cross-build environment (pyodide-build refuses a mismatch), so the base
+# image's default interpreter is load bearing. 25.10 ships python 3.13, which is
+# what pyodide 0.29.4 wants.
+FROM ubuntu:25.10
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install python-is-python3 cmake ninja-build python3.12-venv python3-pip vim git unzip
+RUN apt-get update && apt-get -y install python-is-python3 cmake ninja-build python3.13-venv python3-pip vim git unzip
 
-RUN python -m venv venv
+RUN python3.13 -m venv venv
 RUN /venv/bin/python -m pip install pip-tools "pyodide-build>=0.28.0"
 RUN echo 'source "/venv/bin/activate"' >> $HOME/.bashrc
 
@@ -12,8 +16,8 @@ RUN echo 'source "/venv/bin/activate"' >> $HOME/.bashrc
 # and everything built against it must use. Unpinned, pyodide-build takes the
 # latest compatible one, which drifts ahead of the Pyodide that actually runs the
 # result. Keep in sync with .github/actions/setup_base/action.yml, and note the
-# venv above must be python 3.12 for a 3.12 cross-build env to install at all.
-ARG PYODIDE_VERSION=0.27.7
+# venv above must be python 3.13 for a 3.13 cross-build env to install at all.
+ARG PYODIDE_VERSION=0.29.4
 RUN /venv/bin/pyodide xbuildenv install "$PYODIDE_VERSION" && \
     echo "pyodide $PYODIDE_VERSION -> python $(/venv/bin/pyodide config get python_version)"
 

--- a/scripts/llvm_wasm/pyproject.toml
+++ b/scripts/llvm_wasm/pyproject.toml
@@ -47,10 +47,15 @@ cmake.args = ["-C", "llvm_wasm_cache.cmake"]
 CMAKE_BUILD_TYPE = { env = "CMAKE_BUILD_TYPE", default = "Release" }
 CMAKE_C_COMPILER_LAUNCHER = { env = "CMAKE_C_COMPILER_LAUNCHER", default = "" }
 CMAKE_CXX_COMPILER_LAUNCHER = { env = "CMAKE_CXX_COMPILER_LAUNCHER", default = "" }
-CMAKE_CXX_FLAGS = "-sNO_DISABLE_EXCEPTION_CATCHING"
-CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT"
-CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT"
-CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sNO_DISABLE_EXCEPTION_CATCHING -sWASM_BIGINT"
+# No -sNO_DISABLE_EXCEPTION_CATCHING here: pyodide-build injects -fwasm-exceptions,
+# and em++ >= 4.0.9 rejects the pair outright with
+#   "DISABLE_EXCEPTION_CATCHING=0 is not compatible with -fwasm-exceptions".
+# That surfaces confusingly as LLVM's CheckCompilerVersion probe failing to
+# compile, which CMake then reports as "libstdc++ version must be at least 7.4".
+# -fwasm-exceptions supersedes it, so LLVM_ENABLE_EH below still works.
+CMAKE_EXE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
+CMAKE_SHARED_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
+CMAKE_MODULE_LINKER_FLAGS = "-sALLOW_TABLE_GROWTH -sASSERTIONS -sWASM_BIGINT"
 CMAKE_VERBOSE_MAKEFILE = "ON"
 
 LLVM_ENABLE_EH = "ON"


### PR DESCRIPTION
Fixes the abort in #502 at its actual cause.

## Why

Pyodide 0.27's loader keys loaded libraries by path but resolves `dylink.0` dependencies by
basename. `get_dynlibs` returns a wheel's `.so` paths in **zip namelist order**, unsorted, which
puts `libMLIRPythonWasmCAPI.so` at entry 24 of 25 — behind all 21 extensions that name it by bare
basename. The first extension loads the aggregate under the basename key; when the loop reaches the
aggregate's own entry it passes an absolute path, misses, and instantiates it a **second time**.
0.27.7's `loadDynlib` aliases path → basename *after* loading and never checks basename → path
*before*, so the guard is one-directional.

Confirmed in the console on the deployed site — two keys, two different DSOs, two different export
tables:

```js
const L = pyodide._module.LDSO.loadedLibsByName;
const a = L["libMLIRPythonWasmCAPI.so"];
const b = L["/lib/python3.12/site-packages/mlir/_mlir_libs/libMLIRPythonWasmCAPI.so"];
console.log(a === b, a.exports === b.exports);   // false false
```

So the 70 MB aggregate is fetched, compiled, and instantiated twice on every page load, and LLVM's
`cl::opt` constructors run twice:

```
CommandLine Error: Option 'dump-thin-cg-sccs' registered more than once!
```

Fixed upstream by **pyodide/pyodide#5610**, which drops the path/basename bookkeeping in favour of
`emscripten_dlopen`; present from 0.28.0.