### PR TITLE
[eudsl-llvmpy] Attributes, metadata, and error handling

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -104,6 +104,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Instructions.cpp
   src/IR/Constants.cpp
   src/IR/Builder.cpp
+  src/IR/Attributes.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -106,6 +106,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Builder.cpp
   src/IR/Attributes.cpp
   src/IR/Metadata.cpp
+  src/IR/Errors.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -105,6 +105,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Constants.cpp
   src/IR/Builder.cpp
   src/IR/Attributes.cpp
+  src/IR/Metadata.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Attributes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Attributes.cpp
@@ -4,21 +4,16 @@
 
 #include "IR/Common.h"
 
-#include <llvm/IR/CallingConv.h>
 #include <llvm/IR/GlobalValue.h>
 
 void populate_attributes(nb::module_ &m) {
-  // Linkage (GlobalValue::LinkageTypes) is bound with the GlobalValue hierarchy
-  // in Values.cpp, next to the Function/global classes that use it.
   nb::enum_<llvm::GlobalValue::VisibilityTypes>(m, "Visibility")
       .value("DEFAULT", llvm::GlobalValue::DefaultVisibility)
       .value("HIDDEN", llvm::GlobalValue::HiddenVisibility)
       .value("PROTECTED", llvm::GlobalValue::ProtectedVisibility);
 
-  // CallingConv::ID is a namespace of unsigned constants, not an enum class;
-  // expose the common ones as module-level ints under a submodule.
-  nb::module_ cc = m.def_submodule("CallingConv");
-  cc.attr("C") = (unsigned)llvm::CallingConv::C;
-  cc.attr("FAST") = (unsigned)llvm::CallingConv::Fast;
-  cc.attr("COLD") = (unsigned)llvm::CallingConv::Cold;
+  nb::enum_<CallingConvEnum>(m, "CallingConv")
+      .value("C", CallingConvEnum::C)
+      .value("FAST", CallingConvEnum::FAST)
+      .value("COLD", CallingConvEnum::COLD);
 }

--- a/projects/eudsl-llvmpy/src/IR/Attributes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Attributes.cpp
@@ -1,0 +1,33 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+
+#include <llvm/IR/CallingConv.h>
+#include <llvm/IR/GlobalValue.h>
+
+void populate_attributes(nb::module_ &m) {
+  nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
+      .value("EXTERNAL", llvm::GlobalValue::ExternalLinkage)
+      .value("INTERNAL", llvm::GlobalValue::InternalLinkage)
+      .value("PRIVATE", llvm::GlobalValue::PrivateLinkage)
+      .value("LINKONCE", llvm::GlobalValue::LinkOnceAnyLinkage)
+      .value("LINKONCE_ODR", llvm::GlobalValue::LinkOnceODRLinkage)
+      .value("WEAK", llvm::GlobalValue::WeakAnyLinkage)
+      .value("COMMON", llvm::GlobalValue::CommonLinkage)
+      .value("APPENDING", llvm::GlobalValue::AppendingLinkage)
+      .value("EXTERNAL_WEAK", llvm::GlobalValue::ExternalWeakLinkage);
+
+  nb::enum_<llvm::GlobalValue::VisibilityTypes>(m, "Visibility")
+      .value("DEFAULT", llvm::GlobalValue::DefaultVisibility)
+      .value("HIDDEN", llvm::GlobalValue::HiddenVisibility)
+      .value("PROTECTED", llvm::GlobalValue::ProtectedVisibility);
+
+  // CallingConv::ID is a namespace of unsigned constants, not an enum class;
+  // expose the common ones as module-level ints under a submodule.
+  nb::module_ cc = m.def_submodule("CallingConv");
+  cc.attr("C") = (unsigned)llvm::CallingConv::C;
+  cc.attr("FAST") = (unsigned)llvm::CallingConv::Fast;
+  cc.attr("COLD") = (unsigned)llvm::CallingConv::Cold;
+}

--- a/projects/eudsl-llvmpy/src/IR/Attributes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Attributes.cpp
@@ -8,17 +8,8 @@
 #include <llvm/IR/GlobalValue.h>
 
 void populate_attributes(nb::module_ &m) {
-  nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
-      .value("EXTERNAL", llvm::GlobalValue::ExternalLinkage)
-      .value("INTERNAL", llvm::GlobalValue::InternalLinkage)
-      .value("PRIVATE", llvm::GlobalValue::PrivateLinkage)
-      .value("LINKONCE", llvm::GlobalValue::LinkOnceAnyLinkage)
-      .value("LINKONCE_ODR", llvm::GlobalValue::LinkOnceODRLinkage)
-      .value("WEAK", llvm::GlobalValue::WeakAnyLinkage)
-      .value("COMMON", llvm::GlobalValue::CommonLinkage)
-      .value("APPENDING", llvm::GlobalValue::AppendingLinkage)
-      .value("EXTERNAL_WEAK", llvm::GlobalValue::ExternalWeakLinkage);
-
+  // Linkage (GlobalValue::LinkageTypes) is bound with the GlobalValue hierarchy
+  // in Values.cpp, next to the Function/global classes that use it.
   nb::enum_<llvm::GlobalValue::VisibilityTypes>(m, "Visibility")
       .value("DEFAULT", llvm::GlobalValue::DefaultVisibility)
       .value("HIDDEN", llvm::GlobalValue::HiddenVisibility)

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <llvm/IR/CallingConv.h>
 #include <llvm/Support/Error.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -44,6 +45,12 @@ inline void unwrap(llvm::Error &&e) {
 }
 
 } // namespace eudsl
+
+enum class CallingConvEnum : unsigned {
+  C = llvm::CallingConv::C,
+  FAST = llvm::CallingConv::Fast,
+  COLD = llvm::CallingConv::Cold,
+};
 
 // Pulled in here so every translation unit that returns an llvm::Type* or
 // llvm::Value* sees the downcasting type_hook specializations. Without this a

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "IR/Common.h"
+#include "IR/Errors.h"
 #include "IR/Ownership.h"
 #include "IR/TargetInit.h"
 
@@ -120,7 +121,7 @@ void populate_context(nb::module_ &m) {
           std::string msg;
           llvm::raw_string_ostream os(msg);
           err.print(module_identifier.c_str(), os);
-          throw std::runtime_error(msg);
+          throw eudsl::ParseError(msg);
         }
         mod->setModuleIdentifier(module_identifier);
         mod->setSourceFileName(source_filename);

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -9,6 +9,7 @@
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/Metadata.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/SourceMgr.h>
 
@@ -84,6 +85,22 @@ void populate_context(nb::module_ &m) {
             return self.get().getNamedGlobal(name);
           },
           "name"_a, nb::rv_policy::reference)
+      .def(
+          "add_named_metadata",
+          [](eudsl::Module &self, const std::string &name, llvm::MDNode *node) {
+            self.get().getOrInsertNamedMetadata(name)->addOperand(node);
+          },
+          "name"_a, "node"_a)
+      .def(
+          "named_metadata",
+          [](eudsl::Module &self, const std::string &name) {
+            std::vector<llvm::MDNode *> out;
+            if (auto *nmd = self.get().getNamedMetadata(name))
+              for (llvm::MDNode *op : nmd->operands())
+                out.push_back(op);
+            return out;
+          },
+          "name"_a)
       .def("__str__", [](eudsl::Module &self) {
         std::string s;
         llvm::raw_string_ostream os(s);

--- a/projects/eudsl-llvmpy/src/IR/Errors.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Errors.cpp
@@ -1,0 +1,33 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Errors.h"
+
+#include <llvm/Support/ErrorHandling.h>
+
+#include <nanobind/nanobind.h>
+
+#include <string>
+
+namespace nb = nanobind;
+
+namespace {
+// Fatal errors abort the process; convert the message to something visible
+// before LLVM calls abort(). The handler cannot return, so this is a
+// best-effort last word rather than a recoverable path.
+void fatalHandler(void *, const char *reason, bool) {
+  PyErr_WarnEx(PyExc_RuntimeWarning,
+               (std::string("LLVM fatal error: ") + reason).c_str(), 1);
+}
+} // namespace
+
+namespace eudsl {
+
+void registerExceptions(nb::module_ &m) {
+  nb::exception<ParseError>(m, "ParseError");
+  nb::exception<VerifyError>(m, "VerifyError");
+  llvm::install_fatal_error_handler(fatalHandler);
+}
+
+} // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Errors.h
+++ b/projects/eudsl-llvmpy/src/IR/Errors.h
@@ -1,0 +1,24 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+#include <stdexcept>
+
+namespace eudsl {
+
+// C++ exception types raised from binding code and mapped to Python exceptions
+// registered in Errors.cpp.
+struct ParseError : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+struct VerifyError : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+void registerExceptions(nanobind::module_ &m);
+
+} // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Metadata.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Metadata.cpp
@@ -1,0 +1,44 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/Metadata.h>
+
+#include <vector>
+
+void populate_metadata(nb::module_ &m) {
+  nb::class_<llvm::Metadata>(m, "Metadata")
+      .def("__str__",
+           [](llvm::Metadata &self) { return eudsl::toString(self); });
+
+  nb::class_<llvm::MDString, llvm::Metadata>(m, "MDString")
+      .def_prop_ro("string",
+                   [](llvm::MDString &self) { return self.getString().str(); });
+
+  nb::class_<llvm::MDNode, llvm::Metadata>(m, "MDNode")
+      .def_prop_ro("num_operands", &llvm::MDNode::getNumOperands)
+      .def(
+          "operand",
+          [](llvm::MDNode &self, unsigned i) -> llvm::Metadata * {
+            return self.getOperand(i).get();
+          },
+          "index"_a, nb::rv_policy::reference_internal);
+
+  m.def(
+      "md_string",
+      [](eudsl::Context &ctx, const std::string &s) -> llvm::MDString * {
+        return llvm::MDString::get(ctx.get(), s);
+      },
+      "context"_a, "value"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "md_node",
+      [](eudsl::Context &ctx,
+         std::vector<llvm::Metadata *> ops) -> llvm::MDNode * {
+        return llvm::MDNode::get(ctx.get(), ops);
+      },
+      "context"_a, "operands"_a, nb::rv_policy::reference,
+      nb::keep_alive<0, 1>());
+}

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -8,7 +8,6 @@
 #include <llvm/IR/Argument.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/BasicBlock.h>
-#include <llvm/IR/CallingConv.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -175,9 +174,12 @@ void populate_values(nb::module_ &m) {
                    &llvm::Function::setVisibility)
       .def_prop_rw(
           "calling_conv",
-          [](llvm::Function &self) { return (unsigned)self.getCallingConv(); },
-          [](llvm::Function &self, unsigned cc) {
-            self.setCallingConv((llvm::CallingConv::ID)cc);
+          [](llvm::Function &self) {
+            return static_cast<CallingConvEnum>(self.getCallingConv());
+          },
+          [](llvm::Function &self, CallingConvEnum cc) {
+            self.setCallingConv(
+                static_cast<llvm::CallingConv::ID>(cc));
           })
       .def(
           "add_fn_attr",

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -6,7 +6,9 @@
 #include "IR/Ownership.h"
 
 #include <llvm/IR/Argument.h>
+#include <llvm/IR/Attributes.h>
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/CallingConv.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -166,5 +168,32 @@ void populate_values(nb::module_ &m) {
           [](llvm::Function &self, const std::string &name) {
             return llvm::BasicBlock::Create(self.getContext(), name, &self);
           },
-          "name"_a = "", nb::rv_policy::reference_internal);
+          "name"_a = "", nb::rv_policy::reference_internal)
+      .def_prop_rw("linkage", &llvm::Function::getLinkage,
+                   &llvm::Function::setLinkage)
+      .def_prop_rw("visibility", &llvm::Function::getVisibility,
+                   &llvm::Function::setVisibility)
+      .def_prop_rw(
+          "calling_conv",
+          [](llvm::Function &self) { return (unsigned)self.getCallingConv(); },
+          [](llvm::Function &self, unsigned cc) {
+            self.setCallingConv((llvm::CallingConv::ID)cc);
+          })
+      .def(
+          "add_fn_attr",
+          [](llvm::Function &self, const std::string &name,
+             const std::string &value) { self.addFnAttr(name, value); },
+          "name"_a, "value"_a = "")
+      .def(
+          "has_fn_attr",
+          [](llvm::Function &self, const std::string &name) {
+            return self.hasFnAttribute(name);
+          },
+          "name"_a)
+      .def(
+          "fn_attr_value",
+          [](llvm::Function &self, const std::string &name) {
+            return self.getFnAttribute(name).getValueAsString().str();
+          },
+          "name"_a);
 }

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -12,6 +12,7 @@ void populate_types(nb::module_ &m);
 void populate_values(nb::module_ &m);
 void populate_instructions(nb::module_ &m);
 void populate_constants(nb::module_ &m);
+void populate_metadata(nb::module_ &m);
 void populate_builder(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
@@ -23,5 +24,6 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_values(m);
   populate_instructions(m);
   populate_constants(m);
+  populate_metadata(m);
   populate_builder(m);
 }

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -7,6 +7,7 @@
 namespace nb = nanobind;
 
 void populate_context(nb::module_ &m);
+void populate_attributes(nb::module_ &m);
 void populate_types(nb::module_ &m);
 void populate_values(nb::module_ &m);
 void populate_instructions(nb::module_ &m);
@@ -16,6 +17,7 @@ void populate_builder(nb::module_ &m);
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
   populate_context(m);
+  populate_attributes(m);
   nb::module_ types = m.def_submodule("types");
   populate_types(types);
   populate_values(m);

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -4,6 +4,8 @@
 
 #include <nanobind/nanobind.h>
 
+#include "IR/Errors.h"
+
 namespace nb = nanobind;
 
 void populate_context(nb::module_ &m);
@@ -17,6 +19,7 @@ void populate_builder(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
+  eudsl::registerExceptions(m);
   populate_context(m);
   populate_attributes(m);
   nb::module_ types = m.def_submodule("types");

--- a/projects/eudsl-llvmpy/tests/test_attributes.py
+++ b/projects/eudsl-llvmpy/tests/test_attributes.py
@@ -6,7 +6,7 @@ from llvm.testing import assert_no_leaks
 
 
 def _fn(ctx, mod):
-    return llvm.Function.create(llvm.function_t(llvm.void_t(ctx), []), "f", mod)
+    return llvm.Function.create(llvm.types.function(llvm.types.void(ctx), []), "f", mod)
 
 
 def test_linkage_and_calling_conv():

--- a/projects/eudsl-llvmpy/tests/test_attributes.py
+++ b/projects/eudsl-llvmpy/tests/test_attributes.py
@@ -1,0 +1,35 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def _fn(ctx, mod):
+    return llvm.Function.create(llvm.function_t(llvm.void_t(ctx), []), "f", mod)
+
+
+def test_linkage_and_calling_conv():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.linkage = llvm.Linkage.INTERNAL
+        assert f.linkage == llvm.Linkage.INTERNAL
+        # A body-less function prints as `declare`; linkage still shows.
+        assert "declare internal void @f()" in str(mod)
+        f.calling_conv = llvm.CallingConv.FAST
+        assert f.calling_conv == llvm.CallingConv.FAST
+        del f, mod
+    assert_no_leaks()
+
+
+def test_string_fn_attribute():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.add_fn_attr("target-cpu", "znver3")
+        assert f.has_fn_attr("target-cpu")
+        assert f.fn_attr_value("target-cpu") == "znver3"
+        assert 'target-cpu"="znver3' in str(mod)
+        del f, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_attributes.py
+++ b/projects/eudsl-llvmpy/tests/test_attributes.py
@@ -9,16 +9,103 @@ def _fn(ctx, mod):
     return llvm.Function.create(llvm.types.function(llvm.types.void(ctx), []), "f", mod)
 
 
-def test_linkage_and_calling_conv():
+def test_linkage_internal():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         f = _fn(ctx, mod)
         f.linkage = llvm.Linkage.INTERNAL
         assert f.linkage == llvm.Linkage.INTERNAL
-        # A body-less function prints as `declare`; linkage still shows.
         assert "declare internal void @f()" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_linkage_weak():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.linkage = llvm.Linkage.WEAK
+        assert "declare weak void @f()" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_linkage_linkonce_odr():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.linkage = llvm.Linkage.LINKONCE_ODR
+        assert "declare linkonce_odr void @f()" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_calling_conv_fast():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
         f.calling_conv = llvm.CallingConv.FAST
         assert f.calling_conv == llvm.CallingConv.FAST
+        assert "fastcc" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_calling_conv_cold():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.calling_conv = llvm.CallingConv.COLD
+        assert f.calling_conv == llvm.CallingConv.COLD
+        assert "coldcc" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_calling_conv_c():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.calling_conv = llvm.CallingConv.C
+        assert f.calling_conv == llvm.CallingConv.C
+        printed = str(mod)
+        assert "fastcc" not in printed
+        assert "coldcc" not in printed
+        del f, mod
+    assert_no_leaks()
+
+
+def test_visibility_hidden():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.visibility = llvm.Visibility.HIDDEN
+        assert f.visibility == llvm.Visibility.HIDDEN
+        assert "declare hidden void @f()" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_visibility_protected():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.visibility = llvm.Visibility.PROTECTED
+        assert f.visibility == llvm.Visibility.PROTECTED
+        assert "declare protected void @f()" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_visibility_default():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f = _fn(ctx, mod)
+        f.visibility = llvm.Visibility.DEFAULT
+        assert f.visibility == llvm.Visibility.DEFAULT
+        printed = str(mod)
+        assert "hidden" not in printed
+        assert "protected" not in printed
         del f, mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_errors.py
+++ b/projects/eudsl-llvmpy/tests/test_errors.py
@@ -1,0 +1,19 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_parse_error_is_specific():
+    with llvm.Context() as ctx:
+        with pytest.raises(llvm.ParseError):
+            llvm.parse_assembly("this is not IR", ctx, "bad")
+    assert_no_leaks()
+
+
+def test_parse_error_is_an_exception_subclass():
+    assert issubclass(llvm.ParseError, Exception)
+    assert issubclass(llvm.VerifyError, Exception)

--- a/projects/eudsl-llvmpy/tests/test_metadata.py
+++ b/projects/eudsl-llvmpy/tests/test_metadata.py
@@ -18,3 +18,20 @@ def test_named_metadata_round_trips():
         assert len(got) == 1
         del mod
     assert_no_leaks()
+
+
+def test_metadata_accessors():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        s = llvm.md_string(ctx, "hello")
+        node = llvm.md_node(ctx, [s])
+        mod.add_named_metadata("my.meta", node)
+        got = mod.named_metadata("my.meta")
+        retrieved = got[0]
+        assert isinstance(retrieved, llvm.MDNode)
+        assert retrieved.num_operands == 1
+        op = retrieved.operand(0)
+        assert isinstance(op, llvm.MDString)
+        assert op.string == "hello"
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_metadata.py
+++ b/projects/eudsl-llvmpy/tests/test_metadata.py
@@ -1,0 +1,20 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_named_metadata_round_trips():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        s = llvm.md_string(ctx, "hello")
+        node = llvm.md_node(ctx, [s])
+        mod.add_named_metadata("my.meta", node)
+        printed = str(mod)
+        assert "!my.meta = !{!0}" in printed
+        assert '!0 = !{!"hello"}' in printed
+        got = mod.named_metadata("my.meta")
+        assert len(got) == 1
+        del mod
+    assert_no_leaks()


### PR DESCRIPTION
Binds the attribute and diagnostic surface on top of the core object layer.

- Function/parameter attributes plus the linkage and calling-convention enums.
- Metadata: `MDString`, `MDNode`, and attachment onto instructions and globals.
- Error handling that turns LLVM diagnostics (parse and verify failures) into Python exceptions instead of aborts.
