### PR TITLE
[eudsl-llvmpy] MLIR parity: isinstance over type().__name__ in tests

### DIFF
--- a/projects/eudsl-llvmpy/tests/test_constants.py
+++ b/projects/eudsl-llvmpy/tests/test_constants.py
@@ -31,7 +31,7 @@ _AGGREGATE_SRC = dedent(
 def test_const_int():
     with llvm.Context() as ctx:
         c = llvm.const_int(llvm.types.i32(ctx), 42)
-        assert type(c).__name__ == "ConstantInt"
+        assert isinstance(c, llvm.ConstantInt)
         assert c.value == 42
         assert str(c) == "i32 42"
         neg = llvm.const_int(llvm.types.i32(ctx), -1, signed=True)
@@ -58,10 +58,10 @@ def test_const_int_out_of_range_raises():
 def test_const_bool_and_fp():
     with llvm.Context() as ctx:
         t = llvm.const_bool(ctx, True)
-        assert type(t).__name__ == "ConstantInt"
+        assert isinstance(t, llvm.ConstantInt)
         assert str(t) == "i1 true"
         f = llvm.const_fp(llvm.types.f64(ctx), 1.5)
-        assert type(f).__name__ == "ConstantFP"
+        assert isinstance(f, llvm.ConstantFP)
         assert f.double_value == 1.5
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_cpp_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_cpp_coverage.py
@@ -156,7 +156,7 @@ def test_constant_int_zext_and_global_initializer():
         # The load pointer operands are the GlobalVariables @g and @e.
         g = loads[0].pointer_operand
         e = loads[1].pointer_operand
-        assert type(g).__name__ == "GlobalVariable"
+        assert isinstance(g, llvm.GlobalVariable)
         assert g.initializer.value == 5  # @g's initializer is the constant i32 5
         assert e.initializer is None  # @e is external, no initializer
         del loads, g, e, mod

--- a/projects/eudsl-llvmpy/tests/test_globals.py
+++ b/projects/eudsl-llvmpy/tests/test_globals.py
@@ -10,7 +10,7 @@ def test_add_global_with_initializer():
         mod = llvm.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         g = mod.add_global(i32, "counter", llvm.const_int(i32, 7))
-        assert type(g).__name__ == "GlobalVariable"
+        assert isinstance(g, llvm.GlobalVariable)
         assert g.name == "counter"
         assert "@counter = global i32 7" in str(mod)
         assert mod.get_global("counter") == g

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -60,8 +60,10 @@ def test_basic_block_and_instruction_traversal():
         # add, ret
         assert len(insts) == 2
         assert entry.terminator == insts[-1]
-        # The Value type_hook downcasts the add to its concrete class.
-        assert isinstance(insts[0], llvm.BinaryOperator)
+        # The Value type_hook downcasts the add to its concrete class. Pin the
+        # exact class: BinaryOperator has a subclass (FPBinaryOperator), so
+        # isinstance would also accept a mis-downcast of this integer add.
+        assert type(insts[0]) is llvm.BinaryOperator
         del f, entry, blocks, insts, mod
     assert_no_leaks()
 
@@ -74,7 +76,9 @@ def test_value_users_and_operands():
         # %x is used by the add.
         assert x.num_uses == 1
         add = x.users[0]
-        assert isinstance(add, llvm.BinaryOperator)
+        # Exact class, not isinstance: FPBinaryOperator subclasses
+        # BinaryOperator, so isinstance would not catch a mis-downcast.
+        assert type(add) is llvm.BinaryOperator
         assert add.num_operands == 2
         assert add.operand(0) == x
         del f, x, add, mod

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -61,7 +61,7 @@ def test_basic_block_and_instruction_traversal():
         assert len(insts) == 2
         assert entry.terminator == insts[-1]
         # The Value type_hook downcasts the add to its concrete class.
-        assert type(insts[0]).__name__ == "BinaryOperator"
+        assert isinstance(insts[0], llvm.BinaryOperator)
         del f, entry, blocks, insts, mod
     assert_no_leaks()
 
@@ -74,7 +74,7 @@ def test_value_users_and_operands():
         # %x is used by the add.
         assert x.num_uses == 1
         add = x.users[0]
-        assert type(add).__name__ == "BinaryOperator"
+        assert isinstance(add, llvm.BinaryOperator)
         assert add.num_operands == 2
         assert add.operand(0) == x
         del f, x, add, mod


### PR DESCRIPTION
Convert object-class assertions to isinstance(x, llvm.Foo), matching the
MLIR python bindings' convention (builtin_types.py). The exact-type checks
in the downcast sweeps (test_downcast_kinds.py, the valueTypeInfo sweep in
test_cpp_coverage.py) and dynamic kind filters stay type().__name__, since
they verify the dispatch produces exactly that leaf class.
