### PR TITLE
[eudsl-llvmpy] MLIR parity: iteration ergonomics

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -45,6 +45,18 @@ inline void unwrap(llvm::Error &&e) {
     throw std::runtime_error(llvm::toString(std::move(e))); // LCOV_EXCL_LINE
 }
 
+/// Python __getitem__ helper: negative-index aware, raises IndexError (not a
+/// C++ crash) past the ends. Used by the iterable container bindings.
+template <typename T>
+T *nthOrThrow(const std::vector<T *> &items, Py_ssize_t i) {
+  Py_ssize_t n = static_cast<Py_ssize_t>(items.size());
+  if (i < 0)
+    i += n;
+  if (i < 0 || i >= n)
+    throw nb::index_error("index out of range");
+  return items[i];
+}
+
 } // namespace eudsl
 
 enum class CallingConvEnum : unsigned {

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -19,6 +19,7 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Target/TargetMachine.h>
 
+#include <nanobind/make_iterator.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -95,6 +96,28 @@ void populate_context(nb::module_ &m) {
                        out.push_back(&f);
                      return out;
                    })
+      .def("__len__",
+           [](eudsl::Module &self) {
+             return static_cast<Py_ssize_t>(std::distance(
+                 self.get().begin(), self.get().end()));
+           })
+      .def(
+          "__getitem__",
+          [](eudsl::Module &self, Py_ssize_t i) {
+            std::vector<llvm::Function *> out;
+            for (llvm::Function &f : self.get().functions())
+              out.push_back(&f);
+            return eudsl::nthOrThrow(out, i);
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "__iter__",
+          [](eudsl::Module &self) {
+            return nb::make_iterator<nb::rv_policy::reference>(
+                nb::type<eudsl::Module>(), "FunctionIterator",
+                self.get().begin(), self.get().end());
+          },
+          nb::keep_alive<0, 1>())
       .def(
           "get_function",
           [](eudsl::Module &self, const std::string &name) {

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -19,6 +19,8 @@
 #include <llvm/IR/User.h>
 #include <llvm/IR/Value.h>
 
+#include <nanobind/make_iterator.h>
+
 #include <vector>
 
 void populate_values(nb::module_ &m) {
@@ -58,7 +60,22 @@ void populate_values(nb::module_ &m) {
         for (unsigned i = 0, n = self.getNumOperands(); i < n; ++i)
           out.push_back(self.getOperand(i));
         return out;
-      });
+      })
+      .def("__len__",
+           [](llvm::User &self) {
+             return static_cast<Py_ssize_t>(self.getNumOperands());
+           })
+      .def(
+          "__getitem__",
+          [](llvm::User &self, Py_ssize_t i) -> llvm::Value * {
+            Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumOperands());
+            if (i < 0)
+              i += n;
+            if (i < 0 || i >= n)
+              throw nb::index_error("index out of range");
+            return self.getOperand(static_cast<unsigned>(i));
+          },
+          nb::rv_policy::reference_internal);
 
   // Structural spine of the Value hierarchy. These base classes are registered
   // bare so the concrete subclasses bound in Instructions.cpp / Constants.cpp
@@ -113,7 +130,28 @@ void populate_values(nb::module_ &m) {
         for (llvm::Instruction &i : self)
           out.push_back(&i);
         return out;
-      });
+      })
+      .def("__len__",
+           [](llvm::BasicBlock &self) {
+             return static_cast<Py_ssize_t>(self.size());
+           })
+      .def(
+          "__getitem__",
+          [](llvm::BasicBlock &self, Py_ssize_t i) {
+            std::vector<llvm::Instruction *> out;
+            for (llvm::Instruction &inst : self)
+              out.push_back(&inst);
+            return eudsl::nthOrThrow(out, i);
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "__iter__",
+          [](llvm::BasicBlock &self) {
+            return nb::make_iterator<nb::rv_policy::reference>(
+                nb::type<llvm::BasicBlock>(), "InstructionIterator",
+                self.begin(), self.end());
+          },
+          nb::keep_alive<0, 1>());
 
   nb::class_<llvm::Function, llvm::GlobalObject>(m, "Function")
       .EUDSL_CAST_CTOR(llvm::Function, llvm::Value)
@@ -148,6 +186,27 @@ void populate_values(nb::module_ &m) {
                        out.push_back(&b);
                      return out;
                    })
+      .def("__len__",
+           [](llvm::Function &self) {
+             return static_cast<Py_ssize_t>(self.size());
+           })
+      .def(
+          "__getitem__",
+          [](llvm::Function &self, Py_ssize_t i) {
+            std::vector<llvm::BasicBlock *> out;
+            for (llvm::BasicBlock &b : self)
+              out.push_back(&b);
+            return eudsl::nthOrThrow(out, i);
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "__iter__",
+          [](llvm::Function &self) {
+            return nb::make_iterator<nb::rv_policy::reference>(
+                nb::type<llvm::Function>(), "BasicBlockIterator", self.begin(),
+                self.end());
+          },
+          nb::keep_alive<0, 1>())
       .def_prop_ro(
           "entry_block",
           [](llvm::Function &self) -> llvm::BasicBlock * {

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -75,7 +75,15 @@ void populate_values(nb::module_ &m) {
               throw nb::index_error("index out of range");
             return self.getOperand(static_cast<unsigned>(i));
           },
-          nb::rv_policy::reference_internal);
+          nb::rv_policy::reference_internal)
+      .def(
+          "__iter__",
+          [](llvm::User &self) {
+            return nb::make_iterator<nb::rv_policy::reference>(
+                nb::type<llvm::User>(), "OperandIterator",
+                self.value_op_begin(), self.value_op_end());
+          },
+          nb::keep_alive<0, 1>());
 
   // Structural spine of the Value hierarchy. These base classes are registered
   // bare so the concrete subclasses bound in Instructions.cpp / Constants.cpp

--- a/projects/eudsl-llvmpy/tests/test_iteration.py
+++ b/projects/eudsl-llvmpy/tests/test_iteration.py
@@ -1,0 +1,75 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""MLIR-style iteration ergonomics: len(), indexing, and `for x in container`.
+
+Module iterates its functions, Function its basic blocks, BasicBlock its
+instructions, and User its operands. Each supports len(), negative and
+bounds-checked __getitem__ (IndexError past the ends), and iteration.
+"""
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @f(i32 %x, i32 %y) {
+    entry:
+      %sum = add i32 %x, %y
+      ret i32 %sum
+    }
+    define void @g() {
+    entry:
+      ret void
+    }
+    """
+)
+
+
+def test_iteration_and_indexing():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+
+        # Module -> functions
+        fns = list(mod)
+        assert [f.name for f in fns] == ["f", "g"]
+        assert len(mod) == 2
+        assert mod[0] == fns[0]
+        assert mod[-1] == fns[1]
+        with pytest.raises(IndexError):
+            _ = mod[2]
+
+        f = mod.get_function("f")
+
+        # Function -> basic blocks
+        bbs = list(f)
+        assert len(f) == 1
+        assert f[0] == f.entry_block
+        assert f[-1] == bbs[-1]
+        with pytest.raises(IndexError):
+            _ = f[5]
+
+        # BasicBlock -> instructions
+        entry = f.entry_block
+        insts = list(entry)
+        assert len(entry) == 2  # add, ret
+        assert entry[0] == insts[0]
+        assert entry[-1] == entry.terminator
+        with pytest.raises(IndexError):
+            _ = entry[2]
+
+        # User -> operands
+        add = insts[0]
+        ops = list(add)
+        assert len(add) == add.num_operands == 2
+        assert add[0] == add.operand(0)
+        assert add[-1] == add.operand(1)
+        assert ops[0] == f.arg(0)
+        with pytest.raises(IndexError):
+            _ = add[2]
+
+        del f, entry, fns, bbs, insts, add, ops, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_iteration.py
+++ b/projects/eudsl-llvmpy/tests/test_iteration.py
@@ -16,6 +16,7 @@ from llvm.testing import assert_no_leaks
 
 _SRC = dedent(
     """\
+    declare i32 @ext(i32)
     define i32 @f(i32 %x, i32 %y) {
     entry:
       %sum = add i32 %x, %y
@@ -35,12 +36,24 @@ def test_iteration_and_indexing():
 
         # Module -> functions
         fns = list(mod)
-        assert [f.name for f in fns] == ["f", "g"]
-        assert len(mod) == 2
+        assert [f.name for f in fns] == ["ext", "f", "g"]
+        assert len(mod) == 3
         assert mod[0] == fns[0]
-        assert mod[-1] == fns[1]
+        assert mod[-1] == fns[-1]
+        assert list(mod) == list(mod)  # __iter__ yields a fresh iterator
         with pytest.raises(IndexError):
-            _ = mod[2]
+            _ = mod[3]
+        with pytest.raises(IndexError):
+            _ = mod[-100]  # still negative after i += n
+        with pytest.raises(TypeError):
+            _ = mod[0:1]  # slicing is not supported
+
+        # A declaration is the empty case for every protocol method.
+        ext = mod.get_function("ext")
+        assert len(ext) == 0
+        assert list(ext) == []
+        with pytest.raises(IndexError):
+            _ = ext[0]
 
         f = mod.get_function("f")
 
@@ -51,6 +64,8 @@ def test_iteration_and_indexing():
         assert f[-1] == bbs[-1]
         with pytest.raises(IndexError):
             _ = f[5]
+        with pytest.raises(IndexError):
+            _ = f[-100]
 
         # BasicBlock -> instructions
         entry = f.entry_block
@@ -60,6 +75,8 @@ def test_iteration_and_indexing():
         assert entry[-1] == entry.terminator
         with pytest.raises(IndexError):
             _ = entry[2]
+        with pytest.raises(IndexError):
+            _ = entry[-100]
 
         # User -> operands
         add = insts[0]
@@ -67,9 +84,13 @@ def test_iteration_and_indexing():
         assert len(add) == add.num_operands == 2
         assert add[0] == add.operand(0)
         assert add[-1] == add.operand(1)
+        # Full operand order, via the explicit __iter__ (not the getitem fallback).
+        assert ops == [add.operand(0), add.operand(1)]
         assert ops[0] == f.arg(0)
         with pytest.raises(IndexError):
             _ = add[2]
+        with pytest.raises(IndexError):
+            _ = add[-100]
 
-        del f, entry, fns, bbs, insts, add, ops, mod
+        del f, entry, ext, fns, bbs, insts, add, ops, mod
     assert_no_leaks()


### PR DESCRIPTION
Make the containers first-class Python sequences: len(), negative and
bounds-checked __getitem__ (IndexError past the ends), and __iter__. Module
iterates its functions, Function its basic blocks, BasicBlock its
instructions, User its operands. __iter__ uses nb::make_iterator with an
explicit rv_policy::reference (the elements are non-copyable llvm objects, so
the default copy policy aborts). A shared nthOrThrow helper does the
negative-index/IndexError handling.
