### PR TITLE
[eudsl-llvmpy] MLIR parity: checked-downcast constructors

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -59,7 +59,8 @@ enum class CallingConvEnum : unsigned {
           return d;                                                            \
         throw nb::value_error("value is not a " #Derived);                     \
       }),                                                                      \
-      nb::rv_policy::reference, nb::keep_alive<0, 1>())
+      nb::arg("value").none(), nb::rv_policy::reference,                       \
+      nb::keep_alive<0, 1>())
 
 // Pulled in here so every translation unit that returns an llvm::Type* or
 // llvm::Value* sees the downcasting type_hook specializations. Without this a

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <llvm/IR/CallingConv.h>
+#include <llvm/Support/Casting.h>
 #include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -51,6 +52,14 @@ enum class CallingConvEnum : unsigned {
   FAST = llvm::CallingConv::Fast,
   COLD = llvm::CallingConv::Cold,
 };
+
+#define EUDSL_CAST_CTOR(Derived, Base)                                         \
+  def(nb::new_([](Base *v) -> Derived * {                                      \
+        if (auto *d = llvm::dyn_cast_or_null<Derived>(v))                      \
+          return d;                                                            \
+        throw nb::value_error("value is not a " #Derived);                     \
+      }),                                                                      \
+      nb::rv_policy::reference, nb::keep_alive<0, 1>())
 
 // Pulled in here so every translation unit that returns an llvm::Type* or
 // llvm::Value* sees the downcasting type_hook specializations. Without this a

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -15,6 +15,7 @@ void populate_constants(nb::module_ &m) {
   nb::class_<llvm::ConstantAggregate, llvm::Constant>(m, "ConstantAggregate");
 
   nb::class_<llvm::ConstantInt, llvm::ConstantData>(m, "ConstantInt")
+      .EUDSL_CAST_CTOR(llvm::ConstantInt, llvm::Value)
       .def_prop_ro("value",
                    [](llvm::ConstantInt &self) {
                      return self.getValue().getSExtValue();
@@ -24,6 +25,7 @@ void populate_constants(nb::module_ &m) {
       });
 
   nb::class_<llvm::ConstantFP, llvm::ConstantData>(m, "ConstantFP")
+      .EUDSL_CAST_CTOR(llvm::ConstantFP, llvm::Value)
       .def_prop_ro("double_value", [](llvm::ConstantFP &self) {
         return self.getValueAPF().convertToDouble();
       });
@@ -49,6 +51,7 @@ void populate_constants(nb::module_ &m) {
   nb::class_<llvm::BlockAddress, llvm::Constant>(m, "BlockAddress");
 
   nb::class_<llvm::GlobalVariable, llvm::GlobalObject>(m, "GlobalVariable")
+      .EUDSL_CAST_CTOR(llvm::GlobalVariable, llvm::Value)
       .def_prop_ro("is_constant", &llvm::GlobalVariable::isConstant)
       .def_prop_ro(
           "initializer",

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -42,9 +42,11 @@ void populate_instructions(nb::module_ &m) {
   nb::class_<llvm::FuncletPadInst, llvm::Instruction>(m, "FuncletPadInst");
 
   nb::class_<llvm::CmpInst, llvm::Instruction>(m, "CmpInst")
+      .EUDSL_CAST_CTOR(llvm::CmpInst, llvm::Value)
       .def_prop_ro("predicate", &llvm::CmpInst::getPredicate);
 
   nb::class_<llvm::CallBase, llvm::Instruction>(m, "CallBase")
+      .EUDSL_CAST_CTOR(llvm::CallBase, llvm::Value)
       .def_prop_ro("num_args", &llvm::CallBase::arg_size)
       .def(
           "arg_operand",
@@ -66,6 +68,7 @@ void populate_instructions(nb::module_ &m) {
   nb::class_<llvm::CallBrInst, llvm::CallBase>(m, "CallBrInst");
 
   nb::class_<llvm::PHINode, llvm::Instruction>(m, "PHINode")
+      .EUDSL_CAST_CTOR(llvm::PHINode, llvm::Value)
       .def_prop_ro("num_incoming", &llvm::PHINode::getNumIncomingValues)
       .def(
           "incoming_value",
@@ -86,21 +89,25 @@ void populate_instructions(nb::module_ &m) {
       .def("add_incoming", &llvm::PHINode::addIncoming, "value"_a, "block"_a);
 
   nb::class_<llvm::AllocaInst, llvm::UnaryInstruction>(m, "AllocaInst")
+      .EUDSL_CAST_CTOR(llvm::AllocaInst, llvm::Value)
       .def_prop_ro(
           "allocated_type",
           [](llvm::AllocaInst &self) { return self.getAllocatedType(); },
           nb::rv_policy::reference_internal);
   nb::class_<llvm::LoadInst, llvm::UnaryInstruction>(m, "LoadInst")
+      .EUDSL_CAST_CTOR(llvm::LoadInst, llvm::Value)
       .def_prop_ro(
           "pointer_operand",
           [](llvm::LoadInst &self) { return self.getPointerOperand(); },
           nb::rv_policy::reference_internal);
   nb::class_<llvm::StoreInst, llvm::Instruction>(m, "StoreInst")
+      .EUDSL_CAST_CTOR(llvm::StoreInst, llvm::Value)
       .def_prop_ro(
           "pointer_operand",
           [](llvm::StoreInst &self) { return self.getPointerOperand(); },
           nb::rv_policy::reference_internal);
   nb::class_<llvm::GetElementPtrInst, llvm::Instruction>(m, "GetElementPtrInst")
+      .EUDSL_CAST_CTOR(llvm::GetElementPtrInst, llvm::Value)
       .def_prop_ro(
           "source_element_type",
           [](llvm::GetElementPtrInst &self) {
@@ -109,13 +116,16 @@ void populate_instructions(nb::module_ &m) {
           nb::rv_policy::reference_internal);
 
   nb::class_<llvm::ReturnInst, llvm::Instruction>(m, "ReturnInst")
+      .EUDSL_CAST_CTOR(llvm::ReturnInst, llvm::Value)
       .def_prop_ro(
           "return_value",
           [](llvm::ReturnInst &self) { return self.getReturnValue(); },
           nb::rv_policy::reference_internal);
   nb::class_<llvm::UncondBrInst, llvm::Instruction>(m, "UncondBrInst")
+      .EUDSL_CAST_CTOR(llvm::UncondBrInst, llvm::Value)
       .def_prop_ro("is_conditional", [](llvm::UncondBrInst &) { return false; });
   nb::class_<llvm::CondBrInst, llvm::Instruction>(m, "CondBrInst")
+      .EUDSL_CAST_CTOR(llvm::CondBrInst, llvm::Value)
       .def_prop_ro("is_conditional", [](llvm::CondBrInst &) { return true; })
       .def_prop_ro(
           "condition",

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -83,12 +83,15 @@ void populate_types(nb::module_ &m) {
 #undef EUDSL_PRIMITIVE_TYPE
 
   nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType")
+      .EUDSL_CAST_CTOR(llvm::IntegerType, llvm::Type)
       .def_prop_ro("bit_width", &llvm::IntegerType::getBitWidth);
 
   nb::class_<llvm::PointerType, llvm::Type>(m, "PointerType")
+      .EUDSL_CAST_CTOR(llvm::PointerType, llvm::Type)
       .def_prop_ro("address_space", &llvm::PointerType::getAddressSpace);
 
   nb::class_<llvm::StructType, llvm::Type>(m, "StructType")
+      .EUDSL_CAST_CTOR(llvm::StructType, llvm::Type)
       .def_prop_ro("name",
                    [](llvm::StructType &self) -> std::optional<std::string> {
                      if (!self.hasName())
@@ -107,11 +110,13 @@ void populate_types(nb::module_ &m) {
           "element_types"_a, "packed"_a = false);
 
   nb::class_<llvm::ArrayType, llvm::Type>(m, "ArrayType")
+      .EUDSL_CAST_CTOR(llvm::ArrayType, llvm::Type)
       .def_prop_ro("num_elements", &llvm::ArrayType::getNumElements)
       .def_prop_ro("element_type", &llvm::ArrayType::getElementType,
                    nb::rv_policy::reference);
 
   nb::class_<llvm::VectorType, llvm::Type>(m, "VectorType")
+      .EUDSL_CAST_CTOR(llvm::VectorType, llvm::Type)
       .def_prop_ro("min_num_elements",
                    [](llvm::VectorType &self) {
                      return self.getElementCount().getKnownMinValue();
@@ -131,6 +136,7 @@ void populate_types(nb::module_ &m) {
                    &llvm::ScalableVectorType::getMinNumElements);
 
   nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType")
+      .EUDSL_CAST_CTOR(llvm::FunctionType, llvm::Type)
       .def_prop_ro("return_type", &llvm::FunctionType::getReturnType,
                    nb::rv_policy::reference)
       .def_prop_ro("num_params", &llvm::FunctionType::getNumParams)

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -49,6 +49,7 @@ void populate_values(nb::module_ &m) {
       });
 
   nb::class_<llvm::User, llvm::Value>(m, "User")
+      .EUDSL_CAST_CTOR(llvm::User, llvm::Value)
       .def_prop_ro("num_operands", &llvm::User::getNumOperands)
       .def("operand", &llvm::User::getOperand, "index"_a,
            nb::rv_policy::reference_internal)
@@ -68,6 +69,7 @@ void populate_values(nb::module_ &m) {
   nb::class_<llvm::GlobalObject, llvm::GlobalValue>(m, "GlobalObject");
 
   nb::class_<llvm::Instruction, llvm::User>(m, "Instruction")
+      .EUDSL_CAST_CTOR(llvm::Instruction, llvm::Value)
       .def_prop_ro("num_successors",
                    [](llvm::Instruction &self) {
                      return self.getNumSuccessors();
@@ -83,12 +85,14 @@ void populate_values(nb::module_ &m) {
           nb::rv_policy::reference_internal);
 
   nb::class_<llvm::Argument, llvm::Value>(m, "Argument")
+      .EUDSL_CAST_CTOR(llvm::Argument, llvm::Value)
       .def_prop_ro("arg_no", &llvm::Argument::getArgNo)
       .def_prop_ro(
           "parent", [](llvm::Argument &self) { return self.getParent(); },
           nb::rv_policy::reference_internal);
 
   nb::class_<llvm::BasicBlock, llvm::Value>(m, "BasicBlock")
+      .EUDSL_CAST_CTOR(llvm::BasicBlock, llvm::Value)
       .def_static(
           "create",
           [](eudsl::Context &ctx, const std::string &name,
@@ -112,6 +116,7 @@ void populate_values(nb::module_ &m) {
       });
 
   nb::class_<llvm::Function, llvm::GlobalObject>(m, "Function")
+      .EUDSL_CAST_CTOR(llvm::Function, llvm::Value)
       .def_static(
           "create",
           [](llvm::FunctionType *ft, const std::string &name,

--- a/projects/eudsl-llvmpy/tests/test_cast_constructors.py
+++ b/projects/eudsl-llvmpy/tests/test_cast_constructors.py
@@ -43,12 +43,12 @@ _SRC = dedent(
 def test_type_cast_constructors():
     with llvm.Context() as ctx:
         cases = [
-            (llvm.IntegerType, llvm.i32(ctx)),
-            (llvm.PointerType, llvm.ptr_t(ctx)),
-            (llvm.StructType, llvm.struct_t(ctx, [llvm.i32(ctx)])),
-            (llvm.ArrayType, llvm.array_t(llvm.i32(ctx), 2)),
-            (llvm.VectorType, llvm.vector_t(llvm.i32(ctx), 2)),
-            (llvm.FunctionType, llvm.function_t(llvm.void_t(ctx), [])),
+            (llvm.types.IntegerType, llvm.types.i32(ctx)),
+            (llvm.types.PointerType, llvm.types.ptr(ctx)),
+            (llvm.types.StructType, llvm.types.struct(ctx, [llvm.types.i32(ctx)])),
+            (llvm.types.ArrayType, llvm.types.array(llvm.types.i32(ctx), 2)),
+            (llvm.types.VectorType, llvm.types.vector(llvm.types.i32(ctx), 2)),
+            (llvm.types.FunctionType, llvm.types.function(llvm.types.void(ctx), [])),
         ]
         for cls, ty in cases:
             narrowed = cls(ty)  # cast from the base Type handle
@@ -56,7 +56,7 @@ def test_type_cast_constructors():
             assert narrowed == ty
         # Mismatch raises ValueError (shared throw path for every cast ctor).
         with pytest.raises(ValueError, match="is not a"):
-            llvm.IntegerType(llvm.ptr_t(ctx))
+            llvm.types.IntegerType(llvm.types.ptr(ctx))
     assert_no_leaks()
 
 
@@ -102,8 +102,8 @@ def test_value_cast_constructors():
             (llvm.ReturnInst, ret),
             (llvm.CondBrInst, entry.terminator),
             (llvm.UncondBrInst, a_block.terminator),
-            (llvm.ConstantInt, llvm.const_int(llvm.i32(ctx), 1)),
-            (llvm.ConstantFP, llvm.const_fp(llvm.f32(ctx), 1.0)),
+            (llvm.ConstantInt, llvm.const_int(llvm.types.i32(ctx), 1)),
+            (llvm.ConstantFP, llvm.const_fp(llvm.types.f32(ctx), 1.0)),
             (llvm.GlobalVariable, gvar),
         ]
         for cls, val in cases:

--- a/projects/eudsl-llvmpy/tests/test_cast_constructors.py
+++ b/projects/eudsl-llvmpy/tests/test_cast_constructors.py
@@ -4,8 +4,11 @@
 """MLIR-style checked-downcast constructors: IntegerType(t), LoadInst(v), ...
 
 Each concrete class accepts a base handle (Type or Value) and returns it
-re-typed if the dynamic kind matches, else raises ValueError -- the parity
-analogue of MLIR's `IntegerType(t)`.
+re-typed if the dynamic kind matches. A wrong kind within the same base
+hierarchy -- and None -- raise ValueError (the shared throw path). An argument
+from the other hierarchy entirely (a Value into a Type ctor, or vice versa) is
+rejected by nanobind as a TypeError before the cast body runs. This is the
+parity analogue of MLIR's `IntegerType(t)`.
 """
 from textwrap import dedent
 
@@ -42,21 +45,52 @@ _SRC = dedent(
 
 def test_type_cast_constructors():
     with llvm.Context() as ctx:
+        # (concrete class, a value that IS one, a probe reading a subclass-only
+        # accessor on the narrowed handle -> proves the cast yields a usable
+        # concrete object, not just an object that compares equal).
         cases = [
-            (llvm.types.IntegerType, llvm.types.i32(ctx)),
-            (llvm.types.PointerType, llvm.types.ptr(ctx)),
-            (llvm.types.StructType, llvm.types.struct(ctx, [llvm.types.i32(ctx)])),
-            (llvm.types.ArrayType, llvm.types.array(llvm.types.i32(ctx), 2)),
-            (llvm.types.VectorType, llvm.types.vector(llvm.types.i32(ctx), 2)),
-            (llvm.types.FunctionType, llvm.types.function(llvm.types.void(ctx), [])),
+            (llvm.types.IntegerType, llvm.types.i32(ctx), lambda t: t.bit_width == 32),
+            (llvm.types.PointerType, llvm.types.ptr(ctx), lambda t: t.address_space == 0),
+            (
+                llvm.types.StructType,
+                llvm.types.struct(ctx, [llvm.types.i32(ctx)]),
+                lambda t: t.num_elements == 1,
+            ),
+            (
+                llvm.types.ArrayType,
+                llvm.types.array(llvm.types.i32(ctx), 2),
+                lambda t: t.num_elements == 2,
+            ),
+            (
+                llvm.types.VectorType,
+                llvm.types.vector(llvm.types.i32(ctx), 2),
+                lambda t: t.min_num_elements == 2,
+            ),
+            (
+                llvm.types.FunctionType,
+                llvm.types.function(llvm.types.void(ctx), []),
+                lambda t: t.num_params == 0,
+            ),
         ]
-        for cls, ty in cases:
+        for cls, ty, probe in cases:
             narrowed = cls(ty)  # cast from the base Type handle
             assert isinstance(narrowed, cls)
             assert narrowed == ty
-        # Mismatch raises ValueError (shared throw path for every cast ctor).
+            assert probe(narrowed)
+        # Wrong kind within the Type hierarchy raises ValueError (shared throw
+        # path for every cast ctor). A no-op `return v` ctor would NOT raise.
         with pytest.raises(ValueError, match="is not a"):
             llvm.types.IntegerType(llvm.types.ptr(ctx))
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.types.VectorType(llvm.types.array(llvm.types.i32(ctx), 2))
+        # None reaches the dyn_cast_or_null null branch -> ValueError, not a
+        # TypeError that would slip past callers catching ValueError.
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.types.IntegerType(None)
+        # A Value handed to a Type ctor is the other hierarchy entirely:
+        # nanobind rejects it as a TypeError before the cast body runs.
+        with pytest.raises(TypeError):
+            llvm.types.IntegerType(llvm.const_int(llvm.types.i32(ctx), 1))
     assert_no_leaks()
 
 
@@ -85,33 +119,63 @@ def test_value_cast_constructors():
         ret = join.terminator
         a_block = next(b for b in f.basic_blocks if b.name == "a")
 
-        # (concrete class, a value that IS one) -> cast round-trips to the class.
+        # (concrete class, a value that IS one, a probe reading a subclass-only
+        # accessor on the narrowed handle).
         cases = [
-            (llvm.Function, f),
-            (llvm.Argument, f.arg(0)),
-            (llvm.BasicBlock, entry),
-            (llvm.Instruction, alloca),
-            (llvm.User, alloca),
-            (llvm.AllocaInst, alloca),
-            (llvm.StoreInst, store),
-            (llvm.LoadInst, load_v),
-            (llvm.GetElementPtrInst, gep),
-            (llvm.CmpInst, cmp),
-            (llvm.CallBase, call),
-            (llvm.PHINode, phi),
-            (llvm.ReturnInst, ret),
-            (llvm.CondBrInst, entry.terminator),
-            (llvm.UncondBrInst, a_block.terminator),
-            (llvm.ConstantInt, llvm.const_int(llvm.types.i32(ctx), 1)),
-            (llvm.ConstantFP, llvm.const_fp(llvm.types.f32(ctx), 1.0)),
-            (llvm.GlobalVariable, gvar),
+            (llvm.Function, f, lambda v: v.num_args == 3),
+            (llvm.Argument, f.arg(0), lambda v: v.arg_no == 0),
+            (llvm.BasicBlock, entry, lambda v: v.name == "entry"),
+            (llvm.Instruction, alloca, lambda v: v.is_terminator is False),
+            (llvm.User, alloca, lambda v: isinstance(v.num_operands, int)),
+            (llvm.AllocaInst, alloca, lambda v: str(v.allocated_type) == "i32"),
+            (llvm.StoreInst, store, lambda v: v.pointer_operand is not None),
+            (llvm.LoadInst, load_v, lambda v: v.pointer_operand is not None),
+            (
+                llvm.GetElementPtrInst,
+                gep,
+                lambda v: str(v.source_element_type) == "i32",
+            ),
+            (llvm.CmpInst, cmp, lambda v: v.predicate is not None),
+            (llvm.CallBase, call, lambda v: v.num_args == 1),
+            (llvm.PHINode, phi, lambda v: v.num_incoming == 2),
+            (llvm.ReturnInst, ret, lambda v: v.return_value is not None),
+            (llvm.CondBrInst, entry.terminator, lambda v: v.is_conditional is True),
+            (
+                llvm.UncondBrInst,
+                a_block.terminator,
+                lambda v: v.is_conditional is False,
+            ),
+            (
+                llvm.ConstantInt,
+                llvm.const_int(llvm.types.i32(ctx), 1),
+                lambda v: v.value == 1,
+            ),
+            (
+                llvm.ConstantFP,
+                llvm.const_fp(llvm.types.f32(ctx), 1.0),
+                lambda v: v.double_value == 1.0,
+            ),
+            (llvm.GlobalVariable, gvar, lambda v: v.is_constant is False),
         ]
-        for cls, val in cases:
+        for cls, val, probe in cases:
             narrowed = cls(val)
             assert isinstance(narrowed, cls)
             assert narrowed == val
-        # Mismatch raises ValueError.
+            assert probe(narrowed)
+        # Wrong kind within the Value hierarchy raises ValueError (siblings, not
+        # obviously-unrelated). A no-op `return v` ctor would NOT raise.
         with pytest.raises(ValueError, match="is not a"):
             llvm.LoadInst(store)
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.StoreInst(load_v)
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.PHINode(ret)
+        # None reaches the dyn_cast_or_null null branch -> ValueError.
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.LoadInst(None)
+        # A Type handed to a Value ctor is the other hierarchy: nanobind rejects
+        # it as a TypeError before the cast body runs.
+        with pytest.raises(TypeError):
+            llvm.LoadInst(llvm.types.i32(ctx))
         del f, entry, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_cast_constructors.py
+++ b/projects/eudsl-llvmpy/tests/test_cast_constructors.py
@@ -1,0 +1,117 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""MLIR-style checked-downcast constructors: IntegerType(t), LoadInst(v), ...
+
+Each concrete class accepts a base handle (Type or Value) and returns it
+re-typed if the dynamic kind matches, else raises ValueError -- the parity
+analogue of MLIR's `IntegerType(t)`.
+"""
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    @g = global i32 0
+    declare i32 @callee(i32)
+    define i32 @f(i1 %c, ptr %p, i32 %x) {
+    entry:
+      %s = alloca i32
+      store i32 7, ptr %s
+      %v = load i32, ptr %s
+      %e = getelementptr i32, ptr %p, i64 1
+      %cmp = icmp eq i32 %x, 0
+      %call = call i32 @callee(i32 %x)
+      %gl = load i32, ptr @g
+      br i1 %c, label %a, label %b
+    a:
+      br label %join
+    b:
+      br label %join
+    join:
+      %phi = phi i32 [ %v, %a ], [ %call, %b ]
+      ret i32 %phi
+    }
+    """
+)
+
+
+def test_type_cast_constructors():
+    with llvm.Context() as ctx:
+        cases = [
+            (llvm.IntegerType, llvm.i32(ctx)),
+            (llvm.PointerType, llvm.ptr_t(ctx)),
+            (llvm.StructType, llvm.struct_t(ctx, [llvm.i32(ctx)])),
+            (llvm.ArrayType, llvm.array_t(llvm.i32(ctx), 2)),
+            (llvm.VectorType, llvm.vector_t(llvm.i32(ctx), 2)),
+            (llvm.FunctionType, llvm.function_t(llvm.void_t(ctx), [])),
+        ]
+        for cls, ty in cases:
+            narrowed = cls(ty)  # cast from the base Type handle
+            assert isinstance(narrowed, cls)
+            assert narrowed == ty
+        # Mismatch raises ValueError (shared throw path for every cast ctor).
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.IntegerType(llvm.ptr_t(ctx))
+    assert_no_leaks()
+
+
+def test_value_cast_constructors():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        entry = f.entry_block
+
+        def by(cls):
+            return next(i for i in entry.instructions if isinstance(i, cls))
+
+        alloca = by(llvm.AllocaInst)
+        store = by(llvm.StoreInst)
+        gep = by(llvm.GetElementPtrInst)
+        cmp = by(llvm.CmpInst)
+        call = by(llvm.CallBase)
+        load_v = next(
+            i for i in entry.instructions if isinstance(i, llvm.LoadInst)
+        )
+        gvar = [
+            i for i in entry.instructions if isinstance(i, llvm.LoadInst)
+        ][-1].pointer_operand
+        join = next(b for b in f.basic_blocks if b.name == "join")
+        phi = next(i for i in join.instructions if isinstance(i, llvm.PHINode))
+        ret = join.terminator
+        a_block = next(b for b in f.basic_blocks if b.name == "a")
+
+        # (concrete class, a value that IS one) -> cast round-trips to the class.
+        cases = [
+            (llvm.Function, f),
+            (llvm.Argument, f.arg(0)),
+            (llvm.BasicBlock, entry),
+            (llvm.Instruction, alloca),
+            (llvm.User, alloca),
+            (llvm.AllocaInst, alloca),
+            (llvm.StoreInst, store),
+            (llvm.LoadInst, load_v),
+            (llvm.GetElementPtrInst, gep),
+            (llvm.CmpInst, cmp),
+            (llvm.CallBase, call),
+            (llvm.PHINode, phi),
+            (llvm.ReturnInst, ret),
+            (llvm.CondBrInst, entry.terminator),
+            (llvm.UncondBrInst, a_block.terminator),
+            (llvm.ConstantInt, llvm.const_int(llvm.i32(ctx), 1)),
+            (llvm.ConstantFP, llvm.const_fp(llvm.f32(ctx), 1.0)),
+            (llvm.GlobalVariable, gvar),
+        ]
+        for cls, val in cases:
+            narrowed = cls(val)
+            assert isinstance(narrowed, cls)
+            assert narrowed == val
+        # Mismatch raises ValueError.
+        with pytest.raises(ValueError, match="is not a"):
+            llvm.LoadInst(store)
+        del f, entry, mod
+    assert_no_leaks()


### PR DESCRIPTION
Add MLIR-style IntegerType(t)/LoadInst(v)/... cast constructors: each concrete
class accepts a base Type/Value handle and returns it re-typed via dyn_cast, or
raises ValueError on mismatch. Implemented with a shared EUDSL_CAST_CTOR macro
over nb::new_ + rv_policy::reference + keep_alive<0,1> (reference so nanobind
never deletes a context-owned object; keep_alive so the result transitively
pins the owning Context/Module).

Covers the full Type hierarchy and the accessor-bearing Value classes
(Function/Argument/BasicBlock/Instruction/User, the compare/call/phi/alloca/
load/store/gep/return/branch instructions, ConstantInt/FP, GlobalVariable).
tests/test_cast_constructors.py exercises every cast plus the ValueError path.
