### PR TITLE
[eudsl-llvmpy] DSL control flow: if/elif/else, while, for lowered to blocks and phi nodes

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -87,6 +87,8 @@ void populate_values(nb::module_ &m) {
                    })
       .def("successor", &llvm::Instruction::getSuccessor, "index"_a,
            nb::rv_policy::reference_internal)
+      .def("set_successor", &llvm::Instruction::setSuccessor, "index"_a,
+           "block"_a)
       .def_prop_ro("is_terminator",
                    [](llvm::Instruction &self) { return self.isTerminator(); })
       .def_prop_ro(

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -9,3 +9,6 @@ from .eudslllvm_ext import __doc__
 from .dsl.values import install_value_casters as _install_value_casters
 
 _install_value_casters()
+
+from .dsl.func import function
+from .dsl.cf import yield_

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -11,4 +11,4 @@ from .dsl.values import install_value_casters as _install_value_casters
 _install_value_casters()
 
 from .dsl.func import function
-from .dsl.cf import yield_
+from .dsl.cf import yield_, range_

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -169,6 +169,19 @@ class ReplaceIfWithWith(StrictTransformer):
             return then_with
 
 
+def _reject_nested_control_flow(body_stmts, where):
+    """The loop transforms lift the body into a nested function the if/else
+    transformers do not revisit, so control flow nested inside a loop body is
+    not lowered. Detect and refuse rather than miscompile."""
+    for stmt in body_stmts:
+        for child in ast.walk(stmt):
+            if isinstance(child, (ast.If, ast.For, ast.While)):
+                raise NotImplementedError(
+                    f"control flow nested inside a `{where}` loop body is not "
+                    "supported"
+                )
+
+
 def _carried_from_yield(yield_value):
     """Names carried by a trailing `yield a, b` (or `yield a`)."""
     if yield_value is None:
@@ -219,6 +232,7 @@ class WhileToWhileLoop(StrictTransformer):
             )
         carried = _carried_from_yield(last.value.value)
         body_stmts = node.body[:-1]
+        _reject_nested_control_flow(body_stmts, "while")
 
         def params():
             return ast.arguments(
@@ -328,6 +342,7 @@ class ForToForLoop(StrictTransformer):
             )
         carried = _carried_from_yield(last.value.value)
         body_stmts = node.body[:-1]
+        _reject_nested_control_flow(body_stmts, "for")
 
         body_name = f"__fbody_{line}__"
         params = ast.arguments(
@@ -383,6 +398,40 @@ class RejectUnsupportedJumps(StrictTransformer):
     cond/body functions the loop transforms introduce. Rather than emit wrong
     IR, detect and refuse. Must run before the loop/if transformers so it only
     sees user-written jumps (not the `return`s those transforms synthesize).
+    """
+
+    def visit_Break(self, node):
+        raise NotImplementedError(
+            "`break` inside DSL control flow is not supported"
+        )
+
+    def visit_Continue(self, node):
+        raise NotImplementedError(
+            "`continue` inside DSL control flow is not supported"
+        )
+
+    def _reject_nested_return(self, node):
+        for child in ast.walk(node):
+            if isinstance(child, ast.Return):
+                raise NotImplementedError(
+                    "early `return` inside DSL control flow is not supported"
+                )
+        return self.generic_visit(node)
+
+    visit_If = _reject_nested_return
+    visit_While = _reject_nested_return
+    visit_For = _reject_nested_return
+
+
+class RejectUnsupportedJumps(StrictTransformer):
+    """Reject control flow the phi-based lowering does not model.
+
+    break/continue and early `return` inside if/while/for would need edge
+    duplication and predecessor bookkeeping the yield-protocol lowering does not
+    do (and the loop transforms lift bodies into nested functions, where a bare
+    return/break/continue would silently mean the wrong thing). Detect and
+    refuse rather than emit wrong IR. Runs before the loop/if transformers, so
+    the constructs are still in their original ast form.
     """
 
     def visit_Break(self, node):

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -286,6 +286,7 @@ class WhileToWhileLoop(StrictTransformer):
         out = [cond_fn, body_fn, call]
         for n in out:
             ast.copy_location(n, node)
+            n.end_lineno = n.lineno
             ast.fix_missing_locations(n)
         return out
 
@@ -386,6 +387,7 @@ class ForToForLoop(StrictTransformer):
         out = [body_fn, call]
         for n in out:
             ast.copy_location(n, node)
+            n.end_lineno = n.lineno
             ast.fix_missing_locations(n)
         return out
 

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -167,3 +167,110 @@ class ReplaceIfWithWith(StrictTransformer):
             return [then_with, else_with]
         else:
             return then_with
+
+
+def _carried_from_yield(yield_value):
+    """Names carried by a trailing `yield a, b` (or `yield a`)."""
+    if yield_value is None:
+        return []
+    if isinstance(yield_value, ast.Tuple):
+        elts = yield_value.elts
+    else:
+        elts = [yield_value]
+    names = []
+    for e in elts:
+        if not isinstance(e, ast.Name):
+            raise NotImplementedError(
+                "loop yield must list plain loop-carried variable names, "
+                f"got {ast.dump(e)}"
+            )
+        names.append(e.id)
+    return names
+
+
+class WhileToWhileLoop(StrictTransformer):
+    """Rewrite `while COND: BODY; yield carried` into a while_loop call.
+
+        while COND:
+            BODY
+            yield acc, i
+        # ->
+        def __wcond_L__(acc, i): return COND
+        def __wbody_L__(acc, i):
+            BODY
+            return (acc, i)
+        (acc, i) = while_loop(__wcond_L__, __wbody_L__, (acc, i))
+
+    The loop-carried variables (from the trailing yield) become the parameters
+    and results of the nested cond/body functions, so the while_loop runtime can
+    feed header phis in and thread body results back as phi incomings without
+    rebinding Python closure variables. Straight-line loop bodies only: control
+    flow nested inside a loop body is not lowered (the nested functions are not
+    revisited by the if/else transformers).
+    """
+
+    def visit_While(self, node: ast.While) -> list:
+        node = self.generic_visit(node)
+        line = node.lineno
+        last = node.body[-1]
+        if not (isinstance(last, ast.Expr) and isinstance(last.value, ast.Yield)):
+            raise NotImplementedError(
+                "a DSL `while` body must end with `yield <loop-carried vars>`"
+            )
+        carried = _carried_from_yield(last.value.value)
+        body_stmts = node.body[:-1]
+
+        def params():
+            return ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg=n) for n in carried],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            )
+
+        carried_load = ast.Tuple(
+            [ast.Name(n, ast.Load()) for n in carried], ast.Load()
+        )
+        carried_store = ast.Tuple(
+            [ast.Name(n, ast.Store()) for n in carried], ast.Store()
+        )
+
+        cond_name = f"__wcond_{line}__"
+        body_name = f"__wbody_{line}__"
+
+        cond_fn = ast.FunctionDef(
+            name=cond_name,
+            args=params(),
+            body=[ast.Return(node.test)],
+            decorator_list=[],
+            type_params=[],
+        )
+        body_fn = ast.FunctionDef(
+            name=body_name,
+            args=params(),
+            body=list(body_stmts) + [ast.Return(carried_load)],
+            decorator_list=[],
+            type_params=[],
+        )
+        call = ast.Assign(
+            targets=[carried_store],
+            value=ast.Call(
+                func=ast.Name("while_loop", ast.Load()),
+                args=[
+                    ast.Name(cond_name, ast.Load()),
+                    ast.Name(body_name, ast.Load()),
+                    ast.Tuple(
+                        [ast.Name(n, ast.Load()) for n in carried], ast.Load()
+                    ),
+                ],
+                keywords=[],
+            ),
+        )
+        out = [cond_fn, body_fn, call]
+        for n in out:
+            ast.copy_location(n, node)
+            ast.fix_missing_locations(n)
+        return out

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -373,3 +373,36 @@ class ForToForLoop(StrictTransformer):
             ast.copy_location(n, node)
             ast.fix_missing_locations(n)
         return out
+
+
+class RejectUnsupportedJumps(StrictTransformer):
+    """Reject control flow the phi-based lowering does not model.
+
+    break/continue and early `return` inside an if/while/for would need edge
+    duplication, predecessor bookkeeping, or returning across the nested
+    cond/body functions the loop transforms introduce. Rather than emit wrong
+    IR, detect and refuse. Must run before the loop/if transformers so it only
+    sees user-written jumps (not the `return`s those transforms synthesize).
+    """
+
+    def visit_Break(self, node):
+        raise NotImplementedError(
+            "`break` inside DSL control flow is not supported"
+        )
+
+    def visit_Continue(self, node):
+        raise NotImplementedError(
+            "`continue` inside DSL control flow is not supported"
+        )
+
+    def _reject_nested_return(self, node):
+        for child in ast.walk(node):
+            if isinstance(child, ast.Return):
+                raise NotImplementedError(
+                    "early `return` inside DSL control flow is not supported"
+                )
+        return self.generic_visit(node)
+
+    visit_If = _reject_nested_return
+    visit_While = _reject_nested_return
+    visit_For = _reject_nested_return

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -149,6 +149,7 @@ class ReplaceIfWithWith(StrictTransformer):
         then_with = ast.With(items=[withitem])
         then_with = ast.copy_location(then_with, updated_node)
         then_with = ast.fix_missing_locations(then_with)
+        then_with.end_lineno = then_with.lineno
         then_with.body = updated_node.body
 
         if updated_node.orelse:
@@ -160,9 +161,11 @@ class ReplaceIfWithWith(StrictTransformer):
             else_with = ast.With(items=[withitem])
             if is_elif:
                 else_with = ast.copy_location(else_with, updated_node.orelse[0])
+                else_with = ast.fix_missing_locations(else_with)
+                else_with.end_lineno = else_with.lineno
             else:
                 else_with = set_lineno(else_with, updated_node.orelse[0].lineno - 1)
-            else_with = ast.fix_missing_locations(else_with)
+                else_with = ast.fix_missing_locations(else_with)
             else_with.body = updated_node.orelse
             return [then_with, else_with]
         else:

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -274,3 +274,102 @@ class WhileToWhileLoop(StrictTransformer):
             ast.copy_location(n, node)
             ast.fix_missing_locations(n)
         return out
+
+
+class ForToForLoop(StrictTransformer):
+    """Rewrite `for i in range_(...): BODY; yield carried` into a for_loop call.
+
+        for i in range_(start, stop, step):
+            BODY
+            yield acc
+        # ->
+        def __fbody_L__(i, acc):
+            BODY
+            return (acc,)
+        (acc,) = for_loop(start, stop, step, __fbody_L__, (acc,))
+
+    Like WhileToWhileLoop, the loop-carried variables come from the trailing
+    yield and become the body function's parameters/results (after the induction
+    variable `i`), so no closure rebinding is needed. Only `range_(...)` iterables
+    are handled; other `for` iterables are left untouched.
+    """
+
+    def visit_For(self, node: ast.For) -> object:
+        node = self.generic_visit(node)
+        it = node.iter
+        if not (
+            isinstance(it, ast.Call)
+            and isinstance(it.func, ast.Name)
+            and it.func.id == "range_"
+        ):
+            return node
+        if not isinstance(node.target, ast.Name):
+            raise NotImplementedError("for target must be a single name")
+        iv = node.target.id
+        line = node.lineno
+
+        args = list(it.args)
+        if len(args) == 1:
+            start = ast.Constant(0)
+            stop = args[0]
+            step = ast.Constant(1)
+        elif len(args) == 2:
+            start, stop = args
+            step = ast.Constant(1)
+        elif len(args) == 3:
+            start, stop, step = args
+        else:
+            raise NotImplementedError("range_ takes 1-3 arguments")
+
+        last = node.body[-1]
+        if not (isinstance(last, ast.Expr) and isinstance(last.value, ast.Yield)):
+            raise NotImplementedError(
+                "a DSL `for` body must end with `yield <loop-carried vars>`"
+            )
+        carried = _carried_from_yield(last.value.value)
+        body_stmts = node.body[:-1]
+
+        body_name = f"__fbody_{line}__"
+        params = ast.arguments(
+            posonlyargs=[],
+            args=[ast.arg(arg=iv)] + [ast.arg(arg=n) for n in carried],
+            vararg=None,
+            kwonlyargs=[],
+            kw_defaults=[],
+            kwarg=None,
+            defaults=[],
+        )
+        carried_load = ast.Tuple(
+            [ast.Name(n, ast.Load()) for n in carried], ast.Load()
+        )
+        carried_store = ast.Tuple(
+            [ast.Name(n, ast.Store()) for n in carried], ast.Store()
+        )
+        body_fn = ast.FunctionDef(
+            name=body_name,
+            args=params,
+            body=list(body_stmts) + [ast.Return(carried_load)],
+            decorator_list=[],
+            type_params=[],
+        )
+        call = ast.Assign(
+            targets=[carried_store],
+            value=ast.Call(
+                func=ast.Name("for_loop", ast.Load()),
+                args=[
+                    start,
+                    stop,
+                    step,
+                    ast.Name(body_name, ast.Load()),
+                    ast.Tuple(
+                        [ast.Name(n, ast.Load()) for n in carried], ast.Load()
+                    ),
+                ],
+                keywords=[],
+            ),
+        )
+        out = [body_fn, call]
+        for n in out:
+            ast.copy_location(n, node)
+            ast.fix_missing_locations(n)
+        return out

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -393,39 +393,6 @@ class ForToForLoop(StrictTransformer):
 class RejectUnsupportedJumps(StrictTransformer):
     """Reject control flow the phi-based lowering does not model.
 
-    break/continue and early `return` inside an if/while/for would need edge
-    duplication, predecessor bookkeeping, or returning across the nested
-    cond/body functions the loop transforms introduce. Rather than emit wrong
-    IR, detect and refuse. Must run before the loop/if transformers so it only
-    sees user-written jumps (not the `return`s those transforms synthesize).
-    """
-
-    def visit_Break(self, node):
-        raise NotImplementedError(
-            "`break` inside DSL control flow is not supported"
-        )
-
-    def visit_Continue(self, node):
-        raise NotImplementedError(
-            "`continue` inside DSL control flow is not supported"
-        )
-
-    def _reject_nested_return(self, node):
-        for child in ast.walk(node):
-            if isinstance(child, ast.Return):
-                raise NotImplementedError(
-                    "early `return` inside DSL control flow is not supported"
-                )
-        return self.generic_visit(node)
-
-    visit_If = _reject_nested_return
-    visit_While = _reject_nested_return
-    visit_For = _reject_nested_return
-
-
-class RejectUnsupportedJumps(StrictTransformer):
-    """Reject control flow the phi-based lowering does not model.
-
     break/continue and early `return` inside if/while/for would need edge
     duplication and predecessor bookkeeping the yield-protocol lowering does not
     do (and the loop transforms lift bodies into nested functions, where a bare

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -1,0 +1,160 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Runtime for lowered control flow: real basic blocks and phi nodes.
+
+The AST canonicalizer (llvm.ast.cf_transformers) rewrites
+
+    if c:
+        r = yield a + 1
+    else:
+        r = yield b
+    return r
+
+into
+
+    with if_ctx_manager(c, (placeholder_opaque_t(),)) as __if_op__:
+        r = yield_(a + 1)
+    with else_ctx_manager(__if_op__):
+        r = yield_(b)
+    return r
+
+The MLIR analogue uses regions whose results become block/region results. Here
+we emit explicit LLVM blocks: `if_ctx_manager` creates then/merge blocks and a
+provisional conditional branch (false edge -> merge); `else_ctx_manager`
+repoints that false edge to a fresh else block; and the values passed to
+`yield_` become phi nodes at the merge block. Because Python's `r = yield_(...)`
+executes in the else branch last, the else-branch `yield_` is the one that
+builds the phis (both incoming edges are then known) and returns them, so `r`
+binds to the phi that `return r` uses.
+"""
+
+from contextlib import contextmanager
+
+from ..ast.canonicalize import Canonicalizer, FunctionPatcher
+from ..ast import cf_transformers as _T
+from .casters import maybe_downcast
+from .context import current_builder, current_function
+
+
+def placeholder_opaque_t():
+    # Marks a phi-result slot in the rewritten AST. The real value is the phi
+    # built by yield_; the placeholder itself is never inspected here.
+    return None
+
+
+class _IfOp:
+    """Bookkeeping for one lowered if/else."""
+
+    def __init__(self, cond):
+        b = current_builder()
+        fn = current_function()
+        self.builder = b
+        self.cond = cond
+        self.entry_block = b.insert_block
+        self.then_block = fn.append_basic_block("if.then")
+        self.merge_block = fn.append_basic_block("if.end")
+        self.else_block = None
+        # Provisional branch; else_ctx_manager repoints successor 1 (false edge).
+        self.cond_br = b.cond_br(cond, self.then_block, self.merge_block)
+        self.then_vals = None
+        self.else_vals = None
+        self.active = "then"
+
+    def _terminate_current(self):
+        b = self.builder
+        if b.insert_block.terminator is None:
+            b.br(self.merge_block)
+
+    def record_and_maybe_phi(self, values):
+        """Called by yield_. Record this branch's values; on the else branch
+        (both edges known) build the phis and return them."""
+        b = self.builder
+        if self.active == "then":
+            self.then_vals = list(values)
+            self._terminate_current()
+            # No phis yet; the value bound here is overwritten by the else
+            # branch's assignment (or unused for a side-effecting if). Match the
+            # else-branch return shape (scalar for a single value).
+            vals = list(values)
+            if len(vals) == 1:
+                return vals[0]
+            return tuple(vals)
+        # else branch
+        self.else_vals = list(values)
+        self._terminate_current()
+        b.set_insert_point(self.merge_block)
+        phis = []
+        for i, tv in enumerate(self.then_vals):
+            phi = b.phi(tv.type, f"if.phi.{i}")
+            phi.add_incoming(tv, self.then_block)
+            phi.add_incoming(self.else_vals[i], self.else_block)
+            phis.append(maybe_downcast(phi, current_function()))
+        self.phis = phis
+        if len(phis) == 1:
+            return phis[0]
+        return tuple(phis)
+
+
+_if_stack = []
+
+
+@contextmanager
+def if_ctx_manager(cond, results=()):
+    op = _IfOp(cond)
+    _if_stack.append(op)
+    op.builder.set_insert_point(op.then_block)
+    try:
+        yield op
+    finally:
+        # Each branch body is terminated by its trailing yield_ (the
+        # canonicalizer guarantees one); do not terminate here or the merge
+        # block would get a self-branch. Just leave the builder at merge for
+        # whatever follows (a no-else if continues here; an else block enters
+        # next and repositions).
+        _if_stack.pop()
+        op.builder.set_insert_point(op.merge_block)
+
+
+@contextmanager
+def else_ctx_manager(op):
+    b = op.builder
+    fn = current_function()
+    op.else_block = fn.append_basic_block("if.else")
+    # Repoint the entry conditional branch's false edge to the else block.
+    op.cond_br.set_successor(1, op.else_block)
+    op.active = "else"
+    _if_stack.append(op)
+    b.set_insert_point(op.else_block)
+    try:
+        yield op
+    finally:
+        # else body already terminated + phis built by its trailing yield_.
+        _if_stack.pop()
+        b.set_insert_point(op.merge_block)
+
+
+def yield_(*values):
+    if not _if_stack:
+        return values[0] if len(values) == 1 else values
+    return _if_stack[-1].record_and_maybe_phi(values)
+
+
+class _InjectCFGlobals(FunctionPatcher):
+    def patch_function(self, f):
+        g = f.__globals__
+        g["yield_"] = yield_
+        g["if_ctx_manager"] = if_ctx_manager
+        g["else_ctx_manager"] = else_ctx_manager
+        g["placeholder_opaque_t"] = placeholder_opaque_t
+        return f
+
+
+class LLVMCanonicalizer(Canonicalizer):
+    cst_transformers = [
+        _T.CanonicalizeElIfs,
+        _T.InsertEmptyYield,
+        _T.ReplaceYieldWithLLVMYield,
+        _T.ReplaceIfWithWith,
+    ]
+    function_patchers = [_InjectCFGlobals]

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -246,7 +246,8 @@ def for_loop(start, stop, step, body_fn, inits):
             BODY
             yield carried
         # lowered to a while_loop over (i, *carried):
-        #   cond: i < stop ; body: (i + step, *body_fn(i, *carried))
+        #   cond: i < stop (ascending) or i > stop (descending)
+        #   body: (i + step, *body_fn(i, *carried))
 
     body_fn(i, *carried) -> next-carried-tuple. Returns the final carried
     values (the induction variable is internal).
@@ -255,8 +256,11 @@ def for_loop(start, stop, step, body_fn, inits):
     start_v = _as_value(start, stop_v if not isinstance(stop, int) else start)
     inits = [_as_value(v, start_v) for v in inits]
 
+    # Pick comparator based on step sign (negative step → descending).
+    step_negative = step < 0 if isinstance(step, int) else False
+
     def cond(iv, *carried):
-        return iv < stop_v
+        return iv > stop_v if step_negative else iv < stop_v
 
     def body(iv, *carried):
         nxt = body_fn(iv, *carried)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -31,6 +31,7 @@ binds to the phi that `return r` uses.
 
 from contextlib import contextmanager
 
+from ..eudslllvm_ext import Value, const_int
 from ..ast.canonicalize import Canonicalizer, FunctionPatcher
 from ..ast import cf_transformers as _T
 from .casters import maybe_downcast
@@ -233,8 +234,6 @@ def while_loop(cond_fn, body_fn, inits):
 
 def _as_value(x, like):
     """Coerce a Python int to a constant of `like`'s type; pass Values through."""
-    from .. import Value, const_int
-
     if isinstance(x, Value):
         return x
     return const_int(like.type, int(x), signed=True)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -59,12 +59,21 @@ class _IfOp:
         self.cond_br = b.cond_br(cond, self.then_block, self.merge_block)
         self.then_vals = None
         self.else_vals = None
+        # The block that actually reaches merge on each edge. For a plain branch
+        # this is then_block/else_block, but with a nested if in a branch the
+        # real predecessor is whatever block is current when the branch's
+        # trailing yield_ runs (e.g. an inner merge block) -- so capture it
+        # there rather than assuming the branch's entry block.
+        self.then_pred = None
+        self.else_pred = None
         self.active = "then"
 
     def _terminate_current(self):
         b = self.builder
+        pred = b.insert_block
         if b.insert_block.terminator is None:
             b.br(self.merge_block)
+        return pred
 
     def record_and_maybe_phi(self, values):
         """Called by yield_. Record this branch's values; on the else branch
@@ -72,7 +81,7 @@ class _IfOp:
         b = self.builder
         if self.active == "then":
             self.then_vals = list(values)
-            self._terminate_current()
+            self.then_pred = self._terminate_current()
             # No phis yet; the value bound here is overwritten by the else
             # branch's assignment (or unused for a side-effecting if). Match the
             # else-branch return shape (scalar for a single value).
@@ -82,13 +91,13 @@ class _IfOp:
             return tuple(vals)
         # else branch
         self.else_vals = list(values)
-        self._terminate_current()
+        self.else_pred = self._terminate_current()
         b.set_insert_point(self.merge_block)
         phis = []
         for i, tv in enumerate(self.then_vals):
             phi = b.phi(tv.type, f"if.phi.{i}")
-            phi.add_incoming(tv, self.then_block)
-            phi.add_incoming(self.else_vals[i], self.else_block)
+            phi.add_incoming(tv, self.then_pred)
+            phi.add_incoming(self.else_vals[i], self.else_pred)
             phis.append(maybe_downcast(phi, current_function()))
         self.phis = phis
         if len(phis) == 1:

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -156,14 +156,68 @@ class _InjectCFGlobals(FunctionPatcher):
         g["if_ctx_manager"] = if_ctx_manager
         g["else_ctx_manager"] = else_ctx_manager
         g["placeholder_opaque_t"] = placeholder_opaque_t
+        g["while_loop"] = while_loop
         return f
 
 
 class LLVMCanonicalizer(Canonicalizer):
     cst_transformers = [
+        # While first: it lifts the loop body into nested cond/body functions
+        # before the if/else transformers rewrite yields, so a loop's trailing
+        # `yield` is consumed as its carried-value list rather than becoming an
+        # scf-style yield_().
+        _T.WhileToWhileLoop,
         _T.CanonicalizeElIfs,
         _T.InsertEmptyYield,
         _T.ReplaceYieldWithLLVMYield,
         _T.ReplaceIfWithWith,
     ]
     function_patchers = [_InjectCFGlobals]
+
+
+def while_loop(cond_fn, body_fn, inits):
+    """Phi-based while loop.
+
+    cond_fn(*carried) -> i1 and body_fn(*carried) -> next-carried-tuple are both
+    parameterized by the loop-carried values, so the runtime can pass header
+    phis as those arguments -- no closure rebinding needed. Structure:
+
+        preheader: br header
+        header:    <phis> = phi [init, preheader], [next, body]
+                   br cond_fn(phis), body, exit
+        body:      next = body_fn(phis); br header
+        exit:      (phis are the loop results)
+    """
+    b = current_builder()
+    fn = current_function()
+    inits = list(inits)
+
+    preheader = b.insert_block
+    header = fn.append_basic_block("while.header")
+    body_bb = fn.append_basic_block("while.body")
+    exit_bb = fn.append_basic_block("while.end")
+
+    b.br(header)
+
+    b.set_insert_point(header)
+    raw_phis = []
+    carried = []
+    for idx, init in enumerate(inits):
+        phi = b.phi(init.type, f"while.{idx}")
+        phi.add_incoming(init, preheader)
+        raw_phis.append(phi)  # keep the PHINode for add_incoming wiring
+        carried.append(maybe_downcast(phi, fn))  # typed view for the body
+    cond = cond_fn(*carried)
+    b.cond_br(cond, body_bb, exit_bb)
+
+    b.set_insert_point(body_bb)
+    nexts = body_fn(*carried)
+    if not isinstance(nexts, tuple):
+        nexts = (nexts,)
+    body_end = b.insert_block  # nested control flow may have moved us
+    b.br(header)
+    for phi, nxt in zip(raw_phis, nexts):
+        phi.add_incoming(nxt, body_end)
+
+    b.set_insert_point(exit_bb)
+    return carried[0] if len(carried) == 1 else tuple(carried)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -133,6 +133,8 @@ def else_ctx_manager(op):
     op.else_block = fn.append_basic_block("if.else")
     # Repoint the entry conditional branch's false edge to the else block.
     op.cond_br.set_successor(1, op.else_block)
+    # Switch to else-branch state so yield_ builds phis (both edges known)
+    # rather than just recording then-branch values.
     op.active = "else"
     _if_stack.append(op)
     b.set_insert_point(op.else_block)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -157,16 +157,19 @@ class _InjectCFGlobals(FunctionPatcher):
         g["else_ctx_manager"] = else_ctx_manager
         g["placeholder_opaque_t"] = placeholder_opaque_t
         g["while_loop"] = while_loop
+        g["for_loop"] = for_loop
+        g["range_"] = range_
         return f
 
 
 class LLVMCanonicalizer(Canonicalizer):
     cst_transformers = [
-        # While first: it lifts the loop body into nested cond/body functions
+        # Loops first: they lift the loop body into nested cond/body functions
         # before the if/else transformers rewrite yields, so a loop's trailing
         # `yield` is consumed as its carried-value list rather than becoming an
         # scf-style yield_().
         _T.WhileToWhileLoop,
+        _T.ForToForLoop,
         _T.CanonicalizeElIfs,
         _T.InsertEmptyYield,
         _T.ReplaceYieldWithLLVMYield,
@@ -220,4 +223,60 @@ def while_loop(cond_fn, body_fn, inits):
         phi.add_incoming(nxt, body_end)
 
     b.set_insert_point(exit_bb)
-    return carried[0] if len(carried) == 1 else tuple(carried)
+    # Always return a tuple; the AST transform binds `(names,) = while_loop(...)`
+    # and direct callers unpack. (Single-element tuple for one carried value.)
+    return tuple(carried)
+
+
+def _as_value(x, like):
+    """Coerce a Python int to a constant of `like`'s type; pass Values through."""
+    from .. import Value, const_int
+
+    if isinstance(x, Value):
+        return x
+    return const_int(like.type, int(x), signed=True)
+
+
+def for_loop(start, stop, step, body_fn, inits):
+    """Counted loop built on while_loop, with an induction variable.
+
+        for i in range_(start, stop, step):
+            BODY
+            yield carried
+        # lowered to a while_loop over (i, *carried):
+        #   cond: i < stop ; body: (i + step, *body_fn(i, *carried))
+
+    body_fn(i, *carried) -> next-carried-tuple. Returns the final carried
+    values (the induction variable is internal).
+    """
+    stop_v = stop
+    start_v = _as_value(start, stop_v if not isinstance(stop, int) else start)
+    inits = [_as_value(v, start_v) for v in inits]
+
+    def cond(iv, *carried):
+        return iv < stop_v
+
+    def body(iv, *carried):
+        nxt = body_fn(iv, *carried)
+        if nxt is None:
+            nxt = ()
+        elif not isinstance(nxt, tuple):
+            nxt = (nxt,)
+        return (iv + step, *nxt)
+
+    res = while_loop(cond, body, (start_v, *inits))
+    # while_loop returns a tuple; drop the induction variable and return the
+    # remaining carried values as a tuple (the AST transform tuple-unpacks it).
+    carried = res[1:]
+    return tuple(carried)
+
+
+def range_(start, stop=None, step=1):
+    """Marker for `for i in range_(...)`; the AST transform reads its args.
+
+    Also callable at runtime (returns the (start, stop, step) triple) so the
+    name resolves even outside a transformed function.
+    """
+    if stop is None:
+        start, stop = 0, start
+    return (start, stop, step)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -164,7 +164,10 @@ class _InjectCFGlobals(FunctionPatcher):
 
 class LLVMCanonicalizer(Canonicalizer):
     cst_transformers = [
-        # Loops first: they lift the loop body into nested cond/body functions
+        # Reject unsupported jumps first, on the original AST, before the loop
+        # transforms synthesize their own returns.
+        _T.RejectUnsupportedJumps,
+        # Loops next: they lift the loop body into nested cond/body functions
         # before the if/else transformers rewrite yields, so a loop's trailing
         # `yield` is consumed as its carried-value list rather than becoming an
         # scf-style yield_().

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -16,7 +16,7 @@ def _resolve(annotation, ctx):
     """Resolve a parameter/return annotation to an llvm.Type.
 
     Accepts a Type instance directly, or a callable `ctx -> Type` (e.g. the
-    `llvm.i32` factory used bare as an annotation).
+    `llvm.types.i32` factory used bare as an annotation).
     """
     if isinstance(annotation, Type):
         return annotation

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -8,9 +8,7 @@ import inspect
 from .. import Function, IRBuilder
 from ..eudslllvm_ext.types import Type
 from ..eudslllvm_ext.types import function as function_t
-from ..ast.canonicalize import canonicalize
 from .casters import maybe_downcast
-from .cf import LLVMCanonicalizer
 from .context import building
 
 
@@ -38,9 +36,6 @@ def function(*, module, name=None):
         fn = Function.create(function_t(ret_type, param_types), fn_name, module)
         entry = fn.append_basic_block("entry")
         builder = IRBuilder(ctx)
-
-        # Rewrite Python control flow into the cf context-manager calls.
-        f = canonicalize(using=LLVMCanonicalizer())(f)
 
         with builder.at_end_of(entry), building(builder, fn):
             args = [maybe_downcast(fn.arg(i), fn) for i in range(len(param_types))]

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -1,0 +1,52 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The @function decorator: turn a Python function into an LLVM function."""
+
+import inspect
+
+from .. import Function, IRBuilder, Type, function_t
+from ..ast.canonicalize import canonicalize
+from .casters import maybe_downcast
+from .cf import LLVMCanonicalizer
+from .context import building
+
+
+def _resolve(annotation, ctx):
+    """Resolve a parameter/return annotation to an llvm.Type.
+
+    Accepts a Type instance directly, or a callable `ctx -> Type` (e.g. the
+    `llvm.i32` factory used bare as an annotation).
+    """
+    if isinstance(annotation, Type):
+        return annotation
+    if callable(annotation):
+        return annotation(ctx)
+    raise TypeError(f"cannot resolve type annotation {annotation!r}")
+
+
+def function(*, module, name=None):
+    def decorator(f):
+        ctx = module.context
+        sig = inspect.signature(f)
+        param_types = [_resolve(p.annotation, ctx) for p in sig.parameters.values()]
+        ret_type = _resolve(sig.return_annotation, ctx)
+        fn_name = name or f.__name__
+
+        fn = Function.create(function_t(ret_type, param_types), fn_name, module)
+        entry = fn.append_basic_block("entry")
+        builder = IRBuilder(ctx)
+
+        # Rewrite Python control flow into the cf context-manager calls.
+        f = canonicalize(using=LLVMCanonicalizer())(f)
+
+        with builder.at_end_of(entry), building(builder, fn):
+            args = [maybe_downcast(fn.arg(i), fn) for i in range(len(param_types))]
+            result = f(*args)
+            if result is not None:
+                builder.ret(result)
+            elif builder.insert_block.terminator is None:
+                builder.ret(None)
+        return fn
+
+    return decorator

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -5,7 +5,9 @@
 
 import inspect
 
-from .. import Function, IRBuilder, Type, function_t
+from .. import Function, IRBuilder
+from ..eudslllvm_ext.types import Type
+from ..eudslllvm_ext.types import function as function_t
 from ..ast.canonicalize import canonicalize
 from .casters import maybe_downcast
 from .cf import LLVMCanonicalizer

--- a/projects/eudsl-llvmpy/tests/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/test_ast.py
@@ -119,8 +119,10 @@ def test_if_rewrite_preserves_linenos():
     assert len(with_nodes) == 2
     # then-branch With inherits the If's lineno via ast.copy_location.
     assert with_nodes[0].lineno == 2
+    assert with_nodes[0].end_lineno == 2
     # else-branch With gets orelse[0].lineno - 1 (the `else:` keyword line).
     assert with_nodes[1].lineno == 4
+    assert with_nodes[1].end_lineno == 4
 
 
 def test_insert_empty_yield_linenos():

--- a/projects/eudsl-llvmpy/tests/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/test_ast.py
@@ -257,6 +257,9 @@ def test_while_to_while_loop_preserves_lineno():
     assert cond_fn.lineno == 3
     assert body_fn.lineno == 3
     assert call.lineno == 3
+    assert cond_fn.end_lineno == 3
+    assert body_fn.end_lineno == 3
+    assert call.end_lineno == 3
 
 
 def test_for_to_for_loop_preserves_lineno():
@@ -279,3 +282,5 @@ def test_for_to_for_loop_preserves_lineno():
     assert isinstance(call, ast.Assign)
     assert body_fn.lineno == 3
     assert call.lineno == 3
+    assert body_fn.end_lineno == 3
+    assert call.end_lineno == 3

--- a/projects/eudsl-llvmpy/tests/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/test_ast.py
@@ -231,3 +231,51 @@ def test_rewrite_produces_expected_ast_structure():
     else_ctx = node.body[1].items[0].context_expr
     assert isinstance(else_ctx, ast.Call)
     assert else_ctx.func.id == "else_ctx_manager"
+
+
+def test_while_to_while_loop_preserves_lineno():
+    # WhileToWhileLoop replaces the while node with [cond_fn, body_fn, call],
+    # each carrying the original while's lineno via ast.copy_location.
+    src = (
+        "def f():\n"       # line 1
+        "    x = 0\n"      # line 2
+        "    while x:\n"   # line 3
+        "        x = 1\n"  # line 4
+        "        yield x\n"  # line 5
+    )
+    tree = ast.parse(src)
+    node = tree.body[0]
+    node = T.WhileToWhileLoop(context=None, first_lineno=0).generic_visit(node)
+    # The while was on line 3; all emitted nodes should carry that lineno.
+    # node.body = [x = 0, cond_fn, body_fn, call]
+    cond_fn = node.body[1]
+    body_fn = node.body[2]
+    call = node.body[3]
+    assert isinstance(cond_fn, ast.FunctionDef)
+    assert isinstance(body_fn, ast.FunctionDef)
+    assert isinstance(call, ast.Assign)
+    assert cond_fn.lineno == 3
+    assert body_fn.lineno == 3
+    assert call.lineno == 3
+
+
+def test_for_to_for_loop_preserves_lineno():
+    # ForToForLoop replaces the for node with [body_fn, call], each carrying
+    # the original for's lineno via ast.copy_location.
+    src = (
+        "def f():\n"         # line 1
+        "    acc = 0\n"      # line 2
+        "    for i in range_(0, 10):\n"  # line 3
+        "        acc = 1\n"  # line 4
+        "        yield acc\n"  # line 5
+    )
+    tree = ast.parse(src)
+    node = tree.body[0]
+    node = T.ForToForLoop(context=None, first_lineno=0).generic_visit(node)
+    # node.body = [acc = 0, body_fn, call]
+    body_fn = node.body[1]
+    call = node.body[2]
+    assert isinstance(body_fn, ast.FunctionDef)
+    assert isinstance(call, ast.Assign)
+    assert body_fn.lineno == 3
+    assert call.lineno == 3

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -77,3 +77,30 @@ def test_elif_chain_jits():
     assert fn(7) == 1
     del jit, mod, ctx, classify, i32, fn
     assert_no_leaks()
+
+
+def test_while_countdown_jits():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sum_to(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        i = llvm.const_int(i32, 0)
+        while i.ne(n):
+            acc = acc + i
+            i = i + 1
+            yield acc, i
+        return acc
+
+    printed = str(mod)
+    assert "while.header" in printed
+    assert printed.count("phi i32") == 2  # acc, i loop-carried
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("sum_to"))
+    assert fn(5) == 0 + 1 + 2 + 3 + 4
+    assert fn(0) == 0
+    del jit, mod, ctx, sum_to, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -1,0 +1,52 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ctypes
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_if_else_produces_phi():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+
+        @llvm.function(module=mod)
+        def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+            if c:
+                r = yield a + 1
+            else:
+                r = yield b
+            return r
+
+        printed = str(mod)
+        assert "br i1" in printed
+        assert "phi i32" in printed
+        assert "add i32" in printed
+        del mod
+    assert_no_leaks()
+
+
+def test_if_else_jits_correctly():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+        if c:
+            r = yield a
+        else:
+            r = yield b
+        return r
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_bool, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("pick"))
+    assert fn(True, 10, 20) == 10
+    assert fn(False, 10, 20) == 20
+    del jit, mod, ctx, pick, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -104,3 +104,27 @@ def test_while_countdown_jits():
     assert fn(0) == 0
     del jit, mod, ctx, sum_to, i32, fn
     assert_no_leaks()
+
+
+def test_for_range_sum_jits():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def total(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(0, n):
+            acc = acc + i
+            yield acc
+        return acc
+
+    printed = str(mod)
+    assert "while.header" in printed
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
+    assert fn(5) == 0 + 1 + 2 + 3 + 4
+    assert fn(1) == 0
+    del jit, mod, ctx, total, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -60,7 +60,7 @@ def test_elif_chain_jits():
     @llvm.function(module=mod)
     def classify(x: i32) -> i32:
         if x < 0:
-            r = yield llvm.const_int(i32, -1)
+            r = yield llvm.const_int(i32, -1, signed=True)
         elif x.eq(llvm.const_int(i32, 0)):
             r = yield llvm.const_int(i32, 0)
         else:

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -498,3 +498,123 @@ def test_for_loop_wraps_none_and_non_tuple_body_result():
         assert fn_ptr(5) == 0 + 1 + 2 + 3 + 4
         del jit, mod, fn, fn_ptr
     assert_no_leaks()
+
+
+def test_for_negative_step_countdown_jits():
+    # Exercises the descending-loop condition (iv > stop) for negative step.
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def countdown(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(n, 0, -1):
+            acc = acc + i
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("countdown"))
+    # sum(range(5, 0, -1)) = 5 + 4 + 3 + 2 + 1 = 15
+    assert fn_ptr(5) == 15
+    assert fn_ptr(1) == 1
+    assert fn_ptr(0) == 0
+    del jit, mod, fn_ptr, ctx
+
+
+def test_early_return_inside_while_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="early `return`"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                while acc.ne(n):
+                    return acc
+                    yield acc
+                return acc
+        del mod
+    assert_no_leaks()
+
+
+def test_early_return_inside_for_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="early `return`"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    return acc
+                    yield acc
+                return acc
+        del mod
+    assert_no_leaks()
+
+
+def test_if_else_phi_has_correct_incomings():
+    # Structural test: verify the module has correct phi structure.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
+            if c:
+                r = yield a + 1
+            else:
+                r = yield b
+            return r
+
+        mod.verify()
+        printed = str(mod)
+        # phi must have exactly 2 incoming edges (then and else branches).
+        assert printed.count("phi i32") == 1
+        # Each incoming is [value, %block_label]; there should be 2 of them.
+        phi_line = [l for l in printed.splitlines() if "phi i32" in l][0]
+        assert phi_line.count("[") == 2
+        del mod
+    assert_no_leaks()
+
+
+def test_while_loop_verifies_cleanly():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def sum_to(n: i32) -> i32:
+            acc = llvm.const_int(i32, 0)
+            i = llvm.const_int(i32, 0)
+            while i.ne(n):
+                acc = acc + i
+                i = i + 1
+                yield acc, i
+            return acc
+
+        mod.verify()
+        del mod
+    assert_no_leaks()
+
+
+def test_for_loop_verifies_cleanly():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def total(n: i32) -> i32:
+            acc = llvm.const_int(i32, 0)
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            return acc
+
+        mod.verify()
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -6,6 +6,8 @@ import ctypes
 import pytest
 
 import llvm
+from llvm.ast.canonicalize import canonicalize
+from llvm.dsl.cf import LLVMCanonicalizer
 from llvm.testing import assert_no_leaks
 
 
@@ -15,6 +17,7 @@ def test_if_else_produces_phi():
         i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
         def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
             if c:
                 r = yield a + 1
@@ -36,6 +39,7 @@ def test_if_else_jits_correctly():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
         if c:
             r = yield a
@@ -60,6 +64,7 @@ def test_elif_chain_jits():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def classify(x: i32) -> i32:
         if x < 0:
             r = yield llvm.const_int(i32, -1, signed=True)
@@ -87,6 +92,7 @@ def test_while_countdown_jits():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sum_to(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         i = llvm.const_int(i32, 0)
@@ -114,6 +120,7 @@ def test_for_range_sum_jits():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def total(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(0, n):
@@ -163,6 +170,7 @@ def test_if_else_multiple_results():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def swap_if(c: llvm.types.i1, a: i32, b: i32) -> i32:
         if c:
             x, y = yield a, b
@@ -194,6 +202,7 @@ def test_while_single_carried_value():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def count_to(n: i32) -> i32:
         i = llvm.const_int(i32, 0)
         while i.ne(n):
@@ -216,6 +225,7 @@ def test_for_range_single_and_stepped_args():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sum_upto(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(n):
@@ -224,6 +234,7 @@ def test_for_range_single_and_stepped_args():
         return acc
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sum_stepped(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(0, n, 2):
@@ -269,6 +280,7 @@ def test_break_inside_dsl_control_flow_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="`break`"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 i = llvm.const_int(i32, 0)
                 while i.ne(n):
@@ -286,6 +298,7 @@ def test_continue_inside_dsl_control_flow_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="`continue`"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 i = llvm.const_int(i32, 0)
                 while i.ne(n):
@@ -303,6 +316,7 @@ def test_early_return_inside_dsl_control_flow_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(c: llvm.types.i1, a: i32) -> i32:
                 if c:
                     return a
@@ -318,6 +332,7 @@ def test_while_body_without_trailing_yield_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with `yield"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 i = llvm.const_int(i32, 0)
                 while i.ne(n):
@@ -333,6 +348,7 @@ def test_for_body_without_trailing_yield_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with `yield"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -348,6 +364,7 @@ def test_for_target_must_be_single_name_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="single name"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i, j in range_(0, n):
@@ -364,6 +381,7 @@ def test_for_range_wrong_arg_count_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="1-3 arguments"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n, 1, 1):
@@ -380,6 +398,7 @@ def test_loop_yield_non_name_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="plain loop-carried"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -394,6 +413,7 @@ def test_nested_control_flow_inside_loop_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="not supported"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32, c: llvm.types.i1) -> i32:
                 i = llvm.const_int(i32, 0)
                 while i.ne(n):
@@ -411,6 +431,7 @@ def test_while_loop_bare_yield_has_no_carried_values():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def spin(n: i32) -> i32:
         while n.eq(llvm.const_int(i32, 0)):
             yield
@@ -507,6 +528,7 @@ def test_for_negative_step_countdown_jits():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def countdown(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(n, 0, -1):
@@ -531,6 +553,7 @@ def test_early_return_inside_while_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 while acc.ne(n):
@@ -547,6 +570,7 @@ def test_early_return_inside_for_raises():
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -564,6 +588,7 @@ def test_if_else_phi_has_correct_incomings():
         i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
         def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
             if c:
                 r = yield a + 1
@@ -588,6 +613,7 @@ def test_while_loop_verifies_cleanly():
         i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
         def sum_to(n: i32) -> i32:
             acc = llvm.const_int(i32, 0)
             i = llvm.const_int(i32, 0)
@@ -602,12 +628,46 @@ def test_while_loop_verifies_cleanly():
     assert_no_leaks()
 
 
+def test_multiple_while_loops_have_unique_labels():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def two_loops(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        i = llvm.const_int(i32, 0)
+        while i.ne(n):
+            acc = acc + i
+            i = i + 1
+            yield acc, i
+        j = llvm.const_int(i32, 0)
+        while j.ne(n):
+            acc = acc + 1
+            j = j + 1
+            yield acc, j
+        return acc
+
+    printed = str(mod)
+    # LLVM must uniquify the duplicate "while.header" labels.
+    assert "while.header:" in printed
+    assert "while.header1:" in printed
+    mod.verify()
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("two_loops"))
+    # First loop: sum(0..4) = 10; second loop: 10 + 5 = 15.
+    assert fn_ptr(5) == 15
+    del jit, mod, fn_ptr, ctx
+
 def test_for_loop_verifies_cleanly():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
         def total(n: i32) -> i32:
             acc = llvm.const_int(i32, 0)
             for i in range_(0, n):

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -3,6 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ctypes
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -127,4 +129,372 @@ def test_for_range_sum_jits():
     assert fn(5) == 0 + 1 + 2 + 3 + 4
     assert fn(1) == 0
     del jit, mod, ctx, total, i32, fn
+    assert_no_leaks()
+
+
+def test_function_void_no_explicit_return():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+
+        @llvm.function(module=mod)
+        def noop() -> llvm.types.void:
+            pass
+
+        assert "ret void" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_function_rejects_unresolvable_annotation():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(TypeError, match="cannot resolve type annotation"):
+            @llvm.function(module=mod)
+            def bad(x: "not a type") -> i32:
+                return x
+        del mod
+    assert_no_leaks()
+
+
+def test_if_else_multiple_results():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def swap_if(c: llvm.types.i1, a: i32, b: i32) -> i32:
+        if c:
+            x, y = yield a, b
+        else:
+            x, y = yield b, a
+        return x - y
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_bool, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("swap_if"))
+    assert fn(True, 10, 3) == 10 - 3
+    assert fn(False, 10, 3) == 3 - 10
+    del jit, mod, ctx, swap_if, i32, fn
+    assert_no_leaks()
+
+
+def test_yield_outside_if_stack_returns_directly():
+    from llvm.dsl.cf import yield_
+
+    assert yield_(5) == 5
+    assert yield_(1, 2) == (1, 2)
+
+
+def test_while_single_carried_value():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def count_to(n: i32) -> i32:
+        i = llvm.const_int(i32, 0)
+        while i.ne(n):
+            i = i + 1
+            yield i
+        return i
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("count_to"))
+    assert fn(5) == 5
+    assert fn(0) == 0
+    del jit, mod, ctx, count_to, i32, fn
+    assert_no_leaks()
+
+
+def test_for_range_single_and_stepped_args():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sum_upto(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(n):
+            acc = acc + i
+            yield acc
+        return acc
+
+    @llvm.function(module=mod)
+    def sum_stepped(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(0, n, 2):
+            acc = acc + i
+            yield acc
+        return acc
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn1 = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("sum_upto"))
+    fn2 = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("sum_stepped"))
+    assert fn1(5) == 0 + 1 + 2 + 3 + 4
+    assert fn2(10) == 0 + 2 + 4 + 6 + 8
+    del jit, mod, ctx, sum_upto, sum_stepped, i32, fn1, fn2
+    assert_no_leaks()
+
+
+def test_for_non_range_iterable_is_left_untouched():
+    # ForToForLoop only rewrites `for x in range_(...)`; any other iterable
+    # is a plain Python loop that unrolls at trace/build time.
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sum_consts(a: i32) -> i32:
+        acc = a
+        for v in (1, 2, 3):
+            acc = acc + llvm.const_int(i32, v)
+        return acc
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("sum_consts"))
+    assert fn(10) == 10 + 1 + 2 + 3
+    del jit, mod, ctx, sum_consts, i32, fn
+    assert_no_leaks()
+
+
+def test_break_inside_dsl_control_flow_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="`break`"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                i = llvm.const_int(i32, 0)
+                while i.ne(n):
+                    break
+                    i = i + 1
+                    yield i
+                return i
+        del mod
+    assert_no_leaks()
+
+
+def test_continue_inside_dsl_control_flow_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="`continue`"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                i = llvm.const_int(i32, 0)
+                while i.ne(n):
+                    continue
+                    i = i + 1
+                    yield i
+                return i
+        del mod
+    assert_no_leaks()
+
+
+def test_early_return_inside_dsl_control_flow_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="early `return`"):
+            @llvm.function(module=mod)
+            def f(c: llvm.types.i1, a: i32) -> i32:
+                if c:
+                    return a
+                r = yield a
+                return r
+        del mod
+    assert_no_leaks()
+
+
+def test_while_body_without_trailing_yield_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="must end with `yield"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                i = llvm.const_int(i32, 0)
+                while i.ne(n):
+                    i = i + 1
+                return i
+        del mod
+    assert_no_leaks()
+
+
+def test_for_body_without_trailing_yield_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="must end with `yield"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    acc = acc + i
+                return acc
+        del mod
+    assert_no_leaks()
+
+
+def test_for_target_must_be_single_name_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="single name"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i, j in range_(0, n):
+                    acc = acc + i
+                    yield acc
+                return acc
+        del mod
+    assert_no_leaks()
+
+
+def test_for_range_wrong_arg_count_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="1-3 arguments"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n, 1, 1):
+                    acc = acc + i
+                    yield acc
+                return acc
+        del mod
+    assert_no_leaks()
+
+
+def test_loop_yield_non_name_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="plain loop-carried"):
+            @llvm.function(module=mod)
+            def f(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    yield acc + i
+                return acc
+        del mod
+    assert_no_leaks()
+
+def test_nested_control_flow_inside_loop_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="not supported"):
+            @llvm.function(module=mod)
+            def f(n: i32, c: llvm.types.i1) -> i32:
+                i = llvm.const_int(i32, 0)
+                while i.ne(n):
+                    if c:
+                        i = i + 1
+                    yield i
+                return i
+        del mod
+    assert_no_leaks()
+
+
+def test_while_loop_bare_yield_has_no_carried_values():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def spin(n: i32) -> i32:
+        while n.eq(llvm.const_int(i32, 0)):
+            yield
+        return n
+
+    printed = str(mod)
+    assert "while.header" in printed
+    del mod, ctx, spin, i32
+    assert_no_leaks()
+
+
+def test_range_marker_is_callable_directly():
+    from llvm.dsl.cf import range_
+
+    assert range_(5) == (0, 5, 1)
+    assert range_(2, 5) == (2, 5, 1)
+    assert range_(2, 5, 3) == (2, 5, 3)
+
+
+def test_while_loop_wraps_non_tuple_body_result():
+    # Direct call to the runtime primitive (bypassing the AST transform, which
+    # always returns a real tuple) to exercise the non-tuple wrap branch.
+    from llvm.dsl.cf import while_loop
+    from llvm.dsl.context import building
+
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b, fn):
+            n = fn.arg(0)
+
+            def cond(i):
+                return i.ne(n)
+
+            def body(i):
+                return i + 1  # bare Value, not a tuple
+
+            (result,) = while_loop(cond, body, (llvm.const_int(i32, 0),))
+            b.ret(result)
+
+        jit = llvm.LLJIT()
+        jit.add_module(mod)
+        fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
+        assert fn_ptr(5) == 5
+        del jit, mod, fn, fn_ptr
+    assert_no_leaks()
+
+
+def test_for_loop_wraps_none_and_non_tuple_body_result():
+    # Direct calls to the runtime primitive to exercise the None- and
+    # non-tuple-result wrap branches that the AST transform never produces
+    # (its generated body always returns a real tuple).
+    from llvm.dsl.cf import for_loop
+    from llvm.dsl.context import building
+
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b, fn):
+            n = fn.arg(0)
+
+            def body_none(i):
+                return None  # no carried values
+
+            for_loop(llvm.const_int(i32, 0), n, llvm.const_int(i32, 1), body_none, ())
+
+            def body_bare(i, acc):
+                return acc + i  # bare non-tuple, one carried value
+
+            (result,) = for_loop(
+                llvm.const_int(i32, 0), n, llvm.const_int(i32, 1), body_bare,
+                (llvm.const_int(i32, 0),),
+            )
+            b.ret(result)
+
+        jit = llvm.LLJIT()
+        jit.add_module(mod)
+        fn_ptr = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
+        assert fn_ptr(5) == 0 + 1 + 2 + 3 + 4
+        del jit, mod, fn, fn_ptr
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -10,10 +10,10 @@ from llvm.testing import assert_no_leaks
 def test_if_else_produces_phi():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
-        def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+        def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
             if c:
                 r = yield a + 1
             else:
@@ -31,10 +31,10 @@ def test_if_else_produces_phi():
 def test_if_else_jits_correctly():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
-    def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+    def pick(c: llvm.types.i1, a: i32, b: i32) -> i32:
         if c:
             r = yield a
         else:
@@ -55,7 +55,7 @@ def test_if_else_jits_correctly():
 def test_elif_chain_jits():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def classify(x: i32) -> i32:
@@ -82,7 +82,7 @@ def test_elif_chain_jits():
 def test_while_countdown_jits():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def sum_to(n: i32) -> i32:
@@ -109,7 +109,7 @@ def test_while_countdown_jits():
 def test_for_range_sum_jits():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def total(n: i32) -> i32:

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -50,3 +50,30 @@ def test_if_else_jits_correctly():
     assert fn(False, 10, 20) == 20
     del jit, mod, ctx, pick, i32, fn
     assert_no_leaks()
+
+
+def test_elif_chain_jits():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def classify(x: i32) -> i32:
+        if x < 0:
+            r = yield llvm.const_int(i32, -1)
+        elif x.eq(llvm.const_int(i32, 0)):
+            r = yield llvm.const_int(i32, 0)
+        else:
+            r = yield llvm.const_int(i32, 1)
+        return r
+
+    printed = str(mod)
+    assert printed.count("phi i32") == 2  # nested elif phis
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("classify"))
+    assert fn(-5) == -1
+    assert fn(0) == 0
+    assert fn(7) == 1
+    del jit, mod, ctx, classify, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
@@ -4,6 +4,8 @@
 import pytest
 
 import llvm
+from llvm.ast.canonicalize import canonicalize
+from llvm.dsl.cf import LLVMCanonicalizer
 from llvm.testing import assert_no_leaks
 
 
@@ -14,6 +16,7 @@ def test_break_raises_not_implemented():
         with pytest.raises(NotImplementedError, match="break"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
@@ -34,6 +37,7 @@ def test_early_return_in_if_raises():
         with pytest.raises(NotImplementedError, match="return"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad2(c: llvm.types.i1, a: i32) -> i32:
                 if c:
                     return a
@@ -50,6 +54,7 @@ def test_continue_raises_not_implemented():
         with pytest.raises(NotImplementedError, match="continue"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad3(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
@@ -1,0 +1,61 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_break_raises_not_implemented():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="break"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    if i.eq(llvm.const_int(i32, 3)):
+                        r = yield
+                    break
+                    yield acc
+                return acc
+
+        del mod
+    assert_no_leaks()
+
+
+def test_early_return_in_if_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="return"):
+
+            @llvm.function(module=mod)
+            def bad2(c: llvm.i1, a: i32) -> i32:
+                if c:
+                    return a
+                return a
+
+        del mod
+    assert_no_leaks()
+
+
+def test_continue_raises_not_implemented():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        with pytest.raises(NotImplementedError, match="continue"):
+
+            @llvm.function(module=mod)
+            def bad3(n: i32) -> i32:
+                acc = llvm.const_int(i32, 0)
+                for i in range_(0, n):
+                    continue
+                    yield acc
+                return acc
+
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
@@ -10,7 +10,7 @@ from llvm.testing import assert_no_leaks
 def test_break_raises_not_implemented():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="break"):
 
             @llvm.function(module=mod)
@@ -30,11 +30,11 @@ def test_break_raises_not_implemented():
 def test_early_return_in_if_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="return"):
 
             @llvm.function(module=mod)
-            def bad2(c: llvm.i1, a: i32) -> i32:
+            def bad2(c: llvm.types.i1, a: i32) -> i32:
                 if c:
                     return a
                 return a
@@ -46,7 +46,7 @@ def test_early_return_in_if_raises():
 def test_continue_raises_not_implemented():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="continue"):
 
             @llvm.function(module=mod)


### PR DESCRIPTION
Lowers Python control flow to basic blocks and phi nodes.

- `if` / `elif` / `else`.
- `while`, and `for` over `range_`, with loop-carried phis. A phi-based loop runtime is fed by AST transforms that lift each loop body into nested cond/body functions parameterized by the carried variables.
- `break`, `continue`, and early `return` raise `NotImplementedError` for now.