### PR TITLE
[eudsl-llvmpy] MLIR parity: constant/global accessors

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -45,13 +45,28 @@ void populate_constants(nb::module_ &m) {
       m, "ConstantDataSequential")
       .def_prop_ro("num_elements", &llvm::ConstantDataSequential::getNumElements)
       .def("get_element_as_int",
-           [](llvm::ConstantDataSequential &self, unsigned i) {
-             return self.getElementAsInteger(i);
+           [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
+             // getElementAsInteger asserts (aborts the process) on a bad index
+             // or a non-integer element type; surface both as catchable Python
+             // errors instead.
+             Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
+             if (i < 0 || i >= n)
+               throw nb::index_error("element index out of range");
+             if (!self.getElementType()->isIntegerTy())
+               throw nb::value_error("element type is not an integer");
+             return self.getElementAsInteger(static_cast<unsigned>(i));
            },
            "index"_a)
       .def("get_element_as_double",
-           [](llvm::ConstantDataSequential &self, unsigned i) {
-             return self.getElementAsDouble(i);
+           [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
+             // getElementAsDouble likewise asserts on a bad index or a
+             // non-double element type.
+             Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
+             if (i < 0 || i >= n)
+               throw nb::index_error("element index out of range");
+             if (!self.getElementType()->isDoubleTy())
+               throw nb::value_error("element type is not double");
+             return self.getElementAsDouble(static_cast<unsigned>(i));
            },
            "index"_a)
       .def_prop_ro("is_string",

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -42,13 +42,45 @@ void populate_constants(nb::module_ &m) {
   nb::class_<llvm::ConstantStruct, llvm::ConstantAggregate>(m, "ConstantStruct");
   nb::class_<llvm::ConstantVector, llvm::ConstantAggregate>(m, "ConstantVector");
   nb::class_<llvm::ConstantDataSequential, llvm::ConstantData>(
-      m, "ConstantDataSequential");
+      m, "ConstantDataSequential")
+      .def_prop_ro("num_elements", &llvm::ConstantDataSequential::getNumElements)
+      .def("get_element_as_int",
+           [](llvm::ConstantDataSequential &self, unsigned i) {
+             return self.getElementAsInteger(i);
+           },
+           "index"_a)
+      .def("get_element_as_double",
+           [](llvm::ConstantDataSequential &self, unsigned i) {
+             return self.getElementAsDouble(i);
+           },
+           "index"_a)
+      .def_prop_ro("is_string",
+                   [](llvm::ConstantDataSequential &self) {
+                     return self.isString();
+                   })
+      .def_prop_ro("as_string",
+                   [](llvm::ConstantDataSequential &self) -> std::string {
+                     if (!self.isString())
+                       throw nb::value_error("not a string constant");
+                     return self.getAsString().str();
+                   });
   nb::class_<llvm::ConstantDataArray, llvm::ConstantDataSequential>(
       m, "ConstantDataArray");
   nb::class_<llvm::ConstantDataVector, llvm::ConstantDataSequential>(
       m, "ConstantDataVector");
-  nb::class_<llvm::ConstantExpr, llvm::Constant>(m, "ConstantExpr");
-  nb::class_<llvm::BlockAddress, llvm::Constant>(m, "BlockAddress");
+  nb::class_<llvm::ConstantExpr, llvm::Constant>(m, "ConstantExpr")
+      .def_prop_ro("opcode_name", [](llvm::ConstantExpr &self) {
+        return std::string(self.getOpcodeName());
+      });
+  nb::class_<llvm::BlockAddress, llvm::Constant>(m, "BlockAddress")
+      .def_prop_ro(
+          "function",
+          [](llvm::BlockAddress &self) { return self.getFunction(); },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "basic_block",
+          [](llvm::BlockAddress &self) { return self.getBasicBlock(); },
+          nb::rv_policy::reference_internal);
 
   nb::class_<llvm::GlobalVariable, llvm::GlobalObject>(m, "GlobalVariable")
       .EUDSL_CAST_CTOR(llvm::GlobalVariable, llvm::Value)
@@ -59,8 +91,20 @@ void populate_constants(nb::module_ &m) {
             return self.hasInitializer() ? self.getInitializer() : nullptr;
           },
           nb::rv_policy::reference_internal);
-  nb::class_<llvm::GlobalAlias, llvm::GlobalValue>(m, "GlobalAlias");
-  nb::class_<llvm::GlobalIFunc, llvm::GlobalObject>(m, "GlobalIFunc");
+  nb::class_<llvm::GlobalAlias, llvm::GlobalValue>(m, "GlobalAlias")
+      .def_prop_ro(
+          "aliasee",
+          [](llvm::GlobalAlias &self) -> llvm::Constant * {
+            return self.getAliasee();
+          },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::GlobalIFunc, llvm::GlobalObject>(m, "GlobalIFunc")
+      .def_prop_ro(
+          "resolver",
+          [](llvm::GlobalIFunc &self) -> llvm::Constant * {
+            return self.getResolver();
+          },
+          nb::rv_policy::reference_internal);
 
   m.def(
       "const_int",

--- a/projects/eudsl-llvmpy/tests/test_const_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_const_accessors.py
@@ -16,6 +16,7 @@ _SRC = dedent(
     """\
     @g = global i32 7
     @darr = global [4 x i8] c"abcd"
+    @sbytes = global [2 x i8] c"\\FF\\7F"
     @dvec = global <4 x i32> <i32 10, i32 20, i32 30, i32 40>
     @fvec = global <2 x double> <double 1.5, double 2.5>
     @ce = global i64 ptrtoint (ptr @g to i64)
@@ -29,6 +30,7 @@ _SRC = dedent(
       br label %b
     b:
       %d = load i8, ptr @darr
+      %sb = load i8, ptr @sbytes
       %v = load i32, ptr @dvec
       %fv = load double, ptr @fvec
       %c = load i64, ptr @ce
@@ -41,44 +43,128 @@ _SRC = dedent(
 )
 
 
-def test_constant_and_global_accessors():
-    with llvm.Context() as ctx:
-        mod = llvm.parse_assembly(_SRC, ctx, "m")
-        f = mod.get_function("f")
-        ptr_of = {}  # global name -> its pointer operand (the global/alias/ifunc)
-        for i in f.walk():
-            if isinstance(i, llvm.LoadInst):
-                g = i.pointer_operand
-                ptr_of[g.name] = g
+def _globals(ctx):
+    """Parse _SRC and map each global's name to the pointer operand (the
+    global/alias/ifunc) of the load that reads it."""
+    mod = llvm.parse_assembly(_SRC, ctx, "m")
+    f = mod.get_function("f")
+    ptr_of = {}
+    for i in f.walk():
+        if isinstance(i, llvm.LoadInst):
+            g = i.pointer_operand
+            ptr_of[g.name] = g
+    return mod, ptr_of
 
+
+def test_constant_data_array_string():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         darr = ptr_of["darr"].initializer  # ConstantDataArray
         assert darr.num_elements == 4
         assert darr.get_element_as_int(0) == ord("a")
         assert darr.is_string
         assert darr.as_string == "abcd"
+        del mod, ptr_of, darr
+    assert_no_leaks()
 
+
+def test_get_element_as_int_is_unsigned():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
+        # get_element_as_int has only the unsigned form (unlike ConstantInt's
+        # value/zext_value): a high-bit byte reads unsigned, not sign-extended.
+        sbytes = ptr_of["sbytes"].initializer
+        assert sbytes.get_element_as_int(0) == 0xFF  # 255, not -1
+        assert sbytes.get_element_as_int(1) == 0x7F
+        del mod, ptr_of, sbytes
+    assert_no_leaks()
+
+
+def test_constant_data_vector_int():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         dvec = ptr_of["dvec"].initializer  # ConstantDataVector (ints)
         assert dvec.num_elements == 4
         assert dvec.get_element_as_int(1) == 20
+        del mod, ptr_of, dvec
+    assert_no_leaks()
 
+
+def test_constant_data_vector_double():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         fvec = ptr_of["fvec"].initializer  # ConstantDataVector (doubles)
         assert fvec.get_element_as_double(0) == 1.5
         assert not fvec.is_string
         with pytest.raises(ValueError, match="not a string"):
             _ = fvec.as_string
+        del mod, ptr_of, fvec
+    assert_no_leaks()
 
+
+def test_get_element_out_of_range_raises():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
+        dvec = ptr_of["dvec"].initializer  # 4 elements
+        fvec = ptr_of["fvec"].initializer  # 2 elements
+        # A bad index would trip LLVM's assert and abort the interpreter; the
+        # binding must raise IndexError instead.
+        with pytest.raises(IndexError):
+            dvec.get_element_as_int(4)
+        with pytest.raises(IndexError):
+            dvec.get_element_as_int(-1)
+        with pytest.raises(IndexError):
+            fvec.get_element_as_double(2)
+        del mod, ptr_of, dvec, fvec
+    assert_no_leaks()
+
+
+def test_get_element_wrong_type_raises():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
+        dvec = ptr_of["dvec"].initializer  # int elements
+        fvec = ptr_of["fvec"].initializer  # double elements
+        # Each accessor asserts its element type in LLVM; guard with ValueError.
+        with pytest.raises(ValueError, match="not double"):
+            dvec.get_element_as_double(0)
+        with pytest.raises(ValueError, match="not an integer"):
+            fvec.get_element_as_int(0)
+        del mod, ptr_of, dvec, fvec
+    assert_no_leaks()
+
+
+def test_constant_expr_opcode_name():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         ce = ptr_of["ce"].initializer  # ConstantExpr
         assert ce.opcode_name == "ptrtoint"
+        del mod, ptr_of, ce
+    assert_no_leaks()
 
+
+def test_block_address():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         ba = ptr_of["ba"].initializer  # BlockAddress
         assert ba.function.name == "f"
         assert ba.basic_block.name == "b"
+        del mod, ptr_of, ba
+    assert_no_leaks()
 
+
+def test_global_alias():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         al = ptr_of["al"]  # GlobalAlias
         assert al.aliasee.name == "g"
+        del mod, ptr_of, al
+    assert_no_leaks()
 
+
+def test_global_ifunc():
+    with llvm.Context() as ctx:
+        mod, ptr_of = _globals(ctx)
         ifu = ptr_of["if"]  # GlobalIFunc
         assert ifu.resolver.name == "res"
-
-        del f, ptr_of, darr, dvec, fvec, ce, ba, al, ifu, mod
+        del mod, ptr_of, ifu
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_const_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_const_accessors.py
@@ -1,0 +1,84 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Accessors for the constant/global kinds that were bare registrations:
+ConstantDataArray/Vector element and string access, ConstantExpr.opcode_name,
+BlockAddress.function/basic_block, GlobalAlias.aliasee, GlobalIFunc.resolver.
+"""
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    @g = global i32 7
+    @darr = global [4 x i8] c"abcd"
+    @dvec = global <4 x i32> <i32 10, i32 20, i32 30, i32 40>
+    @fvec = global <2 x double> <double 1.5, double 2.5>
+    @ce = global i64 ptrtoint (ptr @g to i64)
+    @al = alias i32, ptr @g
+    @res = global ptr null
+    @if = ifunc i32 (), ptr @res
+    @ba = global ptr blockaddress(@f, %b)
+
+    define i32 @f() {
+    entry:
+      br label %b
+    b:
+      %d = load i8, ptr @darr
+      %v = load i32, ptr @dvec
+      %fv = load double, ptr @fvec
+      %c = load i64, ptr @ce
+      %a = load i32, ptr @al
+      %i = load ptr, ptr @if
+      %bp = load ptr, ptr @ba
+      ret i32 0
+    }
+    """
+)
+
+
+def test_constant_and_global_accessors():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        ptr_of = {}  # global name -> its pointer operand (the global/alias/ifunc)
+        for i in f.walk():
+            if isinstance(i, llvm.LoadInst):
+                g = i.pointer_operand
+                ptr_of[g.name] = g
+
+        darr = ptr_of["darr"].initializer  # ConstantDataArray
+        assert darr.num_elements == 4
+        assert darr.get_element_as_int(0) == ord("a")
+        assert darr.is_string
+        assert darr.as_string == "abcd"
+
+        dvec = ptr_of["dvec"].initializer  # ConstantDataVector (ints)
+        assert dvec.num_elements == 4
+        assert dvec.get_element_as_int(1) == 20
+
+        fvec = ptr_of["fvec"].initializer  # ConstantDataVector (doubles)
+        assert fvec.get_element_as_double(0) == 1.5
+        assert not fvec.is_string
+        with pytest.raises(ValueError, match="not a string"):
+            _ = fvec.as_string
+
+        ce = ptr_of["ce"].initializer  # ConstantExpr
+        assert ce.opcode_name == "ptrtoint"
+
+        ba = ptr_of["ba"].initializer  # BlockAddress
+        assert ba.function.name == "f"
+        assert ba.basic_block.name == "b"
+
+        al = ptr_of["al"]  # GlobalAlias
+        assert al.aliasee.name == "g"
+
+        ifu = ptr_of["if"]  # GlobalIFunc
+        assert ifu.resolver.name == "res"
+
+        del f, ptr_of, darr, dvec, fvec, ce, ba, al, ifu, mod
+    assert_no_leaks()


### PR DESCRIPTION
Flesh out the bare constant/global registrations:
- ConstantDataSequential: num_elements, get_element_as_int/double, is_string,
  as_string (data is stored inline, so User's operand access gives nothing).
- ConstantExpr.opcode_name; BlockAddress.function/basic_block.
- GlobalAlias.aliasee; GlobalIFunc.resolver.

ConstantArray/ConstantStruct already get element access by inheriting the
User __len__/__getitem__ added in the iteration PR, so they need nothing more.
Note: is_string is wrapped in a lambda because isString has a default CharSize
argument a method pointer can't bind. A fuller Attribute/AttrBuilder surface
remains a candidate follow-up.
