### PR TITLE
[eudsl-llvmpy] MLIR parity: use-def edges, replace_all_uses_except, walk()

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -65,6 +65,15 @@ enum class CallingConvEnum : unsigned {
   COLD = llvm::CallingConv::Cold,
 };
 
+/// MLIR-style checked-downcast constructor, chained onto an nb::class_:
+///   nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType")
+///       .EUDSL_CAST_CTOR(llvm::IntegerType, llvm::Type)
+/// makes `IntegerType(v)` re-type v when isa<IntegerType>(v), else raise
+/// ValueError -- the parity analogue of MLIR's `IntegerType(t)`. The result
+/// borrows v's non-owning pointer; keep_alive<0,1> keeps the source (and thus
+/// the owning Context/Module) alive for the new wrapper's lifetime, and
+/// rv_policy::reference stops nanobind from trying to delete a context-owned
+/// object.
 #define EUDSL_CAST_CTOR(Derived, Base)                                         \
   def(nb::new_([](Base *v) -> Derived * {                                      \
         if (auto *d = llvm::dyn_cast_or_null<Derived>(v))                      \

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -15,15 +15,25 @@
 #include <llvm/IR/GlobalObject.h>
 #include <llvm/IR/GlobalValue.h>
 #include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/InstIterator.h>
 #include <llvm/IR/Instruction.h>
+#include <llvm/IR/Use.h>
 #include <llvm/IR/User.h>
 #include <llvm/IR/Value.h>
 
 #include <nanobind/make_iterator.h>
 
+#include <algorithm>
 #include <vector>
 
 void populate_values(nb::module_ &m) {
+  // A def-use edge: which User uses a value, and at which operand index.
+  nb::class_<llvm::Use>(m, "Use")
+      .def_prop_ro(
+          "user", [](llvm::Use &self) { return self.getUser(); },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("operand_number", &llvm::Use::getOperandNo);
+
   nb::class_<llvm::Value>(m, "Value")
       .def_prop_rw(
           "name", [](llvm::Value &self) { return self.getName().str(); },
@@ -36,7 +46,24 @@ void populate_values(nb::module_ &m) {
                      return std::vector<llvm::User *>(self.user_begin(),
                                                       self.user_end());
                    })
+      .def_prop_ro("uses",
+                   [](llvm::Value &self) {
+                     std::vector<llvm::Use *> out;
+                     for (llvm::Use &u : self.uses())
+                       out.push_back(&u);
+                     return out;
+                   })
       .def("replace_all_uses_with", &llvm::Value::replaceAllUsesWith, "value"_a)
+      .def(
+          "replace_all_uses_except",
+          [](llvm::Value &self, llvm::Value *newValue,
+             std::vector<llvm::User *> exceptions) {
+            self.replaceUsesWithIf(newValue, [&](llvm::Use &u) {
+              return std::find(exceptions.begin(), exceptions.end(),
+                               u.getUser()) == exceptions.end();
+            });
+          },
+          "value"_a, "exceptions"_a)
       .def("__str__", [](llvm::Value &self) { return eudsl::toString(self); })
       .def("__eq__",
            [](llvm::Value &self, nb::handle other) {
@@ -229,6 +256,16 @@ void populate_values(nb::module_ &m) {
             return llvm::BasicBlock::Create(self.getContext(), name, &self);
           },
           "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "walk",
+          [](llvm::Function &self) {
+            // Every instruction in the function, in block then program order --
+            // the LLVM analogue of MLIR's op.walk() over a single region.
+            return nb::make_iterator<nb::rv_policy::reference>(
+                nb::type<llvm::Function>(), "WalkIterator",
+                llvm::inst_begin(self), llvm::inst_end(self));
+          },
+          nb::keep_alive<0, 1>())
       .def_prop_rw("linkage", &llvm::Function::getLinkage,
                    &llvm::Function::setLinkage)
       .def_prop_rw("visibility", &llvm::Function::getVisibility,

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -58,6 +58,11 @@ void populate_values(nb::module_ &m) {
           "replace_all_uses_except",
           [](llvm::Value &self, llvm::Value *newValue,
              std::vector<llvm::User *> exceptions) {
+            // replaceUsesWithIf asserts the types match and would otherwise
+            // abort the interpreter; reject the mismatch as a Python error.
+            if (newValue->getType() != self.getType())
+              throw nb::value_error(
+                  "replacement value type does not match the value's type");
             self.replaceUsesWithIf(newValue, [&](llvm::Use &u) {
               return std::find(exceptions.begin(), exceptions.end(),
                                u.getUser()) == exceptions.end();

--- a/projects/eudsl-llvmpy/tests/test_use_def.py
+++ b/projects/eudsl-llvmpy/tests/test_use_def.py
@@ -51,7 +51,7 @@ def test_replace_all_uses_except():
         insts = list(f.entry_block)
         a, b, c = insts[0], insts[1], insts[2]
         assert a.num_uses == 2  # used by %b and %c
-        zero = llvm.const_int(llvm.i32(ctx), 0)
+        zero = llvm.const_int(llvm.types.i32(ctx), 0)
         a.replace_all_uses_except(zero, [b])
         printed = str(mod)
         assert "%b = add i32 %a, 2" in printed  # kept (b was excepted)

--- a/projects/eudsl-llvmpy/tests/test_use_def.py
+++ b/projects/eudsl-llvmpy/tests/test_use_def.py
@@ -1,0 +1,95 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""MLIR-parity use-def APIs: Value.uses (Use edges), replace_all_uses_except,
+and Function.walk()."""
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_use_edges():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            "define i32 @f(i32 %x, i32 %y) {\n"
+            "entry:\n  %sum = add i32 %x, %y\n  ret i32 %sum\n}\n",
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        x = f.arg(0)
+        add = x.users[0]
+        uses = x.uses
+        assert len(uses) == 1
+        assert uses[0].user == add
+        assert uses[0].operand_number == 0  # %x is operand 0 of the add
+        # %y is operand 1.
+        assert f.arg(1).uses[0].operand_number == 1
+        del f, x, add, uses, mod
+    assert_no_leaks()
+
+
+def test_replace_all_uses_except():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                define i32 @f(i32 %x) {
+                entry:
+                  %a = add i32 %x, 1
+                  %b = add i32 %a, 2
+                  %c = add i32 %a, 3
+                  ret i32 %b
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        insts = list(f.entry_block)
+        a, b, c = insts[0], insts[1], insts[2]
+        assert a.num_uses == 2  # used by %b and %c
+        zero = llvm.const_int(llvm.i32(ctx), 0)
+        a.replace_all_uses_except(zero, [b])
+        printed = str(mod)
+        assert "%b = add i32 %a, 2" in printed  # kept (b was excepted)
+        assert "%c = add i32 0, 3" in printed  # replaced
+        assert a.num_uses == 1
+        del f, insts, a, b, c, zero, mod
+    assert_no_leaks()
+
+
+def test_function_walk():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                define i32 @f(i32 %x) {
+                entry:
+                  %a = add i32 %x, 1
+                  br label %next
+                next:
+                  %b = mul i32 %a, 2
+                  ret i32 %b
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        # walk() flattens all instructions across every block, in order.
+        walked = list(f.walk())
+        assert [type(i).__name__ for i in walked] == [
+            "BinaryOperator",  # add (entry)
+            "UncondBrInst",  # br  (entry)
+            "BinaryOperator",  # mul (next)
+            "ReturnInst",  # ret (next)
+        ]
+        # Same instructions as concatenating the blocks.
+        by_block = [i for bb in f for i in bb]
+        assert walked == by_block
+        del f, walked, by_block, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_use_def.py
+++ b/projects/eudsl-llvmpy/tests/test_use_def.py
@@ -5,59 +5,127 @@
 and Function.walk()."""
 from textwrap import dedent
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
+
+_EDGE_SRC = (
+    "define i32 @f(i32 %x, i32 %y) {\n"
+    "entry:\n  %sum = add i32 %x, %y\n  ret i32 %sum\n}\n"
+)
+
+_RAUW_SRC = dedent(
+    """\
+    define i32 @f(i32 %x) {
+    entry:
+      %a = add i32 %x, 1
+      %b = add i32 %a, 2
+      %c = add i32 %a, 3
+      ret i32 %b
+    }
+    """
+)
 
 
 def test_use_edges():
     with llvm.Context() as ctx:
-        mod = llvm.parse_assembly(
-            "define i32 @f(i32 %x, i32 %y) {\n"
-            "entry:\n  %sum = add i32 %x, %y\n  ret i32 %sum\n}\n",
-            ctx,
-            "m",
-        )
+        mod = llvm.parse_assembly(_EDGE_SRC, ctx, "m")
         f = mod.get_function("f")
         x = f.arg(0)
         add = x.users[0]
         uses = x.uses
-        assert len(uses) == 1
+        assert len(uses) == x.num_uses == 1
         assert uses[0].user == add
+        # The Use.user edge is downcast to its concrete subclass, not left as
+        # the base Value -- pointer-equality above cannot catch that regression.
+        assert type(uses[0].user).__name__ == "BinaryOperator"
         assert uses[0].operand_number == 0  # %x is operand 0 of the add
         # %y is operand 1.
         assert f.arg(1).uses[0].operand_number == 1
-        del f, x, add, uses, mod
+        # A value with no uses: the (void) terminator.
+        term = f.entry_block.terminator
+        assert term.num_uses == 0
+        assert list(term.uses) == []
+        del f, x, add, uses, term, mod
+    assert_no_leaks()
+
+
+def test_uses_usable_without_value_handle():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_EDGE_SRC, ctx, "m")
+        # The module owns the use list, so `.uses` (and its Use edges) stay
+        # valid without holding the intermediate function/argument handle -- as
+        # with every other reference accessor, lifetime is bounded by the module.
+        uses = mod.get_function("f").arg(0).uses
+        assert len(uses) == 1
+        assert uses[0].operand_number == 0
+        assert type(uses[0].user).__name__ == "BinaryOperator"
+        del uses, mod
     assert_no_leaks()
 
 
 def test_replace_all_uses_except():
     with llvm.Context() as ctx:
-        mod = llvm.parse_assembly(
-            dedent(
-                """\
-                define i32 @f(i32 %x) {
-                entry:
-                  %a = add i32 %x, 1
-                  %b = add i32 %a, 2
-                  %c = add i32 %a, 3
-                  ret i32 %b
-                }
-                """
-            ),
-            ctx,
-            "m",
-        )
+        mod = llvm.parse_assembly(_RAUW_SRC, ctx, "m")
         f = mod.get_function("f")
-        insts = list(f.entry_block)
-        a, b, c = insts[0], insts[1], insts[2]
-        assert a.num_uses == 2  # used by %b and %c
-        zero = llvm.const_int(llvm.types.i32(ctx), 0)
-        a.replace_all_uses_except(zero, [b])
+        x = f.arg(0)
+        a, b, c = list(f.entry_block)[:3]
+        # Consistency of the count accessors on a >1-use value.
+        assert a.num_uses == len(a.uses) == 2  # used by %b and %c
+        assert x.num_uses == 1  # used by %a
+        # Replace with a non-constant (the argument) so BOTH sides are checkable
+        # via the API: %a loses a use, %x gains one. (Constants don't track uses.)
+        a.replace_all_uses_except(x, [b])
+        assert a.num_uses == 1  # only %b now
+        assert x.num_uses == 2  # %a and the rewritten %c
         printed = str(mod)
         assert "%b = add i32 %a, 2" in printed  # kept (b was excepted)
-        assert "%c = add i32 0, 3" in printed  # replaced
-        assert a.num_uses == 1
-        del f, insts, a, b, c, zero, mod
+        assert "%c = add i32 %x, 3" in printed  # replaced
+        del f, x, a, b, c, mod
+    assert_no_leaks()
+
+
+def test_replace_all_uses_except_empty_is_full_rauw():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_RAUW_SRC, ctx, "m")
+        f = mod.get_function("f")
+        x = f.arg(0)
+        a, b, c = list(f.entry_block)[:3]
+        # No exceptions -> every use of %a is replaced (== replace_all_uses_with).
+        a.replace_all_uses_except(x, [])
+        assert a.num_uses == 0
+        assert x.num_uses == 3  # %a plus the rewritten %b and %c
+        del f, x, a, b, c, mod
+    assert_no_leaks()
+
+
+def test_replace_all_uses_except_all_users_excepted_is_noop():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_RAUW_SRC, ctx, "m")
+        f = mod.get_function("f")
+        x = f.arg(0)
+        a, b, c = list(f.entry_block)[:3]
+        # Every user of %a is excepted -> nothing changes.
+        a.replace_all_uses_except(x, [b, c])
+        assert a.num_uses == 2
+        assert x.num_uses == 1
+        del f, x, a, b, c, mod
+    assert_no_leaks()
+
+
+def test_replace_all_uses_except_type_mismatch_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_RAUW_SRC, ctx, "m")
+        f = mod.get_function("f")
+        a, b, _ = list(f.entry_block)[:3]
+        # A mismatched type would trip LLVM's assert and abort the interpreter;
+        # the binding must reject it as a Python error instead.
+        wrong_type = llvm.const_int(llvm.types.i1(ctx), 0)
+        with pytest.raises(ValueError, match="type does not match"):
+            a.replace_all_uses_except(wrong_type, [b])
+        assert a.num_uses == 2  # unchanged
+        del f, a, b, wrong_type, mod
     assert_no_leaks()
 
 
@@ -92,4 +160,14 @@ def test_function_walk():
         by_block = [i for bb in f for i in bb]
         assert walked == by_block
         del f, walked, by_block, mod
+    assert_no_leaks()
+
+
+def test_function_walk_declaration_is_empty():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly("declare i32 @ext(i32)\n", ctx, "m")
+        ext = mod.get_function("ext")
+        # A declaration has no body -> walk() yields nothing.
+        assert list(ext.walk()) == []
+        del ext, mod
     assert_no_leaks()


### PR DESCRIPTION
- Value.uses returns Use edge objects, each exposing .user and
  .operand_number (mirrors MLIR's value.uses).
- Value.replace_all_uses_except(new, exceptions) rewrites every use except
  those in the given users, via LLVM replaceUsesWithIf.
- Function.walk() iterates every instruction across all blocks in order
  (llvm::inst_begin/inst_end), the LLVM analogue of MLIR's op.walk().
