### PR TITLE
[eudsl-llvmpy] MLIR parity: lazy sequence views for traversal

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -112,6 +112,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Types.cpp
   src/IR/Kinds.cpp
   src/IR/Values.cpp
+  src/IR/Sequence.cpp
   src/IR/Instructions.cpp
   src/IR/Constants.cpp
   src/IR/Builder.cpp

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -5,6 +5,7 @@
 #include "IR/Common.h"
 #include "IR/Errors.h"
 #include "IR/Ownership.h"
+#include "IR/Sequence.h"
 #include "IR/TargetInit.h"
 
 #include <llvm/AsmParser/Parser.h>
@@ -89,13 +90,23 @@ void populate_context(nb::module_ &m) {
           "context",
           [](eudsl::Module &self) -> eudsl::Context & { return self.context(); },
           nb::rv_policy::reference_internal)
-      .def_prop_ro("functions",
-                   [](eudsl::Module &self) {
-                     std::vector<llvm::Function *> out;
-                     for (llvm::Function &f : self.get().functions())
-                       out.push_back(&f);
-                     return out;
-                   })
+      .def_prop_ro(
+          "functions",
+          [](eudsl::Module &self) {
+            llvm::Module *mod = &self.get();
+            eudsl::Sequence<llvm::Function> seq;
+            seq.length = [mod] {
+              return static_cast<std::size_t>(
+                  std::distance(mod->begin(), mod->end()));
+            };
+            seq.at = [mod](std::size_t i) {
+              auto it = mod->begin();
+              std::advance(it, i);
+              return &*it;
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
       .def("__len__",
            [](eudsl::Module &self) {
              return static_cast<Py_ssize_t>(std::distance(

--- a/projects/eudsl-llvmpy/src/IR/Sequence.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.cpp
@@ -1,0 +1,23 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Sequence.h"
+
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instruction.h>
+#include <llvm/IR/Use.h>
+#include <llvm/IR/User.h>
+#include <llvm/IR/Value.h>
+
+void populate_sequences(nb::module_ &m) {
+  eudsl::bindSequence<llvm::Function>(m, "FunctionSequence");
+  eudsl::bindSequence<llvm::BasicBlock>(m, "BasicBlockSequence");
+  eudsl::bindSequence<llvm::Argument>(m, "ArgumentSequence");
+  eudsl::bindSequence<llvm::Instruction>(m, "InstructionSequence");
+  eudsl::bindSequence<llvm::Value>(m, "ValueSequence");
+  eudsl::bindSequence<llvm::User>(m, "UserSequence");
+  eudsl::bindSequence<llvm::Use>(m, "UseSequence");
+}

--- a/projects/eudsl-llvmpy/src/IR/Sequence.h
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.h
@@ -1,0 +1,57 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include "IR/Common.h"
+
+#include <cstddef>
+#include <functional>
+
+namespace eudsl {
+
+/// A lazy, sliceable sequence view over an LLVM container. It holds closures
+/// that compute the length and the i-th element on demand, so iterating or
+/// indexing does not materialize a list. The accessor that returns a Sequence
+/// must keep_alive<0,1> it to the parent, whose storage owns the elements.
+///
+/// __len__ and integer __getitem__ (negative-aware, IndexError past the ends)
+/// are lazy; a slice materializes just the requested window into a list.
+/// Iteration uses Python's sequence protocol (__getitem__ until IndexError).
+template <typename T> struct Sequence {
+  std::function<std::size_t()> length;
+  std::function<T *(std::size_t)> at;
+};
+
+template <typename T> void bindSequence(nb::module_ &m, const char *name) {
+  nb::class_<Sequence<T>>(m, name)
+      .def("__len__",
+           [](Sequence<T> &self) {
+             return static_cast<Py_ssize_t>(self.length());
+           })
+      .def("__getitem__", [](Sequence<T> &self, nb::handle index) -> nb::object {
+        Py_ssize_t n = static_cast<Py_ssize_t>(self.length());
+        if (nb::isinstance<nb::slice>(index)) {
+          auto [start, stop, step, count] =
+              nb::cast<nb::slice>(index).compute(static_cast<size_t>(n));
+          nb::list out;
+          Py_ssize_t idx = start;
+          for (size_t k = 0; k < count; ++k) {
+            out.append(nb::cast(self.at(static_cast<std::size_t>(idx)),
+                                nb::rv_policy::reference));
+            idx += step;
+          }
+          return out;
+        }
+        Py_ssize_t i = nb::cast<Py_ssize_t>(index);
+        if (i < 0)
+          i += n;
+        if (i < 0 || i >= n)
+          throw nb::index_error("index out of range");
+        return nb::cast(self.at(static_cast<std::size_t>(i)),
+                        nb::rv_policy::reference);
+      });
+}
+
+} // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Sequence.h
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.h
@@ -44,6 +44,8 @@ template <typename T> void bindSequence(nb::module_ &m, const char *name) {
           }
           return out;
         }
+        if (!nb::isinstance<nb::int_>(index))
+          throw nb::type_error("sequence indices must be integers or slices");
         Py_ssize_t i = nb::cast<Py_ssize_t>(index);
         if (i < 0)
           i += n;

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -4,6 +4,7 @@
 
 #include "IR/Common.h"
 #include "IR/Ownership.h"
+#include "IR/Sequence.h"
 
 #include <llvm/IR/Argument.h>
 #include <llvm/IR/Attributes.h>
@@ -41,18 +42,38 @@ void populate_values(nb::module_ &m) {
       .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference_internal)
       .def_prop_ro("num_uses",
                    [](llvm::Value &self) { return self.getNumUses(); })
-      .def_prop_ro("users",
-                   [](llvm::Value &self) {
-                     return std::vector<llvm::User *>(self.user_begin(),
-                                                      self.user_end());
-                   })
-      .def_prop_ro("uses",
-                   [](llvm::Value &self) {
-                     std::vector<llvm::Use *> out;
-                     for (llvm::Use &u : self.uses())
-                       out.push_back(&u);
-                     return out;
-                   })
+      .def_prop_ro(
+          "users",
+          [](llvm::Value &self) {
+            llvm::Value *v = &self;
+            eudsl::Sequence<llvm::User> seq;
+            seq.length = [v] {
+              return static_cast<std::size_t>(v->getNumUses());
+            };
+            seq.at = [v](std::size_t i) {
+              auto it = v->user_begin();
+              std::advance(it, i);
+              return *it;
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
+      .def_prop_ro(
+          "uses",
+          [](llvm::Value &self) {
+            llvm::Value *v = &self;
+            eudsl::Sequence<llvm::Use> seq;
+            seq.length = [v] {
+              return static_cast<std::size_t>(v->getNumUses());
+            };
+            seq.at = [v](std::size_t i) {
+              auto it = v->use_begin();
+              std::advance(it, i);
+              return &*it;
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
       .def("replace_all_uses_with", &llvm::Value::replaceAllUsesWith, "value"_a)
       .def(
           "replace_all_uses_except",
@@ -87,12 +108,20 @@ void populate_values(nb::module_ &m) {
       .def_prop_ro("num_operands", &llvm::User::getNumOperands)
       .def("operand", &llvm::User::getOperand, "index"_a,
            nb::rv_policy::reference_internal)
-      .def_prop_ro("operands", [](llvm::User &self) {
-        std::vector<llvm::Value *> out;
-        for (unsigned i = 0, n = self.getNumOperands(); i < n; ++i)
-          out.push_back(self.getOperand(i));
-        return out;
-      })
+      .def_prop_ro(
+          "operands",
+          [](llvm::User &self) {
+            llvm::User *u = &self;
+            eudsl::Sequence<llvm::Value> seq;
+            seq.length = [u] {
+              return static_cast<std::size_t>(u->getNumOperands());
+            };
+            seq.at = [u](std::size_t i) {
+              return u->getOperand(static_cast<unsigned>(i));
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
       .def("__len__",
            [](llvm::User &self) {
              return static_cast<Py_ssize_t>(self.getNumOperands());
@@ -165,12 +194,20 @@ void populate_values(nb::module_ &m) {
           "terminator",
           [](llvm::BasicBlock &self) { return self.getTerminatorOrNull(); },
           nb::rv_policy::reference_internal)
-      .def_prop_ro("instructions", [](llvm::BasicBlock &self) {
-        std::vector<llvm::Instruction *> out;
-        for (llvm::Instruction &i : self)
-          out.push_back(&i);
-        return out;
-      })
+      .def_prop_ro(
+          "instructions",
+          [](llvm::BasicBlock &self) {
+            llvm::BasicBlock *b = &self;
+            eudsl::Sequence<llvm::Instruction> seq;
+            seq.length = [b] { return static_cast<std::size_t>(b->size()); };
+            seq.at = [b](std::size_t i) {
+              auto it = b->begin();
+              std::advance(it, i);
+              return &*it;
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
       .def("__len__",
            [](llvm::BasicBlock &self) {
              return static_cast<Py_ssize_t>(self.size());
@@ -212,20 +249,34 @@ void populate_values(nb::module_ &m) {
       .def_prop_ro("is_declaration", &llvm::Function::isDeclaration)
       .def_prop_ro("num_args", &llvm::Function::arg_size)
       .def("arg", &llvm::Function::getArg, "index"_a, nb::rv_policy::reference_internal)
-      .def_prop_ro("args",
-                   [](llvm::Function &self) {
-                     std::vector<llvm::Argument *> out;
-                     for (llvm::Argument &a : self.args())
-                       out.push_back(&a);
-                     return out;
-                   })
-      .def_prop_ro("basic_blocks",
-                   [](llvm::Function &self) {
-                     std::vector<llvm::BasicBlock *> out;
-                     for (llvm::BasicBlock &b : self)
-                       out.push_back(&b);
-                     return out;
-                   })
+      .def_prop_ro(
+          "args",
+          [](llvm::Function &self) {
+            llvm::Function *f = &self;
+            eudsl::Sequence<llvm::Argument> seq;
+            seq.length = [f] {
+              return static_cast<std::size_t>(f->arg_size());
+            };
+            seq.at = [f](std::size_t i) {
+              return f->getArg(static_cast<unsigned>(i));
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
+      .def_prop_ro(
+          "basic_blocks",
+          [](llvm::Function &self) {
+            llvm::Function *f = &self;
+            eudsl::Sequence<llvm::BasicBlock> seq;
+            seq.length = [f] { return static_cast<std::size_t>(f->size()); };
+            seq.at = [f](std::size_t i) {
+              auto it = f->begin();
+              std::advance(it, i);
+              return &*it;
+            };
+            return seq;
+          },
+          nb::keep_alive<0, 1>())
       .def("__len__",
            [](llvm::Function &self) {
              return static_cast<Py_ssize_t>(self.size());

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -9,6 +9,7 @@
 namespace nb = nanobind;
 
 void populate_context(nb::module_ &m);
+void populate_sequences(nb::module_ &m);
 void populate_casters(nb::module_ &m);
 void populate_attributes(nb::module_ &m);
 void populate_types(nb::module_ &m);
@@ -27,6 +28,7 @@ NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
   eudsl::registerExceptions(m);
   populate_context(m);
+  populate_sequences(m);
   populate_casters(m);
   populate_attributes(m);
   nb::module_ types = m.def_submodule("types");

--- a/projects/eudsl-llvmpy/tests/test_lazy_views.py
+++ b/projects/eudsl-llvmpy/tests/test_lazy_views.py
@@ -1,0 +1,80 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The traversal accessors return lazy sequence views (not materialized lists):
+len(), negative/bounds-checked indexing, slicing, and iteration, computed on
+demand. Covers every Sequence<T> instantiation."""
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @f(i32 %x, i32 %y) {
+    entry:
+      %s = add i32 %x, %y
+      ret i32 %s
+    }
+    define void @g() {
+    entry:
+      ret void
+    }
+    """
+)
+
+
+def test_lazy_sequence_views():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+
+        # Module.functions is a lazy view, not a list.
+        fns = mod.functions
+        assert type(fns).__name__ == "FunctionSequence"
+        assert not isinstance(fns, list)
+        assert len(fns) == 2
+        assert fns[0].name == "f"
+        assert fns[-1].name == "g"
+        assert [x.name for x in fns] == ["f", "g"]  # protocol iteration
+        assert [x.name for x in fns[0:1]] == ["f"]  # slice -> list
+        assert [x.name for x in fns[::-1]] == ["g", "f"]  # negative step
+        with pytest.raises(IndexError):
+            _ = fns[9]
+
+        f = mod.get_function("f")
+
+        bbs = f.basic_blocks  # BasicBlockSequence
+        assert type(bbs).__name__ == "BasicBlockSequence"
+        assert len(bbs) == 1 and isinstance(bbs[0], llvm.BasicBlock)
+
+        args = f.args  # ArgumentSequence
+        assert type(args).__name__ == "ArgumentSequence"
+        assert len(args) == 2 and isinstance(args[0], llvm.Argument)
+        assert len(args[:1]) == 1
+
+        insts = f.entry_block.instructions  # InstructionSequence
+        assert type(insts).__name__ == "InstructionSequence"
+        # element downcasts to the concrete class, lazily
+        assert isinstance(insts[0], llvm.BinaryOperator)
+
+        add = insts[0]
+        ops = add.operands  # ValueSequence
+        assert type(ops).__name__ == "ValueSequence"
+        assert len(ops) == 2 and isinstance(ops[0], llvm.Value)
+        assert ops[0] == args[0]
+
+        users = args[0].users  # UserSequence
+        assert type(users).__name__ == "UserSequence"
+        assert len(users) == 1
+        assert users[0] == add
+
+        uses = args[0].uses  # UseSequence
+        assert type(uses).__name__ == "UseSequence"
+        assert uses[0].operand_number == 0
+        with pytest.raises(IndexError):
+            _ = uses[5]
+
+        del f, fns, bbs, args, insts, add, ops, users, uses, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_lazy_views.py
+++ b/projects/eudsl-llvmpy/tests/test_lazy_views.py
@@ -6,6 +6,8 @@ len(), negative/bounds-checked indexing, slicing, and iteration, computed on
 demand. Covers every Sequence<T> instantiation."""
 from textwrap import dedent
 
+import gc
+
 import pytest
 
 import llvm
@@ -42,6 +44,16 @@ def test_lazy_sequence_views():
         assert [x.name for x in fns[::-1]] == ["g", "f"]  # negative step
         with pytest.raises(IndexError):
             _ = fns[9]
+        with pytest.raises(IndexError):
+            _ = fns[-100]  # still out of range after the negative-index adjustment
+        with pytest.raises(TypeError):
+            _ = fns["nope"]  # non-integer, non-slice index
+
+        g = mod.get_function("g")
+        assert len(g.args) == 0  # empty view
+        assert list(g.args) == []
+        with pytest.raises(IndexError):
+            _ = g.args[0]
 
         f = mod.get_function("f")
 
@@ -64,6 +76,10 @@ def test_lazy_sequence_views():
         assert type(ops).__name__ == "ValueSequence"
         assert len(ops) == 2 and isinstance(ops[0], llvm.Value)
         assert ops[0] == args[0]
+        assert ops[1] == args[1]
+        # Distinct operands compare unequal -- not an identity-collapsed tautology.
+        assert ops[0] != ops[1]
+        assert ops[0] != add
 
         users = args[0].users  # UserSequence
         assert type(users).__name__ == "UserSequence"
@@ -76,5 +92,38 @@ def test_lazy_sequence_views():
         with pytest.raises(IndexError):
             _ = uses[5]
 
-        del f, fns, bbs, args, insts, add, ops, users, uses, mod
+        del f, g, fns, bbs, args, insts, add, ops, users, uses, mod
+    assert_no_leaks()
+
+
+def test_view_reflects_live_mutation():
+    # "Lazy" behaviorally: a view created before a mutation reflects it, so it
+    # is a live computed-on-demand window, not an eager snapshot.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        bb = fn.append_basic_block("entry")
+        insts = bb.instructions  # view taken while the block is empty
+        assert len(insts) == 0
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            b.ret(fn.arg(0))
+        assert len(insts) == 1  # same view now sees the appended instruction
+        assert isinstance(insts[0], llvm.ReturnInst)
+        del b, fn, bb, insts, mod
+    assert_no_leaks()
+
+
+def test_container_view_keeps_module_alive():
+    # Module.functions' parent IS the owning module, so holding only the view
+    # keeps the module alive; dropping it releases the module.
+    with llvm.Context() as ctx:
+        fns = llvm.parse_assembly(_SRC, ctx, "m").functions  # sole handle
+        gc.collect()
+        assert llvm.Context._get_live_module_count() == 1
+        assert len(fns) == 2  # still usable with no other reference to the module
+        del fns
+        gc.collect()
+        assert llvm.Context._get_live_module_count() == 0
     assert_no_leaks()


### PR DESCRIPTION
Replace the eager std::vector materialization behind .functions/.basic_blocks/
.args/.instructions/.operands/.users/.uses with a lazy Sequence<T> view: it
holds closures computing length and the i-th element on demand, so len() and
integer indexing don't build a list (a slice materializes just its window).
Iteration uses Python's sequence protocol; elements downcast via type_hook.
Each accessor keep_alive<0,1>s its view to the parent, which owns the storage.
One templated bindSequence registers the seven element types (Function,
BasicBlock, Argument, Instruction, Value, User, Use).
