### PR TITLE
[eudsl-llvmpy] Coverage job: get LLVM distro from the in-run artifact

### DIFF
--- a/.github/workflows/build_test_release_eudsl.yml
+++ b/.github/workflows/build_test_release_eudsl.yml
@@ -405,7 +405,7 @@ jobs:
 
   coverage-eudsl-llvmpy:
 
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' || inputs.workflow_call }}
 
     needs: [build-eudsl]
 
@@ -449,10 +449,23 @@ jobs:
           name: eudsl_macos_arm64_artifact
           path: wheelhouse
 
-      - name: "Fetch LLVM distro (ships llvm-cov/llvm-profdata)"
+      - name: "Pip download MLIR from releases"
+        if: ${{ !inputs.workflow_call }}
         run: |
 
           pip download mlir-wheel -f https://github.com/llvm/eudsl/releases/expanded_assets/llvm
+
+      - name: "Download LLVM distro artifact"
+        if: ${{ inputs.workflow_call }}
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          name: mlir_wheel_manylinux_x86_64_artifact
+          path: "./"
+          run_id: ${{ inputs.workflow_caller_run_id }}
+
+      - name: "Unpack LLVM distro (ships llvm-cov/llvm-profdata)"
+        run: |
+
           unzip -q mlir_wheel*.whl
           mv mlir_wheel llvm-install
 


### PR DESCRIPTION
Lets the C++ coverage CI job get its LLVM distro from the in-run build artifact when the workflow runs via `workflow_call`, falling back to the published release distro otherwise. Mirrors how `build_mlir_python_bindings_wheel.yml` sources its distro.
