### PR TITLE
[ci] Build eudsl-python-extras with the build deps --no-index hid

### DIFF
--- a/.github/workflows/deploy_pip_page.yml
+++ b/.github/workflows/deploy_pip_page.yml
@@ -80,18 +80,43 @@ jobs:
           # That is compatible with every platform, so pip picks it, the tag check
           # below waves it through as a pure-Python wheel, and the deploy ships a
           # placeholder in place of the 23MB wasm wheel.
+          #
+          # The flip side of --no-index is that "the wheel for this Pyodide has not
+          # been published yet" comes out of pip as a resolution error naming neither
+          # the tag nor the index. That is what every Pyodide bump looks like until
+          # build_mlir_python_bindings_wheel.yml lands its wasm wheel, so say so.
+          wheel_tag="$PYODIDE_PY_TAG-$PYODIDE_PY_TAG-$PYODIDE_PLATFORM_TAG"
+          if ! grep -q -- "-$wheel_tag.whl" page/index.html; then
+            echo "::error::no mlir-python-bindings wheel tagged $wheel_tag in the" \
+                 "releases pip index. The wasm wheel for Pyodide $PYODIDE_VERSION is" \
+                 "not published yet -- wait for build_mlir_python_bindings_wheel.yml" \
+                 "to finish on main and re-run this job."
+            exit 1
+          fi
+
           pip download mlir-python-bindings --plat "$PYODIDE_PLATFORM_TAG" --no-deps \
             --python-version "${PYODIDE_PY_TAG#cp}" --no-index -f page/index.html
 
           # Belt and braces: the wheel that lands must be the wasm one.
           ls mlir_python_bindings-*-"$PYODIDE_PLATFORM_TAG".whl
 
+      # The eudsl-python-extras release only ever carries an sdist, so this step has
+      # to build one -- and pip hands its index options to the isolated build env too,
+      # where --no-index means setuptools resolves to nothing and the build dies before
+      # it starts. Installing the build deps up front and dropping isolation leaves
+      # --no-index constraining only which eudsl-python-extras gets picked, which is
+      # the part that matters: PyPI carries a name-reservation sdist under this name.
+      # Keep in sync with build-system.requires in
+      # projects/eudsl-python-extras/pyproject.toml.
       - name: Get eudsl-python-extras
         shell: bash
         run: |
           set -euxo pipefail
 
-          pip wheel eudsl-python-extras --no-index -f page/index.html --no-deps -w .
+          pip install "setuptools>=64.0.0" wheel
+
+          pip wheel eudsl-python-extras --no-index -f page/index.html --no-deps \
+            --no-build-isolation -w .
 
       - name: Create WASM console page
         shell: bash


### PR DESCRIPTION
The Pages deploy has been red on `main` since #508 ([`30776674404`](https://github.com/llvm/eudsl/actions/runs/30776674404), [`30779251133`](https://github.com/llvm/eudsl/actions/runs/30779251133), [`30779495320`](https://github.com/llvm/eudsl/actions/runs/30779495320), [`30782655576`](https://github.com/llvm/eudsl/actions/runs/30782655576)). Two separate causes, in sequence.

## `Download latest WASM wheel` — resolved itself, but silently

#508 pinned Pyodide 0.29.4, whose wheels are tagged `cp313-cp313-pyemscripten_2025_0_wasm32`. The wasm build had not published one under that tag yet; every wheel in the releases index was still `cp312-cp312-pyemscripten_2024_0_wasm32`, so `pip download --plat ... --no-index` matched nothing.

That cleared itself once `mlir_python_bindings-20260803+2450b7e17-cp313-cp313-pyemscripten_2025_0_wasm32.whl` landed, and the step passes as written. What did not clear is the diagnostic: under `--no-index` the failure reads

```
ERROR: Could not find a version that satisfies the requirement mlir-python-bindings (from versions: none)
```

naming neither the tag it wanted nor the index it searched. Every future Pyodide bump reproduces this for however long the wasm build takes. So this PR checks the index for the pinned tag first and says what is missing:

```
::error::no mlir-python-bindings wheel tagged cp314-cp314-pyemscripten_2026_0_wasm32 in the
releases pip index. The wasm wheel for Pyodide 0.30.0 is not published yet -- wait for
build_mlir_python_bindings_wheel.yml to finish on main and re-run this job.
```

## `Get eudsl-python-extras` — the current blocker

```
pip wheel eudsl-python-extras --no-index -f page/index.html --no-deps -w .

  Downloading eudsl_python_extras-0.1.0.20260803.301+21ed31a.tar.gz (127 kB)
  Installing build dependencies: finished with status 'error'
      ERROR: Could not find a version that satisfies the requirement setuptools>=64.0.0 (from versions: none)
```

The release only ever carries an sdist, so this step has to build it, and pip passes its index options down into the isolated build env — where `--no-index` leaves `build-system.requires` (`setuptools>=64.0.0`, `wheel`, `pip`) resolving against a links file that contains none of them. The build dies before it starts.

It worked before #508 only because the step had no `--no-index` at all, which is also how that same run shipped the 6kB PyPI placeholder in place of the 21MB wasm wheel — the thing #508's tag checks were added to catch.

`--no-index` is worth keeping here, because PyPI carries a name-reservation sdist under this name too (`eudsl-python-extras 0.1.0`). So: install the build deps up front, drop isolation, and leave `--no-index` constraining the one thing it should — which `eudsl-python-extras` gets picked.