### PR TITLE
[eudsl-llvmpy] MLIR parity: FileCheck-style IR assertions

### DIFF
--- a/.github/workflows/build_test_release_eudsl.yml
+++ b/.github/workflows/build_test_release_eudsl.yml
@@ -396,6 +396,10 @@ jobs:
 
           python -m pip install pytest pytest-cov
           python -m pip install eudsl-llvmpy eudsl-tblgen -f wheelhouse
+          # mlir-native-tools installs the FileCheck binary into sys.prefix/bin,
+          # which llvm.testing.filecheck_with_comments locates.
+          python -m pip install mlir-native-tools \
+            -f https://github.com/llvm/eudsl/releases/expanded_assets/llvm
 
       - name: "Test eudsl-llvmpy"
         run: |

--- a/.github/workflows/build_test_release_eudsl.yml
+++ b/.github/workflows/build_test_release_eudsl.yml
@@ -482,6 +482,12 @@ jobs:
             "nanobind==2.12.0" ninja "scikit-build-core==0.10.7" \
             typing_extensions numpy pytest pytest-cov
           $python3_command -m pip install eudsl-tblgen -f wheelhouse
+          # mlir-native-tools installs the FileCheck binary into sys.prefix/bin,
+          # which llvm.testing.filecheck_with_comments locates. Needed here too
+          # (not just the Test job) since this job's pytest run exercises the
+          # FileCheck-based tests as part of C++ coverage.
+          $python3_command -m pip install mlir-native-tools \
+            -f https://github.com/llvm/eudsl/releases/expanded_assets/llvm
 
           export CMAKE_PREFIX_PATH="$PWD/llvm-install"
           # llvm-cov/llvm-profdata must match the clang that instruments the

--- a/projects/eudsl-llvmpy/src/llvm/testing.py
+++ b/projects/eudsl-llvmpy/src/llvm/testing.py
@@ -4,6 +4,12 @@
 """Test helpers. Not imported by the llvm package itself."""
 
 import gc
+import inspect
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
 
 from . import Context
 
@@ -21,3 +27,48 @@ def assert_no_leaks():
     gc.collect()
     live = Context._get_live_count()
     assert live == 0, f"{live} Context object(s) still alive"
+
+
+def _find_filecheck():
+    """Locate the LLVM FileCheck binary. It ships in mlir-native-tools (into
+    sys.prefix/bin) and in the mlir_wheel LLVM distro (LLVM_BINDIR)."""
+    for cand in (
+        os.environ.get("FILECHECK"),
+        os.path.join(os.environ.get("LLVM_BINDIR", ""), "FileCheck"),
+        os.path.join(sys.prefix, "bin", "FileCheck"),
+        shutil.which("FileCheck"),
+    ):
+        if cand and os.path.isfile(cand):
+            return cand
+    raise RuntimeError(  # pragma: no cover
+        "FileCheck not found; install mlir-native-tools or set LLVM_BINDIR"
+    )
+
+
+def filecheck_with_comments(module):
+    """Validate a module's IR against the `# CHECK:` comments in the caller.
+
+    Mirrors eudsl-python-extras' filecheck_with_comments: the calling test
+    function's own source is the FileCheck check-file, so `# CHECK:` /
+    `# CHECK-NEXT:` / `# CHECK-NOT:` comments are matched (in order, with SSA
+    name binding) against the printed IR -- catching what a substring `in`
+    check cannot. Uses the real LLVM FileCheck binary.
+    """
+    printed = str(module)
+    caller = inspect.currentframe().f_back.f_code
+    fn_source = inspect.getsource(caller)
+    _, lnum = inspect.findsource(caller)
+    # Prepend blank lines so FileCheck's reported line numbers match the source.
+    check_content = "\n" * lnum + fn_source
+    filecheck = _find_filecheck()
+    with tempfile.NamedTemporaryFile("w", suffix=".txt") as check_file:
+        check_file.write(check_content)
+        check_file.flush()
+        proc = subprocess.run(
+            [filecheck, check_file.name],
+            input=printed,
+            capture_output=True,
+            text=True,
+        )
+    if proc.returncode != 0:
+        raise ValueError(f"FileCheck failed:\n{proc.stdout}\n{proc.stderr}")

--- a/projects/eudsl-llvmpy/src/llvm/testing.py
+++ b/projects/eudsl-llvmpy/src/llvm/testing.py
@@ -31,12 +31,14 @@ def assert_no_leaks():
 
 def _find_filecheck():
     """Locate the LLVM FileCheck binary. It ships in mlir-native-tools (into
-    sys.prefix/bin) and in the mlir_wheel LLVM distro (LLVM_BINDIR)."""
+    sys.prefix/bin, or sys.prefix/Scripts on Windows) and in the mlir_wheel LLVM
+    distro (LLVM_BINDIR)."""
     exe = "FileCheck.exe" if sys.platform == "win32" else "FileCheck"
     for cand in (
         os.environ.get("FILECHECK"),
         os.path.join(os.environ.get("LLVM_BINDIR", ""), exe),
         os.path.join(sys.prefix, "bin", exe),
+        os.path.join(sys.prefix, "Scripts", exe),  # Windows console-script dir
         shutil.which("FileCheck"),
     ):
         if cand and os.path.isfile(cand):
@@ -51,9 +53,10 @@ def filecheck_with_comments(module):
 
     Mirrors eudsl-python-extras' filecheck_with_comments: the calling test
     function's own source is the FileCheck check-file, so `# CHECK:` /
-    `# CHECK-NEXT:` / `# CHECK-NOT:` comments are matched (in order, with SSA
-    name binding) against the printed IR -- catching what a substring `in`
-    check cannot. Uses the real LLVM FileCheck binary.
+    `# CHECK-NEXT:` / `# CHECK-NOT:` comments are matched (in order, and with
+    `[[name:...]]`/`[[name]]` capture-variable binding) against the printed IR --
+    catching what a substring `in` check cannot. Uses the real LLVM FileCheck
+    binary.
     """
     printed = str(module)
     caller = inspect.currentframe().f_back.f_code
@@ -62,14 +65,20 @@ def filecheck_with_comments(module):
     # Prepend blank lines so FileCheck's reported line numbers match the source.
     check_content = "\n" * lnum + fn_source
     filecheck = _find_filecheck()
-    with tempfile.NamedTemporaryFile("w", suffix=".txt") as check_file:
-        check_file.write(check_content)
-        check_file.flush()
+    # Write the check-file and close it *before* invoking FileCheck: on Windows a
+    # still-open NamedTemporaryFile is locked exclusively and the subprocess
+    # cannot reopen the path. mkstemp + explicit close/unlink works everywhere.
+    fd, check_path = tempfile.mkstemp(suffix=".txt")
+    try:
+        with os.fdopen(fd, "w") as check_file:
+            check_file.write(check_content)
         proc = subprocess.run(
-            [filecheck, check_file.name],
+            [filecheck, check_path],
             input=printed,
             capture_output=True,
             text=True,
         )
+    finally:
+        os.unlink(check_path)
     if proc.returncode != 0:
         raise ValueError(f"FileCheck failed:\n{proc.stdout}\n{proc.stderr}")

--- a/projects/eudsl-llvmpy/src/llvm/testing.py
+++ b/projects/eudsl-llvmpy/src/llvm/testing.py
@@ -32,10 +32,11 @@ def assert_no_leaks():
 def _find_filecheck():
     """Locate the LLVM FileCheck binary. It ships in mlir-native-tools (into
     sys.prefix/bin) and in the mlir_wheel LLVM distro (LLVM_BINDIR)."""
+    exe = "FileCheck.exe" if sys.platform == "win32" else "FileCheck"
     for cand in (
         os.environ.get("FILECHECK"),
-        os.path.join(os.environ.get("LLVM_BINDIR", ""), "FileCheck"),
-        os.path.join(sys.prefix, "bin", "FileCheck"),
+        os.path.join(os.environ.get("LLVM_BINDIR", ""), exe),
+        os.path.join(sys.prefix, "bin", exe),
         shutil.which("FileCheck"),
     ):
         if cand and os.path.isfile(cand):

--- a/projects/eudsl-llvmpy/tests/test_builder.py
+++ b/projects/eudsl-llvmpy/tests/test_builder.py
@@ -4,7 +4,7 @@
 import pytest
 
 import llvm
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 
 def test_build_add_function():
@@ -17,10 +17,10 @@ def test_build_add_function():
         with b.at_end_of(bb):
             s = b.add(fn.arg(0), fn.arg(1), "s")
             b.ret(s)
-        printed = str(mod)
-        assert "define i32 @add2(i32 %0, i32 %1)" in printed
-        assert "%s = add i32 %0, %1" in printed
-        assert "ret i32 %s" in printed
+        # CHECK: define i32 @add2(i32 %0, i32 %1)
+        # CHECK:   %s = add i32 %0, %1
+        # CHECK-NEXT:   ret i32 %s
+        filecheck_with_comments(mod)
         del b, fn, bb, mod
     assert_no_leaks()
 
@@ -47,8 +47,10 @@ def test_build_conditional_with_phi():
             p.add_incoming(llvm.const_int(i32, 1), a)
             p.add_incoming(llvm.const_int(i32, 2), b_)
             bld.ret(p)
-        printed = str(mod)
-        assert "phi i32 [ 1, %a ], [ 2, %b ]" in printed
+        # CHECK:   br i1 %0, label %a, label %b
+        # CHECK:   %p = phi i32 [ 1, %a ], [ 2, %b ]
+        # CHECK-NEXT:   ret i32 %p
+        filecheck_with_comments(mod)
         del bld, fn, entry, a, b_, join, p, mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_filecheck.py
+++ b/projects/eudsl-llvmpy/tests/test_filecheck.py
@@ -22,6 +22,28 @@ def test_filecheck_matches_ordered():
     assert_no_leaks()
 
 
+def test_filecheck_binds_capture_variable():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        # A capture var bound on one line must match the same text later --
+        # this is the "SSA name binding" the docstring advertises.
+        # CHECK: %[[S:.*]] = add i32 %x, 1
+        # CHECK: ret i32 %[[S]]
+        filecheck_with_comments(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_filecheck_check_not_passes_when_absent():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        # CHECK: define i32 @f
+        # CHECK-NOT: fdiv
+        filecheck_with_comments(mod)
+        del mod
+    assert_no_leaks()
+
+
 def _check_absent_pattern(mod):
     # CHECK: this text is definitely not in the emitted IR 9f3a2b
     filecheck_with_comments(mod)
@@ -30,7 +52,42 @@ def _check_absent_pattern(mod):
 def test_filecheck_reports_mismatch():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly(_SRC, ctx, "m")
-        with pytest.raises(ValueError, match="FileCheck failed"):
+        # Match the actual content-mismatch diagnostic, not just the "FileCheck
+        # failed" wrapper (which also fires for invocation errors like a missing
+        # directive) -- so a broken directive extraction can't slip through.
+        with pytest.raises(ValueError, match="expected string not found in input"):
             _check_absent_pattern(mod)
+        del mod
+    assert_no_leaks()
+
+
+def _check_not_present_pattern(mod):
+    # CHECK: define i32 @f
+    # CHECK-NOT: add
+    filecheck_with_comments(mod)
+
+
+def test_filecheck_check_not_fails_when_present():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        # CHECK-NOT has inverted semantics: it must FAIL because `add` is present.
+        with pytest.raises(ValueError, match="excluded string found"):
+            _check_not_present_pattern(mod)
+        del mod
+    assert_no_leaks()
+
+
+def _check_no_directives(mod):
+    # no directives in this function, so FileCheck finds no check strings
+    filecheck_with_comments(mod)
+
+
+def test_filecheck_no_directives_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        # The safety property that stops a mistyped/directive-less call from
+        # silently passing: FileCheck errors when there are no check strings.
+        with pytest.raises(ValueError, match="no check strings found"):
+            _check_no_directives(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_filecheck.py
+++ b/projects/eudsl-llvmpy/tests/test_filecheck.py
@@ -1,0 +1,36 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The filecheck_with_comments harness itself: it matches ordered # CHECK
+directives against printed IR and fails on a mismatch (unlike substring `in`)."""
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks, filecheck_with_comments
+
+_SRC = "define i32 @f(i32 %x) {\nentry:\n  %s = add i32 %x, 1\n  ret i32 %s\n}\n"
+
+
+def test_filecheck_matches_ordered():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        # CHECK: define i32 @f(i32 %x)
+        # CHECK:   %s = add i32 %x, 1
+        # CHECK-NEXT:   ret i32 %s
+        filecheck_with_comments(mod)
+        del mod
+    assert_no_leaks()
+
+
+def _check_absent_pattern(mod):
+    # CHECK: this text is definitely not in the emitted IR 9f3a2b
+    filecheck_with_comments(mod)
+
+
+def test_filecheck_reports_mismatch():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        with pytest.raises(ValueError, match="FileCheck failed"):
+            _check_absent_pattern(mod)
+        del mod
+    assert_no_leaks()


### PR DESCRIPTION
Add llvm.testing.filecheck_with_comments, mirroring eudsl-python-extras: the
calling test's own # CHECK:/# CHECK-NEXT: comments are matched (in order,
with SSA-name binding) against the printed IR by the real LLVM FileCheck
binary -- catching ordering/adjacency bugs a substring 'in' check misses.
FileCheck is located from mlir-native-tools (sys.prefix/bin), the mlir_wheel
distro (LLVM_BINDIR), or PATH.

Convert test_builder.py to CHECK-style and add test_filecheck.py (match +
mismatch). Wire the test-eudsl-llvmpy CI job to install mlir-native-tools so
FileCheck is present.
