### PR TITLE
[eudsl-llvmpy] DSL: module globals, README, and coverage

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -170,9 +170,8 @@ class MyInt(llvm.Value):
 - **The fatal-error path is best-effort.** LLVM's fatal error handler cannot
   return, so where a bad argument would trip it, the bindings validate up front
   and raise. A genuine LLVM fatal error still aborts the process after a warning.
-- **No raw C-API escape hatch.** The `llvm-c` surface and `from_capsule` are
-  not exposed. If something isn't bound, it isn't reachable from Python; the fix
-  is to bind it.
+- **No raw C-API escape hatch.** The `llvm-c` surface is not exposed. If
+  something isn't bound, it isn't reachable from Python; the fix is to bind it.
 - **Scope of the binding.** `llvm/IR` is not bound exhaustively. The rule is:
   what the DSL needs, what `llvmlite.binding` exposes, and everything reachable
   by traversal from a `Module`. Out of scope for now: DIBuilder/DebugInfo,

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -1,0 +1,218 @@
+<!--
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+# eudsl-llvmpy
+
+Python bindings for LLVM IR, plus a small DSL for authoring IR from Python. Both
+ship in the top-level `llvm` package.
+
+There are two layers. The lower one is a hand-written [nanobind](https://github.com/wjakob/nanobind)
+wrapper over the LLVM **C++** API, so the Python class hierarchy mirrors
+`llvm::` (a `Value` really is the base of `Instruction`, `Constant`, and the
+rest). The upper one is a DSL: decorate a Python function, write ordinary
+arithmetic and `if`/`while`/`for`, and get back a compiled `llvm::Function`
+whose control flow is lowered to basic blocks and phi nodes.
+
+The DSL sits on top of the bindings. You can use the bindings alone.
+
+## Object layer
+
+Comparable in reach to `llvmlite`, with its own API rather than a compatible
+shim. Bound surface:
+
+- **Context and Module** with real ownership. A `Context` is a context manager;
+  leaving the block frees the underlying `LLVMContext`, and touching anything
+  that outlived it raises instead of segfaulting. `Context._get_live_count()`
+  reports live objects for leak checks.
+- **The `Type` hierarchy**: integers, floats, pointers, structs (named and
+  literal), arrays, vectors, functions. Values downcast to their concrete
+  Python class automatically.
+- **The `Value` hierarchy** down to the instruction classes worth traversing:
+  `PHINode`, `CallInst`, `GetElementPtrInst`, `AllocaInst`, `LoadInst`,
+  `StoreInst`, and the branch and compare instructions. `Argument`,
+  `BasicBlock`, `Function`, `GlobalVariable`, and the `Constant` subclasses are
+  all here too.
+- **`IRBuilder`** with a `with builder.at_end_of(block):` insertion-point
+  context manager.
+- **Attributes, linkage, visibility, calling convention.**
+- **Metadata**: `MDString`, `MDNode`, named module metadata.
+- **Errors as exceptions.** A bad parse raises `ParseError`, a failed
+  `verify()` raises `VerifyError`, and any `llvm::Expected`/`llvm::Error`
+  failure raises `RuntimeError` carrying the LLVM message.
+- **Verify, and bitcode read/write.**
+- **Optimization** through `llvm.run_passes(module, "instcombine,gvn")`, which
+  runs a new-pass-manager pipeline parsed from the string and raises on an
+  unknown pass.
+- **`Target`, `TargetMachine`, `DataLayout`**, with assembly and object
+  emission.
+- **Module linking** through `llvm.link_into(dest, src)`, which raises on
+  conflicting symbols.
+- **ORC `LLJIT`**: add a module, look up a symbol, get an address you can call
+  through `ctypes`.
+- **Intrinsics** by name. Import `llvm.intrinsics`, then
+  `llvm.intrinsics.sqrt(module, [f64])` resolves the intrinsic ID, uses the
+  given overload types, and inserts the declaration, all against LLVM's own
+  tables. The primitives `lookup_intrinsic_id`, `intrinsic_is_overloaded`, and
+  `get_intrinsic_declaration` are there too.
+
+Because `llvm::Value` and `llvm::Type` have no vtables, nanobind's RTTI-based
+downcasting can't apply. The bindings use `nanobind::detail::type_hook` keyed on
+`Value.def`/`Instruction.def` and `Type::TypeID` to pick the right Python class
+for a returned pointer.
+
+```python
+import llvm
+
+with llvm.Context() as ctx:
+    mod = llvm.parse_assembly(
+        "define i32 @f(i32 %x) {\n"
+        "entry:\n"
+        "  %s = add i32 %x, 1\n"
+        "  ret i32 %s\n"
+        "}\n",
+        ctx, "m",
+    )
+    mod.verify()
+    add = mod.get_function("f").basic_blocks[0].instructions[0]
+    print(type(add).__name__)  # BinaryOperator
+```
+
+## DSL layer
+
+Decorate a function with `@llvm.function`. Type annotations are LLVM types.
+Arithmetic and comparison operators emit the matching instruction, dispatched on
+the operand type: `+` becomes `add` for integers and `fadd` for floats, `<`
+becomes `icmp slt` or `fcmp olt`. A Python `int` or `float` operand coerces to a
+constant of the other side's type. This matches `ArithValue` in
+`eudsl-python-extras` so moving between the MLIR DSL and this one costs nothing.
+
+```python
+import ctypes
+import llvm
+from llvm.dsl.cf import range_
+
+ctx = llvm.Context()
+mod = llvm.Module("m", ctx)
+i32 = llvm.i32(ctx)
+
+@llvm.function(module=mod)
+def inc(x: i32) -> i32:
+    return x + 1
+
+@llvm.function(module=mod)
+def total(n: i32) -> i32:
+    acc = llvm.const_int(i32, 0)
+    for i in range_(0, n):
+        acc = acc + i
+        yield acc          # loop-carried value -> phi at the header
+    return acc
+
+jit = llvm.LLJIT()
+jit.add_module(mod)
+f = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
+assert f(5) == 0 + 1 + 2 + 3 + 4
+```
+
+Control flow uses a `yield` protocol borrowed from `eudsl-python-extras`' `scf`
+dialect. An AST canonicalizer rewrites `if`/`elif`/`else`/`while`/`for` into
+basic blocks, and any value you `yield` out of a region becomes a phi node at
+the join or loop header. `if` produces a branch and a join-block phi. `while`
+and `for` produce a header/body/exit structure with loop-carried phis for
+whatever the body yields. `for i in range_(lo, hi, step)` gives you an induction
+variable.
+
+`@llvm.function` also covers declarations (an empty `...` body), definitions,
+calls between decorated functions (via `__call__`), multiple return values,
+function attributes, linkage, calling convention, and varargs.
+
+```python
+@llvm.function(module=mod)
+def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+    if c:
+        r = yield a + 1
+    else:
+        r = yield b
+    return r
+```
+
+### Custom value casters
+
+Like MLIR's `register_value_caster`, you can register a Python subclass to wrap
+values of a given type kind. The DSL uses this to make integer and float values
+come back as `ArithValue` (the class carrying the operator overloads). The
+registry lives in Python (`llvm.dsl.casters`), so nothing holds Python
+references at interpreter shutdown; C++ exposes only a stateless
+`_wrap_value_as` primitive.
+
+```python
+from llvm.dsl.casters import register_value_caster
+from llvm.eudslllvm_ext import TypeID
+
+@register_value_caster(TypeID.Integer)
+class MyInt(llvm.Value):
+    ...
+```
+
+## Limitations
+
+- **`break`, `continue`, and early `return` inside DSL control flow are not
+  supported.** The loop transforms lift a body into a nested function that the
+  `if`/`else` transformer does not revisit, so a bare `break` or `return` there
+  would emit wrong IR silently. The transformer detects these and raises
+  `NotImplementedError` with a message rather than miscompiling.
+- **Control flow nested inside a loop body is rejected** for the same reason.
+  An `if` at the top level of a function works; an `if` inside a `while` or
+  `for` body raises `NotImplementedError`. This is the piece most worth
+  revisiting.
+- **The fatal-error path is best-effort.** LLVM's fatal error handler cannot
+  return, so where a bad argument would trip it, the bindings validate up front
+  and raise. A genuine LLVM fatal error still aborts the process after a warning.
+- **No raw C-API escape hatch.** The `llvm-c` surface and `from_capsule` are
+  not exposed. If something isn't bound, it isn't reachable from Python; the fix
+  is to bind it.
+- **Scope of the binding.** `llvm/IR` is not bound exhaustively. The rule is:
+  what the DSL needs, what `llvmlite.binding` exposes, and everything reachable
+  by traversal from a `Module`. Out of scope for now: DIBuilder/DebugInfo,
+  remarks, the disassembler, object-file inspection, and ORC customization
+  points that need Python callbacks.
+- **Targets.** The build links host targets only by default (AArch64 and X86).
+  AMDGPU and NVPTX stay reachable through the `EUDSL_LLVMPY_TARGETS` CMake
+  option. Emitting AMDGCN assembly never needed an AMD device; only running it
+  did.
+
+## Build
+
+Needs an LLVM install (headers and libraries) and a C++ compiler. Point
+`CMAKE_PREFIX_PATH` at the install, then:
+
+```bash
+pip install -e . --no-build-isolation
+```
+
+CMake options, passed through `--config-settings=cmake.define.<NAME>=<VALUE>`:
+
+- `EUDSL_LLVMPY_TARGETS` (default `AArch64;X86`) selects which LLVM target
+  backends to link and initialize.
+- `EUDSL_LLVMPY_ENABLE_COVERAGE` (default `OFF`) instruments the extension for
+  `llvm-cov`.
+
+## Tests and coverage
+
+```bash
+pytest tests
+```
+
+Python coverage is gated in `pyproject.toml` (`--cov=llvm`, branch coverage,
+fail under 99%). C++ coverage runs through `scripts/cpp_coverage.sh`, which
+builds the extension instrumented, runs the suite under `LLVM_PROFILE_FILE`,
+merges the profile, and enforces a `src/IR` line-coverage threshold with
+`scripts/check_coverage.py`:
+
+```bash
+COVERAGE_THRESHOLD=100 bash scripts/cpp_coverage.sh
+```
+
+Both gates run in CI.

--- a/projects/eudsl-llvmpy/src/IR/Attributes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Attributes.cpp
@@ -8,9 +8,9 @@
 
 void populate_attributes(nb::module_ &m) {
   nb::enum_<llvm::GlobalValue::VisibilityTypes>(m, "Visibility")
-      .value("DEFAULT", llvm::GlobalValue::DefaultVisibility)
-      .value("HIDDEN", llvm::GlobalValue::HiddenVisibility)
-      .value("PROTECTED", llvm::GlobalValue::ProtectedVisibility);
+      .value("DEFAULT", llvm::GlobalValue::VisibilityTypes::DefaultVisibility)
+      .value("HIDDEN", llvm::GlobalValue::VisibilityTypes::HiddenVisibility)
+      .value("PROTECTED", llvm::GlobalValue::VisibilityTypes::ProtectedVisibility);
 
   nb::enum_<CallingConvEnum>(m, "CallingConv")
       .value("C", CallingConvEnum::C)

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -79,13 +79,6 @@ void populate_context(nb::module_ &m) {
             return self.get().getFunction(name);
           },
           "name"_a, nb::rv_policy::reference)
-      .def_prop_ro("globals",
-                   [](eudsl::Module &self) {
-                     std::vector<llvm::GlobalVariable *> out;
-                     for (llvm::GlobalVariable &g : self.get().globals())
-                       out.push_back(&g);
-                     return out;
-                   })
       .def(
           "get_global_variable",
           [](eudsl::Module &self, const std::string &name) {

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -23,6 +23,28 @@
 #include <nanobind/stl/vector.h>
 
 void populate_context(nb::module_ &m) {
+  // GlobalValue linkage kinds (llvm::GlobalValue::LinkageTypes) and thread-local
+  // modes. Registered here, ahead of every other populate_* call, so factories
+  // such as Module.add_global and Function.create can take these as arguments
+  // (rather than hardcoding one choice) with enum defaults.
+  nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
+      .value("EXTERNAL", llvm::GlobalValue::LinkageTypes::ExternalLinkage)
+      .value("INTERNAL", llvm::GlobalValue::LinkageTypes::InternalLinkage)
+      .value("PRIVATE", llvm::GlobalValue::LinkageTypes::PrivateLinkage)
+      .value("LINKONCE", llvm::GlobalValue::LinkageTypes::LinkOnceAnyLinkage)
+      .value("LINKONCE_ODR", llvm::GlobalValue::LinkageTypes::LinkOnceODRLinkage)
+      .value("WEAK", llvm::GlobalValue::LinkageTypes::WeakAnyLinkage)
+      .value("COMMON", llvm::GlobalValue::LinkageTypes::CommonLinkage)
+      .value("APPENDING", llvm::GlobalValue::LinkageTypes::AppendingLinkage)
+      .value("EXTERNAL_WEAK", llvm::GlobalValue::LinkageTypes::ExternalWeakLinkage);
+
+  nb::enum_<llvm::GlobalValue::ThreadLocalMode>(m, "ThreadLocalMode")
+      .value("NOT_THREAD_LOCAL", llvm::GlobalValue::ThreadLocalMode::NotThreadLocal)
+      .value("GENERAL_DYNAMIC", llvm::GlobalValue::ThreadLocalMode::GeneralDynamicTLSModel)
+      .value("LOCAL_DYNAMIC", llvm::GlobalValue::ThreadLocalMode::LocalDynamicTLSModel)
+      .value("INITIAL_EXEC", llvm::GlobalValue::ThreadLocalMode::InitialExecTLSModel)
+      .value("LOCAL_EXEC", llvm::GlobalValue::ThreadLocalMode::LocalExecTLSModel);
+
   nb::class_<eudsl::Context>(m, "Context")
       .def(nb::init<>())
       .def(
@@ -132,13 +154,18 @@ void populate_context(nb::module_ &m) {
           "add_global",
           [](eudsl::Module &self, llvm::Type *ty, const std::string &name,
              llvm::Constant *init, bool isConstant,
+             llvm::GlobalVariable* insertBefore,
+             llvm::GlobalValue::LinkageTypes linkage,
+             llvm::GlobalValue::ThreadLocalMode tlMode,
              unsigned addressSpace) -> llvm::GlobalVariable * {
             return new llvm::GlobalVariable(
-                self.get(), ty, isConstant,
-                llvm::GlobalValue::ExternalLinkage, init, name, nullptr,
-                llvm::GlobalValue::NotThreadLocal, addressSpace);
+                self.get(), ty, isConstant, linkage, init, name, insertBefore,
+                tlMode, addressSpace);
           },
           "type"_a, "name"_a, "init"_a = nullptr, "constant"_a = false,
+          "insert_before"_a = nullptr,
+          "linkage"_a = llvm::GlobalValue::LinkageTypes::ExternalLinkage,
+          "thread_local_mode"_a = llvm::GlobalValue::ThreadLocalMode::NotThreadLocal,
           "address_space"_a = 0, nb::rv_policy::reference_internal)
       .def(
           "get_global",

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -134,7 +134,31 @@ void populate_context(nb::module_ &m) {
           [](eudsl::Module &self, llvm::TargetMachine &tm) {
             self.get().setDataLayout(tm.createDataLayout());
           },
-          "target_machine"_a);
+          "target_machine"_a)
+      .def(
+          "add_global",
+          [](eudsl::Module &self, llvm::Type *ty, const std::string &name,
+             llvm::Constant *init, bool isConstant,
+             unsigned addressSpace) -> llvm::GlobalVariable * {
+            return new llvm::GlobalVariable(
+                self.get(), ty, isConstant,
+                llvm::GlobalValue::ExternalLinkage, init, name, nullptr,
+                llvm::GlobalValue::NotThreadLocal, addressSpace);
+          },
+          "type"_a, "name"_a, "init"_a = nullptr, "constant"_a = false,
+          "address_space"_a = 0, nb::rv_policy::reference_internal)
+      .def(
+          "get_global",
+          [](eudsl::Module &self, const std::string &name) {
+            return self.get().getNamedGlobal(name);
+          },
+          "name"_a, nb::rv_policy::reference_internal)
+      .def_prop_ro("globals", [](eudsl::Module &self) {
+        std::vector<llvm::GlobalVariable *> out;
+        for (llvm::GlobalVariable &g : self.get().globals())
+          out.push_back(&g);
+        return out;
+      });
 
   m.def(
       "parse_assembly",

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -67,19 +67,6 @@ void populate_values(nb::module_ &m) {
   nb::class_<llvm::GlobalValue, llvm::Constant>(m, "GlobalValue");
   nb::class_<llvm::GlobalObject, llvm::GlobalValue>(m, "GlobalObject");
 
-  // GlobalValue linkage kinds (llvm::GlobalValue::LinkageTypes). Bound with the
-  // GlobalValue hierarchy so Function.create and the global factories can take a
-  // linkage argument rather than hardcoding one.
-  nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
-      .value("EXTERNAL", llvm::GlobalValue::ExternalLinkage)
-      .value("INTERNAL", llvm::GlobalValue::InternalLinkage)
-      .value("PRIVATE", llvm::GlobalValue::PrivateLinkage)
-      .value("LINKONCE", llvm::GlobalValue::LinkOnceAnyLinkage)
-      .value("LINKONCE_ODR", llvm::GlobalValue::LinkOnceODRLinkage)
-      .value("WEAK", llvm::GlobalValue::WeakAnyLinkage)
-      .value("COMMON", llvm::GlobalValue::CommonLinkage)
-      .value("APPENDING", llvm::GlobalValue::AppendingLinkage)
-      .value("EXTERNAL_WEAK", llvm::GlobalValue::ExternalWeakLinkage);
   nb::class_<llvm::Instruction, llvm::User>(m, "Instruction")
       .def_prop_ro("num_successors",
                    [](llvm::Instruction &self) {
@@ -132,7 +119,7 @@ void populate_values(nb::module_ &m) {
             return llvm::Function::Create(ft, linkage, name, mod.get());
           },
           "function_type"_a, "name"_a, "module"_a,
-          "linkage"_a = llvm::GlobalValue::ExternalLinkage,
+          "linkage"_a = llvm::GlobalValue::LinkageTypes::ExternalLinkage,
           nb::rv_policy::reference, nb::keep_alive<0, 3>())
       .def_prop_ro("function_type", &llvm::Function::getFunctionType,
                    nb::rv_policy::reference_internal)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -70,10 +70,11 @@ class _IfOp:
         self.active = "then"
 
     def _terminate_current(self):
+        # A branch body never self-terminates (its trailing yield_ is what calls
+        # this), so the current block always needs the branch to merge.
         b = self.builder
         pred = b.insert_block
-        if b.insert_block.terminator is None:
-            b.br(self.merge_block)
+        b.br(self.merge_block)
         return pred
 
     def record_and_maybe_phi(self, values):
@@ -147,8 +148,9 @@ def else_ctx_manager(op):
 
 
 def yield_(*values):
-    if not _if_stack:
-        return values[0] if len(values) == 1 else values
+    # Only ever runs inside if_ctx_manager/else_ctx_manager (the if transform
+    # rewrites branch yields to yield_(); loop yields are consumed by the loop
+    # transforms), so an if-op is always on the stack.
     return _if_stack[-1].record_and_maybe_phi(values)
 
 
@@ -220,9 +222,7 @@ def while_loop(cond_fn, body_fn, inits):
     b.cond_br(cond, body_bb, exit_bb)
 
     b.set_insert_point(body_bb)
-    nexts = body_fn(*carried)
-    if not isinstance(nexts, tuple):
-        nexts = (nexts,)
+    nexts = body_fn(*carried)  # body_fn returns a tuple of next carried values
     body_end = b.insert_block  # nested control flow may have moved us
     b.br(header)
     for phi, nxt in zip(raw_phis, nexts):
@@ -265,11 +265,9 @@ def for_loop(start, stop, step, body_fn, inits):
         return iv > stop_v if step_negative else iv < stop_v
 
     def body(iv, *carried):
+        # body_fn is the lifted loop body; it returns a tuple of next carried
+        # values (empty for a side-effecting loop with a bare yield).
         nxt = body_fn(iv, *carried)
-        if nxt is None:
-            nxt = ()
-        elif not isinstance(nxt, tuple):
-            nxt = (nxt,)
         return (iv + step, *nxt)
 
     res = while_loop(cond, body, (start_v, *inits))

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -90,7 +90,9 @@ def function(
             result = f(*args)
             if result is not None:
                 builder.ret(result)
-            elif builder.insert_block.terminator is None:
+            else:
+                # No DSL `return`: the current block (entry, or a loop/if exit)
+                # is never already terminated here, so close it with `ret void`.
                 builder.ret(None)
         return DSLFunction(fn)
 

--- a/projects/eudsl-llvmpy/src/llvm/dsl/values.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/values.py
@@ -28,15 +28,17 @@ class ArithValue(Value):
     """A Value that supports arithmetic and comparison operators."""
 
     def _coerce(self, other):
-        """Turn a Python int/float into a constant matching this value's type."""
+        """Turn a Python int/float into a constant matching this value's type.
+
+        ArithValue is only registered for integer and floating-point type kinds,
+        so one of the two branches below always applies.
+        """
         if isinstance(other, Value):
             return other
         ty = self.type
         if ty.is_floating_point:
             return const_fp(ty, float(other))
-        if ty.is_integer:
-            return const_int(ty, int(other), signed=True)
-        raise TypeError(f"cannot coerce {other!r} to {ty}")
+        return const_int(ty, int(other), signed=True)
 
     def _wrap(self, v):
         # Re-wrap builder results as ArithValue so `(a + b) + c` stays typed.

--- a/projects/eudsl-llvmpy/tests/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/test_ast.py
@@ -2,7 +2,9 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ast
+import sys
 
+from llvm.ast import canonicalize, util
 from llvm.ast import cf_transformers as T
 
 
@@ -88,8 +90,6 @@ def test_nested_if_in_body_forwards_tuple_yield():
 
 def test_canonicalize_module_imports_clean():
     # The vendored canonicalize/util import with no MLIR deps.
-    import sys
-    from llvm.ast import canonicalize, util  # noqa: F401
     assert hasattr(canonicalize, "canonicalize")
     assert hasattr(util, "get_module_cst")
     assert not any(

--- a/projects/eudsl-llvmpy/tests/test_ast_canonicalize.py
+++ b/projects/eudsl-llvmpy/tests/test_ast_canonicalize.py
@@ -3,7 +3,13 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ast
 
-from llvm.ast.canonicalize import canonicalize, StrictTransformer, find_func_in_code_object
+from llvm.ast.canonicalize import (
+    canonicalize,
+    Canonicalizer,
+    FunctionPatcher,
+    StrictTransformer,
+    find_func_in_code_object,
+)
 from llvm.dsl.cf import LLVMCanonicalizer
 
 

--- a/projects/eudsl-llvmpy/tests/test_ast_canonicalize.py
+++ b/projects/eudsl-llvmpy/tests/test_ast_canonicalize.py
@@ -3,28 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ast
 
-from llvm.ast.canonicalize import (
-    canonicalize,
-    Canonicalizer,
-    FunctionPatcher,
-    StrictTransformer,
-    find_func_in_code_object,
-)
-
-
-class _NoOpPatcher(FunctionPatcher):
-    def patch_function(self, original_f):
-        return original_f
-
-
-class _NoOpCanonicalizer(Canonicalizer):
-    @property
-    def cst_transformers(self):
-        return [StrictTransformer]
-
-    @property
-    def function_patchers(self):
-        return [_NoOpPatcher]
+from llvm.ast.canonicalize import canonicalize, StrictTransformer, find_func_in_code_object
+from llvm.dsl.cf import LLVMCanonicalizer
 
 
 def test_canonicalize_accepts_a_sequence_of_canonicalizers():
@@ -33,7 +13,7 @@ def test_canonicalize_accepts_a_sequence_of_canonicalizers():
     def f(x):
         return x
 
-    g = canonicalize(using=[_NoOpCanonicalizer()])(f)
+    g = canonicalize(using=[LLVMCanonicalizer()])(f)
     assert g(5) == 5
 
 
@@ -47,7 +27,7 @@ def test_canonicalize_accepts_a_single_canonicalizer_and_skips_nested_defs():
 
         return helper(x)
 
-    g = canonicalize(using=_NoOpCanonicalizer())(f)
+    g = canonicalize(using=LLVMCanonicalizer())(f)
     assert g(3) == 6
 
 
@@ -62,7 +42,7 @@ def test_transform_ast_handles_closures():
 
     inner = outer()
     assert inner.__closure__ is not None
-    g = canonicalize(using=_NoOpCanonicalizer())(inner)
+    g = canonicalize(using=LLVMCanonicalizer())(inner)
     assert g(1) == 43
 
 

--- a/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
@@ -257,3 +257,35 @@ def test_value_name_setter_and_instruction_props():
         assert "%renamed = add" in str(mod)
         del f, entry, add, ret, mod
     assert_no_leaks()
+
+
+def test_instruction_set_successor():
+    # set_successor is used by the DSL elif lowering (dsl/cf.py) and validated
+    # indirectly by the elif JIT tests; assert it directly here too.
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                define void @f(i1 %cond) {
+                entry:
+                  br i1 %cond, label %a, label %b
+                a:
+                  ret void
+                b:
+                  ret void
+                c:
+                  ret void
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        br = f.entry_block.terminator
+        c_block = next(b for b in f.basic_blocks if b.name == "c")
+        br.set_successor(0, c_block)  # redirect the true edge from a to c
+        assert br.successor(0).name == "c"
+        assert "br i1 %cond, label %c, label %b" in str(mod)
+        del f, br, c_block, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -198,13 +198,6 @@ def test_if_else_multiple_results():
     assert_no_leaks()
 
 
-def test_yield_outside_if_stack_returns_directly():
-    from llvm.dsl.cf import yield_
-
-    assert yield_(5) == 5
-    assert yield_(1, 2) == (1, 2)
-
-
 def test_while_single_carried_value():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
@@ -458,76 +451,6 @@ def test_range_marker_is_callable_directly():
     assert range_(5) == (0, 5, 1)
     assert range_(2, 5) == (2, 5, 1)
     assert range_(2, 5, 3) == (2, 5, 3)
-
-
-def test_while_loop_wraps_non_tuple_body_result():
-    # Direct call to the runtime primitive (bypassing the AST transform, which
-    # always returns a real tuple) to exercise the non-tuple wrap branch.
-    from llvm.dsl.cf import while_loop
-    from llvm.dsl.context import building
-
-    with llvm.Context() as ctx:
-        mod = llvm.Module("m", ctx)
-        i32 = llvm.types.i32(ctx)
-        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
-        bb = fn.append_basic_block("entry")
-        b = llvm.IRBuilder(ctx)
-        with b.at_end_of(bb), building(b, fn):
-            n = fn.arg(0)
-
-            def cond(i):
-                return i.ne(n)
-
-            def body(i):
-                return i + 1  # bare Value, not a tuple
-
-            (result,) = while_loop(cond, body, (llvm.const_int(i32, 0),))
-            b.ret(result)
-
-        jit = llvm.LLJIT()
-        jit.add_module(mod)
-        fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
-        assert fn_ptr(5) == 5
-        del jit, mod, fn, fn_ptr
-    assert_no_leaks()
-
-
-def test_for_loop_wraps_none_and_non_tuple_body_result():
-    # Direct calls to the runtime primitive to exercise the None- and
-    # non-tuple-result wrap branches that the AST transform never produces
-    # (its generated body always returns a real tuple).
-    from llvm.dsl.cf import for_loop
-    from llvm.dsl.context import building
-
-    with llvm.Context() as ctx:
-        mod = llvm.Module("m", ctx)
-        i32 = llvm.types.i32(ctx)
-        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
-        bb = fn.append_basic_block("entry")
-        b = llvm.IRBuilder(ctx)
-        with b.at_end_of(bb), building(b, fn):
-            n = fn.arg(0)
-
-            def body_none(i):
-                return None  # no carried values
-
-            for_loop(llvm.const_int(i32, 0), n, llvm.const_int(i32, 1), body_none, ())
-
-            def body_bare(i, acc):
-                return acc + i  # bare non-tuple, one carried value
-
-            (result,) = for_loop(
-                llvm.const_int(i32, 0), n, llvm.const_int(i32, 1), body_bare,
-                (llvm.const_int(i32, 0),),
-            )
-            b.ret(result)
-
-        jit = llvm.LLJIT()
-        jit.add_module(mod)
-        fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
-        assert fn_ptr(5) == 0 + 1 + 2 + 3 + 4
-        del jit, mod, fn, fn_ptr
-    assert_no_leaks()
 
 
 def test_for_negative_step_countdown_jits():

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
@@ -7,6 +7,8 @@ import ctypes
 import pytest
 
 import llvm
+from llvm.ast.canonicalize import canonicalize, Canonicalizer, FunctionPatcher
+from llvm.dsl.cf import LLVMCanonicalizer
 from llvm.dsl.cf import range_
 from llvm.dsl.values import with_element_type
 from llvm.testing import assert_no_leaks
@@ -18,6 +20,7 @@ def test_range_single_arg():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def total(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(n):  # single-arg range_: start defaults to 0
@@ -40,6 +43,7 @@ def test_for_side_effect_bare_yield():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def fill(p: llvm.types.ptr, n: i32) -> i32:
         tp = with_element_type(p, i32)
         for i in range_(0, n):
@@ -60,6 +64,7 @@ def test_range_too_many_args_raises():
         with pytest.raises(NotImplementedError, match="range_ takes 1-3"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n, 1, 2):
@@ -77,6 +82,7 @@ def test_for_non_name_target_raises():
         with pytest.raises(NotImplementedError, match="single name"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for (i, j) in range_(0, n):
@@ -94,6 +100,7 @@ def test_for_body_without_trailing_yield_raises():
         with pytest.raises(NotImplementedError, match="must end with"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -110,6 +117,7 @@ def test_while_body_without_trailing_yield_raises():
         with pytest.raises(NotImplementedError, match="must end with"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 i = llvm.const_int(i32, 0)
                 while i.ne(n):
@@ -126,6 +134,7 @@ def test_loop_yield_non_name_raises():
         with pytest.raises(NotImplementedError, match="loop-carried variable names"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -142,6 +151,7 @@ def test_elif_multiple_carried_results():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def pick2(x: i32, a: i32, b: i32) -> i32:
         if x < 0:
             p, q = yield a, b
@@ -177,6 +187,7 @@ def test_for_over_python_list_unrolls():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sum3(a: i32, b: i32, c: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for x in [a, b, c]:
@@ -204,6 +215,7 @@ def test_nested_if_in_then_branch():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def f(c: llvm.types.i1, d: llvm.types.i1, a: i32, b: i32) -> i32:
         if c:
             if d:

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
@@ -1,0 +1,227 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Edge cases and error branches of the DSL control-flow lowering."""
+import ctypes
+
+import pytest
+
+import llvm
+from llvm.dsl.cf import range_
+from llvm.testing import assert_no_leaks
+
+
+def test_range_single_arg():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def total(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(n):  # single-arg range_: start defaults to 0
+            acc = acc + i
+            yield acc
+        return acc
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
+    assert fn(5) == 0 + 1 + 2 + 3 + 4
+    del jit, mod, ctx, total, i32, fn
+    assert_no_leaks()
+
+
+def test_for_side_effect_bare_yield():
+    # No loop-carried values: body ends with a bare `yield`; stores into a ptr.
+    from llvm.dsl.values import with_element_type
+
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def fill(p: llvm.ptr_t, n: i32) -> i32:
+        tp = with_element_type(p, i32)
+        for i in range_(0, n):
+            tp[i] = i
+            yield
+        return n
+
+    printed = str(mod)
+    assert "while.header" in printed and "store i32" in printed
+    del mod, ctx, fill, i32
+    assert_no_leaks()
+
+
+def test_range_too_many_args_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="range_ takes 1-3"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n, 1, 2):
+                    acc = acc + i
+                    yield acc
+                return acc
+
+        del mod
+
+
+def test_for_non_name_target_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="single name"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for (i, j) in range_(0, n):
+                    acc = acc + acc
+                    yield acc
+                return acc
+
+        del mod
+
+
+def test_for_body_without_trailing_yield_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="must end with"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    acc = acc + i
+                return acc
+
+        del mod
+
+
+def test_while_body_without_trailing_yield_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="must end with"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                i = llvm.const_int(i32, 0)
+                while i.ne(n):
+                    i = i + 1
+                return i
+
+        del mod
+
+
+def test_loop_yield_non_name_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="loop-carried variable names"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    acc = acc + i
+                    yield acc + i  # not a plain name
+                return acc
+
+        del mod
+
+
+def test_elif_multiple_carried_results():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def pick2(x: i32, a: i32, b: i32) -> i32:
+        if x < 0:
+            p, q = yield a, b
+        elif x.eq(llvm.const_int(i32, 0)):
+            p, q = yield b, a
+        else:
+            p, q = yield a, a
+        return p - q
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("pick2"))
+    assert fn(-1, 10, 3) == 10 - 3
+    assert fn(0, 10, 3) == 3 - 10
+    assert fn(5, 10, 3) == 10 - 10
+    del jit, mod, ctx, pick2, i32, fn
+    assert_no_leaks()
+
+
+def test_range_runtime_callable():
+    # range_ is a marker consumed by the transform, but also runtime-callable.
+    assert range_(3) == (0, 3, 1)
+    assert range_(1, 4) == (1, 4, 1)
+    assert range_(1, 10, 2) == (1, 10, 2)
+
+
+def test_for_over_python_list_unrolls():
+    # A non-range_ `for` is left as a Python loop and unrolls at trace time.
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sum3(a: i32, b: i32, c: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for x in [a, b, c]:
+            acc = acc + x
+        return acc
+
+    printed = str(mod)
+    assert "while.header" not in printed  # unrolled, no loop
+    assert printed.count("add i32") == 3
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_int32, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("sum3"))
+    assert fn(2, 3, 4) == 9
+    del jit, mod, ctx, sum3, i32, fn
+    assert_no_leaks()
+
+
+def test_nested_if_in_then_branch():
+    # A nested if in the THEN branch that yields forces the body-forward path
+    # of CanonicalizeElIfs.
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def f(c: llvm.i1, d: llvm.i1, a: i32, b: i32) -> i32:
+        if c:
+            if d:
+                r = yield a
+            else:
+                r = yield b
+        else:
+            r = yield b
+        return r
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_bool, ctypes.c_bool, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("f"))
+    assert fn(True, True, 10, 20) == 10
+    assert fn(True, False, 10, 20) == 20
+    assert fn(False, True, 10, 20) == 20
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
@@ -8,6 +8,7 @@ import pytest
 
 import llvm
 from llvm.dsl.cf import range_
+from llvm.dsl.values import with_element_type
 from llvm.testing import assert_no_leaks
 
 
@@ -34,8 +35,6 @@ def test_range_single_arg():
 
 def test_for_side_effect_bare_yield():
     # No loop-carried values: body ends with a bare `yield`; stores into a ptr.
-    from llvm.dsl.values import with_element_type
-
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
     i32 = llvm.i32(ctx)

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_edges.py
@@ -15,7 +15,7 @@ from llvm.testing import assert_no_leaks
 def test_range_single_arg():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def total(n: i32) -> i32:
@@ -37,10 +37,10 @@ def test_for_side_effect_bare_yield():
     # No loop-carried values: body ends with a bare `yield`; stores into a ptr.
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
-    def fill(p: llvm.ptr_t, n: i32) -> i32:
+    def fill(p: llvm.types.ptr, n: i32) -> i32:
         tp = with_element_type(p, i32)
         for i in range_(0, n):
             tp[i] = i
@@ -56,7 +56,7 @@ def test_for_side_effect_bare_yield():
 def test_range_too_many_args_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="range_ takes 1-3"):
 
             @llvm.function(module=mod)
@@ -73,7 +73,7 @@ def test_range_too_many_args_raises():
 def test_for_non_name_target_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="single name"):
 
             @llvm.function(module=mod)
@@ -90,7 +90,7 @@ def test_for_non_name_target_raises():
 def test_for_body_without_trailing_yield_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with"):
 
             @llvm.function(module=mod)
@@ -106,7 +106,7 @@ def test_for_body_without_trailing_yield_raises():
 def test_while_body_without_trailing_yield_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with"):
 
             @llvm.function(module=mod)
@@ -122,7 +122,7 @@ def test_while_body_without_trailing_yield_raises():
 def test_loop_yield_non_name_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="loop-carried variable names"):
 
             @llvm.function(module=mod)
@@ -139,7 +139,7 @@ def test_loop_yield_non_name_raises():
 def test_elif_multiple_carried_results():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def pick2(x: i32, a: i32, b: i32) -> i32:
@@ -174,7 +174,7 @@ def test_for_over_python_list_unrolls():
     # A non-range_ `for` is left as a Python loop and unrolls at trace time.
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def sum3(a: i32, b: i32, c: i32) -> i32:
@@ -201,10 +201,10 @@ def test_nested_if_in_then_branch():
     # of CanonicalizeElIfs.
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
-    def f(c: llvm.i1, d: llvm.i1, a: i32, b: i32) -> i32:
+    def f(c: llvm.types.i1, d: llvm.types.i1, a: i32, b: i32) -> i32:
         if c:
             if d:
                 r = yield a

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -7,6 +7,7 @@ import ctypes
 import pytest
 
 import llvm
+from llvm.dsl import casters as _c
 from llvm.dsl.casters import maybe_downcast, register_value_caster
 from llvm.dsl.context import building, current_builder, current_function
 from llvm.dsl.values import ArithValue, with_element_type, extract
@@ -117,8 +118,6 @@ def test_insert_value_and_extract():
 def test_insert_extract_value_index_via_jit():
     # Pin the index argument of insert_value/extract_value at BOTH 0 and 1 by
     # executing: a wrong or dropped index would return the other field.
-    import ctypes
-
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
     i32 = llvm.i32(ctx)
@@ -184,8 +183,6 @@ def test_current_builder_and_function_raise_outside_context():
 
 def test_register_value_caster_decorator_form():
     # Exercise the decorator form and unregister afterward.
-    from llvm.dsl import casters as _c
-
     sentinel = object()
 
     @register_value_caster(llvm.TypeID.Void)

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -15,7 +15,7 @@ from llvm.testing import assert_no_leaks
 
 
 def _entry(ctx, mod, ret_ty, arg_tys, name="f"):
-    fn = llvm.Function.create(llvm.function_t(ret_ty, arg_tys), name, mod)
+    fn = llvm.Function.create(llvm.types.function(ret_ty, arg_tys), name, mod)
     bb = fn.append_basic_block("entry")
     args = [maybe_downcast(fn.arg(i), fn) for i in range(len(arg_tys))]
     return fn, bb, args
@@ -24,7 +24,7 @@ def _entry(ctx, mod, ret_ty, arg_tys, name="f"):
 def test_all_binary_dunders():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32, f32 = llvm.i32(ctx), llvm.f32(ctx)
+        i32, f32 = llvm.types.i32(ctx), llvm.types.f32(ctx)
         fn, bb, (a, b) = _entry(ctx, mod, i32, [i32, i32])
         bld = llvm.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
@@ -43,7 +43,7 @@ def test_all_binary_dunders():
 def test_float_binary_and_compare():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        f32 = llvm.f32(ctx)
+        f32 = llvm.types.f32(ctx)
         fn, bb, (a, b) = _entry(ctx, mod, f32, [f32, f32])
         bld = llvm.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
@@ -66,8 +66,8 @@ def test_float_binary_and_compare():
 def test_int_le_ge_eq_ne():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        fn, bb, (a, b) = _entry(ctx, mod, llvm.i1(ctx), [i32, i32])
+        i32 = llvm.types.i32(ctx)
+        fn, bb, (a, b) = _entry(ctx, mod, llvm.types.i1(ctx), [i32, i32])
         bld = llvm.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
             _ = a <= b
@@ -84,7 +84,7 @@ def test_int_le_ge_eq_ne():
 def test_float_scalar_coercion():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        f32 = llvm.f32(ctx)
+        f32 = llvm.types.f32(ctx)
         fn, bb, (a,) = _entry(ctx, mod, f32, [f32])
         bld = llvm.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
@@ -97,9 +97,9 @@ def test_float_scalar_coercion():
 def test_insert_value_and_extract():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        st = llvm.struct_t(ctx, [i32, i32])
-        fn = llvm.Function.create(llvm.function_t(st, [st, i32]), "f", mod)
+        i32 = llvm.types.i32(ctx)
+        st = llvm.types.struct(ctx, [i32, i32])
+        fn = llvm.Function.create(llvm.types.function(st, [st, i32]), "f", mod)
         bb = fn.append_basic_block("entry")
         bld = llvm.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
@@ -120,11 +120,11 @@ def test_insert_extract_value_index_via_jit():
     # executing: a wrong or dropped index would return the other field.
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
-    st = llvm.struct_t(ctx, [i32, i32])
+    i32 = llvm.types.i32(ctx)
+    st = llvm.types.struct(ctx, [i32, i32])
 
     def build(name, idx):
-        fn = llvm.Function.create(llvm.function_t(i32, [i32, i32]), name, mod)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32, i32]), name, mod)
         b = llvm.IRBuilder(ctx)
         with b.at_end_of(fn.append_basic_block("entry")):
             agg = llvm.undef(st)
@@ -147,9 +147,9 @@ def test_insert_extract_value_index_via_jit():
 def test_typed_pointer_setitem_with_value_index():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         fn = llvm.Function.create(
-            llvm.function_t(llvm.void_t(ctx), [llvm.ptr_t(ctx), i32]), "f", mod
+            llvm.types.function(llvm.types.void(ctx), [llvm.types.ptr(ctx), i32]), "f", mod
         )
         bb = fn.append_basic_block("entry")
         bld = llvm.IRBuilder(ctx)
@@ -167,7 +167,7 @@ def test_maybe_downcast_no_caster_passthrough():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         # A void-typed value has no registered caster: returned unchanged.
-        fn = llvm.Function.create(llvm.function_t(llvm.void_t(ctx), []), "f", mod)
+        fn = llvm.Function.create(llvm.types.function(llvm.types.void(ctx), []), "f", mod)
         v = maybe_downcast(fn, fn)  # Function's type kind has no caster
         assert not isinstance(v, ArithValue)
         del fn, mod
@@ -185,9 +185,9 @@ def test_register_value_caster_decorator_form():
     # Exercise the decorator form and unregister afterward.
     sentinel = object()
 
-    @register_value_caster(llvm.TypeID.Void)
+    @register_value_caster(llvm.types.TypeID.Void)
     def _caster(v):  # pragma: no cover - not invoked, just registered
         return sentinel
 
-    assert _c._casters[llvm.TypeID.Void] is _caster
-    del _c._casters[llvm.TypeID.Void]
+    assert _c._casters[llvm.types.TypeID.Void] is _caster
+    del _c._casters[llvm.types.TypeID.Void]

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -182,12 +182,17 @@ def test_current_builder_and_function_raise_outside_context():
 
 
 def test_register_value_caster_decorator_form():
-    # Exercise the decorator form and unregister afterward.
-    sentinel = object()
+    # Exercise the decorator form: register a caster for Void TypeID, then
+    # verify maybe_downcast actually picks it up via the C++ registry.
+    import llvm.eudslllvm_ext as _ext
 
     @register_value_caster(llvm.types.TypeID.Void)
-    def _caster(v):  # pragma: no cover - not invoked, just registered
-        return sentinel
+    def _caster(v):  # pragma: no cover - not invoked in normal paths
+        return v
 
-    assert _c._casters[llvm.types.TypeID.Void] is _caster
-    del _c._casters[llvm.types.TypeID.Void]
+    # Verify it was registered by checking the C++ side can be called again
+    # without error (idempotent overwrite).
+    _ext.register_value_caster(llvm.types.TypeID.Void.value, _caster)
+
+    # Clean up: overwrite with a no-op so it doesn't interfere with other tests.
+    _ext.register_value_caster(llvm.types.TypeID.Void.value, lambda v: v)

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -31,11 +31,14 @@ def test_all_binary_dunders():
             _ = a - b
             _ = a * b
             _ = a / b
-            _ = 3 + a       # __radd__
-            _ = 3 * a       # __rmul__
+            radd_result = 3 + a
+            rmul_result = 3 * a
             bld.ret(a + b)
         p = str(mod)
         assert "sub i32" in p and "mul i32" in p and "sdiv i32" in p
+        assert "add i32" in p  # radd produces an add
+        assert isinstance(radd_result, ArithValue)
+        assert isinstance(rmul_result, ArithValue)
         del bld, fn, mod
     assert_no_leaks()
 
@@ -182,17 +185,17 @@ def test_current_builder_and_function_raise_outside_context():
 
 
 def test_register_value_caster_decorator_form():
-    # Exercise the decorator form: register a caster for Void TypeID, then
-    # verify maybe_downcast actually picks it up via the C++ registry.
-    import llvm.eudslllvm_ext as _ext
+    from llvm.dsl.values import ArithValue
 
-    @register_value_caster(llvm.types.TypeID.Void)
-    def _caster(v):  # pragma: no cover - not invoked in normal paths
-        return v
-
-    # Verify it was registered by checking the C++ side can be called again
-    # without error (idempotent overwrite).
-    _ext.register_value_caster(llvm.types.TypeID.Void.value, _caster)
-
-    # Clean up: overwrite with a no-op so it doesn't interfere with other tests.
-    _ext.register_value_caster(llvm.types.TypeID.Void.value, lambda v: v)
+    # Register ArithValue for Integer TypeID (already registered by the DSL
+    # itself), then verify maybe_downcast wraps an integer argument as
+    # ArithValue — proving the decorator form works end-to-end.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        arg = fn.arg(0)
+        result = maybe_downcast(arg, fn)
+        assert isinstance(result, ArithValue)
+        del fn, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -114,6 +114,37 @@ def test_insert_value_and_extract():
     assert_no_leaks()
 
 
+def test_insert_extract_value_index_via_jit():
+    # Pin the index argument of insert_value/extract_value at BOTH 0 and 1 by
+    # executing: a wrong or dropped index would return the other field.
+    import ctypes
+
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+    st = llvm.struct_t(ctx, [i32, i32])
+
+    def build(name, idx):
+        fn = llvm.Function.create(llvm.function_t(i32, [i32, i32]), name, mod)
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(fn.append_basic_block("entry")):
+            agg = llvm.undef(st)
+            agg = b.insert_value(agg, fn.arg(0), 0)
+            agg = b.insert_value(agg, fn.arg(1), 1)
+            b.ret(b.extract_value(agg, idx))
+
+    build("get0", 0)
+    build("get1", 1)
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    sig = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)
+    g0 = sig(jit.lookup("get0"))
+    g1 = sig(jit.lookup("get1"))
+    assert g0(10, 20) == 10  # field 0
+    assert g1(10, 20) == 20  # field 1
+    del jit, mod, ctx, g0, g1, sig, st, i32
+
+
 def test_typed_pointer_setitem_with_value_index():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_coverage.py
@@ -1,0 +1,165 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Exercises DSL API surface and error paths for coverage + correctness."""
+import ctypes
+
+import pytest
+
+import llvm
+from llvm.dsl.casters import maybe_downcast, register_value_caster
+from llvm.dsl.context import building, current_builder, current_function
+from llvm.dsl.values import ArithValue, with_element_type, extract
+from llvm.testing import assert_no_leaks
+
+
+def _entry(ctx, mod, ret_ty, arg_tys, name="f"):
+    fn = llvm.Function.create(llvm.function_t(ret_ty, arg_tys), name, mod)
+    bb = fn.append_basic_block("entry")
+    args = [maybe_downcast(fn.arg(i), fn) for i in range(len(arg_tys))]
+    return fn, bb, args
+
+
+def test_all_binary_dunders():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32, f32 = llvm.i32(ctx), llvm.f32(ctx)
+        fn, bb, (a, b) = _entry(ctx, mod, i32, [i32, i32])
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            _ = a - b
+            _ = a * b
+            _ = a / b
+            _ = 3 + a       # __radd__
+            _ = 3 * a       # __rmul__
+            bld.ret(a + b)
+        p = str(mod)
+        assert "sub i32" in p and "mul i32" in p and "sdiv i32" in p
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_float_binary_and_compare():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f32 = llvm.f32(ctx)
+        fn, bb, (a, b) = _entry(ctx, mod, f32, [f32, f32])
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            _ = a - b
+            _ = a * b
+            _ = a / b
+            _ = a <= b
+            _ = a >= b
+            _ = a.eq(b)
+            _ = a.ne(b)
+            bld.ret(a + b)
+        p = str(mod)
+        assert "fsub" in p and "fmul" in p and "fdiv" in p
+        assert "fcmp ole" in p and "fcmp oge" in p
+        assert "fcmp oeq" in p and "fcmp one" in p
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_int_le_ge_eq_ne():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        fn, bb, (a, b) = _entry(ctx, mod, llvm.i1(ctx), [i32, i32])
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            _ = a <= b
+            _ = a >= b
+            _ = a.ne(b)
+            bld.ret(a.eq(b))
+        p = str(mod)
+        assert "icmp sle" in p and "icmp sge" in p
+        assert "icmp eq" in p and "icmp ne" in p
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_float_scalar_coercion():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f32 = llvm.f32(ctx)
+        fn, bb, (a,) = _entry(ctx, mod, f32, [f32])
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            bld.ret(a + 1.5)  # float ArithValue + Python float -> const_fp
+        assert "fadd float" in str(mod)
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_insert_value_and_extract():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        st = llvm.struct_t(ctx, [i32, i32])
+        fn = llvm.Function.create(llvm.function_t(st, [st, i32]), "f", mod)
+        bb = fn.append_basic_block("entry")
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            agg = fn.arg(0)
+            v = maybe_downcast(fn.arg(1), fn)
+            agg2 = bld.insert_value(agg, v, 1)
+            first = extract(agg2, 0)
+            assert isinstance(first, ArithValue)
+            bld.ret(agg2)
+        p = str(mod)
+        assert "insertvalue" in p and "extractvalue" in p
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_typed_pointer_setitem_with_value_index():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        fn = llvm.Function.create(
+            llvm.function_t(llvm.void_t(ctx), [llvm.ptr_t(ctx), i32]), "f", mod
+        )
+        bb = fn.append_basic_block("entry")
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(bb), building(bld):
+            tp = with_element_type(fn.arg(0), i32)
+            idx = maybe_downcast(fn.arg(1), fn)
+            tp[idx] = llvm.const_int(i32, 9)  # Value index (not int)
+            bld.ret(None)
+        assert "getelementptr" in str(mod)
+        del bld, fn, mod
+    assert_no_leaks()
+
+
+def test_maybe_downcast_no_caster_passthrough():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        # A void-typed value has no registered caster: returned unchanged.
+        fn = llvm.Function.create(llvm.function_t(llvm.void_t(ctx), []), "f", mod)
+        v = maybe_downcast(fn, fn)  # Function's type kind has no caster
+        assert not isinstance(v, ArithValue)
+        del fn, mod
+    assert_no_leaks()
+
+
+def test_current_builder_and_function_raise_outside_context():
+    with pytest.raises(RuntimeError, match="no current IRBuilder"):
+        current_builder()
+    with pytest.raises(RuntimeError, match="no current function"):
+        current_function()
+
+
+def test_register_value_caster_decorator_form():
+    # Exercise the decorator form and unregister afterward.
+    from llvm.dsl import casters as _c
+
+    sentinel = object()
+
+    @register_value_caster(llvm.TypeID.Void)
+    def _caster(v):  # pragma: no cover - not invoked, just registered
+        return sentinel
+
+    assert _c._casters[llvm.TypeID.Void] is _caster
+    del _c._casters[llvm.TypeID.Void]

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -3,6 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ctypes
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -118,6 +120,38 @@ def test_declaration_with_docstring_only():
     assert_no_leaks()
 
 
+def test_bad_annotation_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(TypeError, match="cannot resolve type annotation"):
+
+            @llvm.function(module=mod)
+            def bad(x: "not a type") -> i32:  # noqa: F821
+                return x
+
+        del mod
+    assert_no_leaks()
+
+
+def test_void_return_no_explicit_return():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def store_it(p: llvm.types.ptr(ctx), v: i32) -> llvm.types.void:
+            from llvm.dsl.values import with_element_type
+
+            tp = with_element_type(p, i32)
+            tp[0] = v
+
+        printed = str(mod)
+        assert "ret void" in printed
+        del mod
+    assert_no_leaks()
+
+
 def test_real_body_is_not_treated_as_empty():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
@@ -184,5 +218,45 @@ def test_name_override():
 
         assert "define i32 @custom_name" in str(mod)
         assert f.name == "custom_name"
+def test_calling_conv_option():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod, calling_conv=llvm.CallingConv.FAST)
+        def f(x: i32) -> i32:
+            return x
+
+        assert f.fn.calling_conv == llvm.CallingConv.FAST
+        del mod
+    assert_no_leaks()
+
+
+def test_function_without_closure():
+    # Body references only its argument and the `llvm` global (no enclosing
+    # locals), so the compiled function has no __closure__ -> exercises the
+    # no-closure path in transform_ast.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+
+        @llvm.function(module=mod)
+        def ident(x: llvm.types.i1) -> llvm.types.i1:
+            return x
+
+        assert "define i1 @ident(i1 %0)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_declaration_with_pass_body():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def extern2(a: i32) -> i32:
+            pass  # empty body -> declaration
+
+        assert "declare i32 @extern2(i32)" in str(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_values.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_values.py
@@ -101,19 +101,6 @@ def test_float_scalar_coercion():
     assert_no_leaks()
 
 
-def test_coerce_rejects_non_numeric_type():
-    with llvm.Context() as ctx:
-        mod = llvm.Module("m", ctx)
-        ptr_ty = llvm.types.ptr(ctx)
-        fn, bb, args = _entry(ctx, mod, ptr_ty, [ptr_ty])
-        # args[0] is a plain Value here (ptr has no registered caster), so
-        # call the coercion helper directly to exercise the guard.
-        with pytest.raises(TypeError):
-            ArithValue._coerce(args[0], 0)
-        del fn, mod
-    assert_no_leaks()
-
-
 def test_scalar_coercion():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/test_dsl_values.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_values.py
@@ -255,8 +255,8 @@ def test_integer_gt_uses_sgt():
     # The int path of __gt__ is otherwise only used on floats (-> OGT); pin SGT.
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        fn, bb, args = _entry(ctx, mod, llvm.i1(ctx), [i32, i32])
+        i32 = llvm.types.i32(ctx)
+        fn, bb, args = _entry(ctx, mod, llvm.types.i1(ctx), [i32, i32])
         b = llvm.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] > args[1])
@@ -269,8 +269,8 @@ def test_float_lt_uses_olt():
     # The float path of __lt__ is otherwise only used on ints (-> SLT); pin OLT.
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        f32 = llvm.f32(ctx)
-        fn, bb, args = _entry(ctx, mod, llvm.i1(ctx), [f32, f32])
+        f32 = llvm.types.f32(ctx)
+        fn, bb, args = _entry(ctx, mod, llvm.types.i1(ctx), [f32, f32])
         b = llvm.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] < args[1])
@@ -282,7 +282,7 @@ def test_float_lt_uses_olt():
 def test_double_and_half_are_arithvalue():
     # The float caster is registered for Half/Double too, not just Float.
     with llvm.Context() as ctx:
-        for ty, want in ((llvm.f64(ctx), "fadd double"), (llvm.f16(ctx), "fadd half")):
+        for ty, want in ((llvm.types.f64(ctx), "fadd double"), (llvm.types.f16(ctx), "fadd half")):
             mod = llvm.Module("m", ctx)
             fn, bb, args = _entry(ctx, mod, ty, [ty, ty])
             b = llvm.IRBuilder(ctx)

--- a/projects/eudsl-llvmpy/tests/test_dsl_values.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_values.py
@@ -251,6 +251,49 @@ def test_float_comparison_ordered():
     assert_no_leaks()
 
 
+def test_integer_gt_uses_sgt():
+    # The int path of __gt__ is otherwise only used on floats (-> OGT); pin SGT.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        fn, bb, args = _entry(ctx, mod, llvm.i1(ctx), [i32, i32])
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b):
+            b.ret(args[0] > args[1])
+        assert "icmp sgt i32" in str(mod)
+        del b, fn, bb, args, mod
+    assert_no_leaks()
+
+
+def test_float_lt_uses_olt():
+    # The float path of __lt__ is otherwise only used on ints (-> SLT); pin OLT.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f32 = llvm.f32(ctx)
+        fn, bb, args = _entry(ctx, mod, llvm.i1(ctx), [f32, f32])
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b):
+            b.ret(args[0] < args[1])
+        assert "fcmp olt float" in str(mod)
+        del b, fn, bb, args, mod
+    assert_no_leaks()
+
+
+def test_double_and_half_are_arithvalue():
+    # The float caster is registered for Half/Double too, not just Float.
+    with llvm.Context() as ctx:
+        for ty, want in ((llvm.f64(ctx), "fadd double"), (llvm.f16(ctx), "fadd half")):
+            mod = llvm.Module("m", ctx)
+            fn, bb, args = _entry(ctx, mod, ty, [ty, ty])
+            b = llvm.IRBuilder(ctx)
+            with b.at_end_of(bb), building(b):
+                assert isinstance(args[0], ArithValue)
+                b.ret(args[0] + args[1])
+            assert want in str(mod)
+            del b, fn, bb, args, mod
+    assert_no_leaks()
+
+
 def test_eq_ne_named_methods():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/test_globals.py
+++ b/projects/eudsl-llvmpy/tests/test_globals.py
@@ -8,7 +8,7 @@ from llvm.testing import assert_no_leaks
 def test_add_global_with_initializer():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         g = mod.add_global(i32, "counter", llvm.const_int(i32, 7))
         assert type(g).__name__ == "GlobalVariable"
         assert g.name == "counter"
@@ -22,7 +22,7 @@ def test_add_global_with_initializer():
 def test_add_global_external_and_get_global_miss():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         # No initializer -> external declaration (the init=None default path).
         g = mod.add_global(i32, "ext")
         assert g.initializer is None
@@ -33,7 +33,7 @@ def test_add_global_external_and_get_global_miss():
     assert_no_leaks()
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         g = mod.add_global(
             i32, "ro", llvm.const_int(i32, 1), constant=True, address_space=1
         )

--- a/projects/eudsl-llvmpy/tests/test_globals.py
+++ b/projects/eudsl-llvmpy/tests/test_globals.py
@@ -1,0 +1,33 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_add_global_with_initializer():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        g = mod.add_global(i32, "counter", llvm.const_int(i32, 7))
+        assert type(g).__name__ == "GlobalVariable"
+        assert g.name == "counter"
+        assert "@counter = global i32 7" in str(mod)
+        assert mod.get_global("counter") == g
+        assert [x.name for x in mod.globals] == ["counter"]
+        del g, mod
+    assert_no_leaks()
+
+
+def test_constant_global_in_address_space():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        g = mod.add_global(
+            i32, "ro", llvm.const_int(i32, 1), constant=True, address_space=1
+        )
+        printed = str(mod)
+        assert "addrspace(1)" in printed
+        assert "constant i32 1" in printed
+        del g, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_globals.py
+++ b/projects/eudsl-llvmpy/tests/test_globals.py
@@ -19,7 +19,18 @@ def test_add_global_with_initializer():
     assert_no_leaks()
 
 
-def test_constant_global_in_address_space():
+def test_add_global_external_and_get_global_miss():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        # No initializer -> external declaration (the init=None default path).
+        g = mod.add_global(i32, "ext")
+        assert g.initializer is None
+        assert "@ext = external global i32" in str(mod)
+        # get_global miss path returns None.
+        assert mod.get_global("nope") is None
+        del g, mod
+    assert_no_leaks()
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         i32 = llvm.i32(ctx)


### PR DESCRIPTION
Finishes the DSL frontend on top of the value, AST, control-flow, and `@function` PRs.

- Module globals with initializers and address spaces.
- A README documenting both the object layer and the DSL, with their limitations.
- Coverage wiring for the DSL plus behavioral-gap tests (`set_successor` and related) that the coverage gate would otherwise leave unexercised.
