### PR TITLE
[eudsl-llvmpy] DSL @function: declarations, calls, returns, linkage/cc/attrs/varargs

### DIFF
--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -58,7 +58,9 @@ class DSLFunction:
         return maybe_downcast(call, self.fn)
 
 
-def function(*, module, name=None):
+def function(
+    *, module, name=None, linkage=None, calling_conv=None, attrs=None, var_arg=False
+):
     def decorator(f):
         ctx = module.context
         sig = inspect.signature(f)
@@ -66,7 +68,15 @@ def function(*, module, name=None):
         ret_type = _resolve(sig.return_annotation, ctx)
         fn_name = name or f.__name__
 
-        fn = Function.create(function_t(ret_type, param_types), fn_name, module)
+        fn = Function.create(
+            function_t(ret_type, param_types, var_arg=var_arg), fn_name, module
+        )
+        if linkage is not None:
+            fn.linkage = linkage
+        if calling_conv is not None:
+            fn.calling_conv = calling_conv
+        for k, v in (attrs or {}).items():
+            fn.add_fn_attr(k, v)
 
         # Empty body -> declaration: no entry block, stays a `declare`.
         if _body_is_empty(f):

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -3,13 +3,15 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """The @function decorator: turn a Python function into an LLVM function."""
 
+import ast
 import inspect
 
 from .. import Function, IRBuilder
 from ..eudslllvm_ext.types import Type
 from ..eudslllvm_ext.types import function as function_t
+from ..ast.util import get_module_cst
 from .casters import maybe_downcast
-from .context import building
+from .context import building, current_builder
 
 
 def _resolve(annotation, ctx):
@@ -25,6 +27,37 @@ def _resolve(annotation, ctx):
     raise TypeError(f"cannot resolve type annotation {annotation!r}")
 
 
+def _body_is_empty(f) -> bool:
+    """True if f's body is only `...`, `pass`, and/or a docstring (a declaration)."""
+    fn_node = get_module_cst(f).body[0]
+    for stmt in fn_node.body:
+        if isinstance(stmt, ast.Pass):
+            continue
+        if isinstance(stmt, ast.Expr) and isinstance(
+            stmt.value, ast.Constant
+        ):
+            # `...` (Ellipsis) or a docstring.
+            continue
+        return False
+    return True
+
+
+class DSLFunction:
+    """Wraps a bound llvm.Function so it can be called from inside another
+    @function body (emitting a `call`), while still exposing the Function."""
+
+    def __init__(self, fn: Function):
+        self.fn = fn
+
+    @property
+    def name(self):
+        return self.fn.name
+
+    def __call__(self, *args):
+        call = current_builder().call(self.fn, list(args))
+        return maybe_downcast(call, self.fn)
+
+
 def function(*, module, name=None):
     def decorator(f):
         ctx = module.context
@@ -34,6 +67,11 @@ def function(*, module, name=None):
         fn_name = name or f.__name__
 
         fn = Function.create(function_t(ret_type, param_types), fn_name, module)
+
+        # Empty body -> declaration: no entry block, stays a `declare`.
+        if _body_is_empty(f):
+            return DSLFunction(fn)
+
         entry = fn.append_basic_block("entry")
         builder = IRBuilder(ctx)
 
@@ -44,6 +82,6 @@ def function(*, module, name=None):
                 builder.ret(result)
             elif builder.insert_block.terminator is None:
                 builder.ret(None)
-        return fn
+        return DSLFunction(fn)
 
     return decorator

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -2,6 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ctypes
+import re
 
 import pytest
 
@@ -758,8 +759,8 @@ def test_if_else_phi_has_correct_incomings():
         mod.verify()
         printed = str(mod)
         assert printed.count("phi i32") == 1
-        import re
-        assert len(re.findall(r"\[.*?,\s*%\w+\]", [l for l in printed.splitlines() if "phi i32" in l][0])) == 2
+        phi_line = [l for l in printed.splitlines() if "phi i32" in l][0]
+        assert len(re.findall(r"\[.*?,\s*%[\w.]+\s*\]", phi_line)) == 2
         del mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -578,7 +578,7 @@ def test_elif_elif_three_way():
     @canonicalize(using=LLVMCanonicalizer())
     def sign(x: i32) -> i32:
         if x < 0:
-            r = yield llvm.const_int(i32, -1)
+            r = yield llvm.const_int(i32, -1, signed=True)
         elif x.eq(llvm.const_int(i32, 0)):
             r = yield llvm.const_int(i32, 0)
         elif x < 10:

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -573,6 +573,7 @@ def test_if_no_else_side_effect_only():
     printed = str(mod)
     assert "br i1" in printed
     assert "store i32 0" in printed
+    mod.verify()
     del mod, ctx, clamp0, i32
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -547,6 +547,153 @@ def test_for_negative_step_countdown_jits():
     del jit, mod, fn_ptr, ctx
 
 
+def test_if_no_else_side_effect_only():
+    # A single-branch if with no yielded result: side effect via store.
+    from llvm.dsl.values import with_element_type
+
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def clamp0(c: llvm.types.i1, p: llvm.types.ptr) -> i32:
+        tp = with_element_type(p, i32)
+        if c:
+            tp[0] = llvm.const_int(i32, 0)
+        return tp[0]
+
+    printed = str(mod)
+    assert "br i1" in printed
+    assert "store i32 0" in printed
+    del mod, ctx, clamp0, i32
+    assert_no_leaks()
+
+
+def test_elif_elif_three_way():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sign(x: i32) -> i32:
+        if x < 0:
+            r = yield llvm.const_int(i32, -1)
+        elif x.eq(llvm.const_int(i32, 0)):
+            r = yield llvm.const_int(i32, 0)
+        elif x < 10:
+            r = yield llvm.const_int(i32, 1)
+        else:
+            r = yield llvm.const_int(i32, 2)
+        return r
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("sign"))
+    assert fn(-4) == -1
+    assert fn(0) == 0
+    assert fn(5) == 1
+    assert fn(99) == 2
+    del jit, mod, ctx, sign, i32, fn
+    assert_no_leaks()
+
+
+def test_while_two_carried_values():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    # Fibonacci-ish: iterate n times advancing (a, b) -> (b, a+b).
+    @llvm.function(module=mod)
+    def fib(n: i32) -> i32:
+        a = llvm.const_int(i32, 0)
+        b = llvm.const_int(i32, 1)
+        i = llvm.const_int(i32, 0)
+        while i.ne(n):
+            a, b = b, a + b
+            i = i + 1
+            yield a, b, i
+        return a
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("fib"))
+    assert fn(0) == 0
+    assert fn(1) == 1
+    assert fn(7) == 13  # 0,1,1,2,3,5,8,13
+    del jit, mod, ctx, fib, i32, fn
+    assert_no_leaks()
+
+
+def test_for_with_step_and_two_carried():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    # Sum every other value in [0, n) and count how many; step 2.
+    @llvm.function(module=mod)
+    def strided(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        cnt = llvm.const_int(i32, 0)
+        for i in range_(0, n, 2):
+            acc = acc + i
+            cnt = cnt + 1
+            yield acc, cnt
+        return acc
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("strided"))
+    assert fn(10) == 0 + 2 + 4 + 6 + 8
+    assert fn(1) == 0
+    del jit, mod, ctx, strided, i32, fn
+    assert_no_leaks()
+
+
+def test_for_result_used_after_loop():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def total_plus_one(n: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(0, n):
+            acc = acc + i
+            yield acc
+        return acc + 1
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total_plus_one"))
+    assert fn(5) == (0 + 1 + 2 + 3 + 4) + 1
+    del jit, mod, ctx, total_plus_one, i32, fn
+    assert_no_leaks()
+
+
+def test_for_mixed_start_stop():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def sum_range(lo: i32, hi: i32) -> i32:
+        acc = llvm.const_int(i32, 0)
+        for i in range_(lo, hi):
+            acc = acc + i
+            yield acc
+        return acc
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+        jit.lookup("sum_range")
+    )
+    assert fn(2, 5) == 2 + 3 + 4
+    assert fn(5, 5) == 0
+    del jit, mod, ctx, sum_range, i32, fn
+    assert_no_leaks()
+
+
 def test_early_return_inside_while_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
@@ -598,11 +745,9 @@ def test_if_else_phi_has_correct_incomings():
 
         mod.verify()
         printed = str(mod)
-        # phi must have exactly 2 incoming edges (then and else branches).
         assert printed.count("phi i32") == 1
-        # Each incoming is [value, %block_label]; there should be 2 of them.
-        phi_line = [l for l in printed.splitlines() if "phi i32" in l][0]
-        assert phi_line.count("[") == 2
+        import re
+        assert len(re.findall(r"\[.*?,\s*%\w+\]", [l for l in printed.splitlines() if "phi i32" in l][0])) == 2
         del mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -141,12 +141,19 @@ def test_for_range_sum_jits():
 
 
 def test_function_void_no_explicit_return():
+    # A non-empty body (an empty/pass/docstring-only body is a declaration,
+    # not a definition) that falls off the end without a DSL `return` still
+    # needs the entry block terminated with `ret void`.
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
-        def noop() -> llvm.types.void:
-            pass
+        def store_and_fall_through(p: llvm.types.ptr) -> llvm.types.void:
+            from llvm.dsl.values import with_element_type
+
+            tp = with_element_type(p, i32)
+            tp[0] = llvm.const_int(i32, 0)
 
         assert "ret void" in str(mod)
         del mod

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf.py
@@ -8,6 +8,7 @@ import pytest
 import llvm
 from llvm.ast.canonicalize import canonicalize
 from llvm.dsl.cf import LLVMCanonicalizer
+from llvm.dsl.values import with_element_type
 from llvm.testing import assert_no_leaks
 
 
@@ -549,13 +550,12 @@ def test_for_negative_step_countdown_jits():
 
 def test_if_no_else_side_effect_only():
     # A single-branch if with no yielded result: side effect via store.
-    from llvm.dsl.values import with_element_type
-
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def clamp0(c: llvm.types.i1, p: llvm.types.ptr) -> i32:
         tp = with_element_type(p, i32)
         if c:
@@ -575,6 +575,7 @@ def test_elif_elif_three_way():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sign(x: i32) -> i32:
         if x < 0:
             r = yield llvm.const_int(i32, -1)
@@ -604,6 +605,7 @@ def test_while_two_carried_values():
 
     # Fibonacci-ish: iterate n times advancing (a, b) -> (b, a+b).
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def fib(n: i32) -> i32:
         a = llvm.const_int(i32, 0)
         b = llvm.const_int(i32, 1)
@@ -631,6 +633,7 @@ def test_for_with_step_and_two_carried():
 
     # Sum every other value in [0, n) and count how many; step 2.
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def strided(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         cnt = llvm.const_int(i32, 0)
@@ -655,6 +658,7 @@ def test_for_result_used_after_loop():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def total_plus_one(n: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(0, n):
@@ -676,6 +680,7 @@ def test_for_mixed_start_stop():
     i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
     def sum_range(lo: i32, hi: i32) -> i32:
         acc = llvm.const_int(i32, 0)
         for i in range_(lo, hi):

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
@@ -1,6 +1,7 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Unsupported control flow must raise NotImplementedError, not miscompile."""
 import pytest
 
 import llvm
@@ -9,7 +10,7 @@ from llvm.dsl.cf import LLVMCanonicalizer
 from llvm.testing import assert_no_leaks
 
 
-def test_break_raises_not_implemented():
+def test_break_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
@@ -18,16 +19,30 @@ def test_break_raises_not_implemented():
             @llvm.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
-                acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
                     if i.eq(llvm.const_int(i32, 3)):
-                        r = yield
-                    break
-                    yield acc
-                return acc
+                        break
+                    yield i
+                return n
 
         del mod
-    assert_no_leaks()
+
+
+def test_continue_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="continue"):
+
+            @llvm.function(module=mod)
+            def bad(n: i32) -> i32:
+                for i in range_(0, n):
+                    if i.eq(llvm.const_int(i32, 3)):
+                        continue
+                    yield i
+                return n
+
+        del mod
 
 
 def test_early_return_in_if_raises():
@@ -44,23 +59,41 @@ def test_early_return_in_if_raises():
                 return a
 
         del mod
-    assert_no_leaks()
 
 
-def test_continue_raises_not_implemented():
+def test_nested_control_flow_in_loop_raises():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
-        with pytest.raises(NotImplementedError, match="continue"):
+        with pytest.raises(NotImplementedError, match="nested inside"):
 
             @llvm.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def bad3(n: i32) -> i32:
                 acc = llvm.const_int(i32, 0)
                 for i in range_(0, n):
-                    continue
+                    if i < n:
+                        acc = yield i
                     yield acc
                 return acc
 
+        del mod
+
+
+def test_trailing_return_is_allowed():
+    # The function's own trailing return must NOT be rejected.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def ok(c: llvm.types.i1, a: i32, b: i32) -> i32:
+            if c:
+                r = yield a
+            else:
+                r = yield b
+            return r
+
+        assert "phi i32" in str(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_cf_reject.py
@@ -35,6 +35,7 @@ def test_continue_raises():
         with pytest.raises(NotImplementedError, match="continue"):
 
             @llvm.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 for i in range_(0, n):
                     if i.eq(llvm.const_int(i32, 3)):
@@ -87,6 +88,7 @@ def test_trailing_return_is_allowed():
         i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
         def ok(c: llvm.types.i1, a: i32, b: i32) -> i32:
             if c:
                 r = yield a

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -22,6 +22,20 @@ def test_declaration_has_no_body():
     assert_no_leaks()
 
 
+def test_declaration_with_pass_body():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def extern(a: i32) -> i32:
+            pass
+
+        assert "declare i32 @extern(i32)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
 def test_call_between_functions_jits():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
@@ -59,6 +73,20 @@ def test_function_options():
         printed = str(mod)
         assert "define internal i32 @f" in printed
         assert 'target-cpu"="znver3' in printed
+        del mod
+    assert_no_leaks()
+
+
+def test_function_calling_conv():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod, calling_conv=llvm.CallingConv.FAST)
+        def f(x: i32) -> i32:
+            return x
+
+        assert "define fastcc i32 @f" in str(mod)
         del mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -10,7 +10,7 @@ from llvm.testing import assert_no_leaks
 def test_declaration_has_no_body():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod)
         def extern(a: i32) -> i32: ...
@@ -25,7 +25,7 @@ def test_declaration_has_no_body():
 def test_call_between_functions_jits():
     ctx = llvm.Context()
     mod = llvm.Module("m", ctx)
-    i32 = llvm.i32(ctx)
+    i32 = llvm.types.i32(ctx)
 
     @llvm.function(module=mod)
     def inc(x: i32) -> i32:
@@ -46,7 +46,7 @@ def test_call_between_functions_jits():
 def test_function_options():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
 
         @llvm.function(
             module=mod,
@@ -66,10 +66,10 @@ def test_function_options():
 def test_varargs_declaration():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
+        i32 = llvm.types.i32(ctx)
 
         @llvm.function(module=mod, var_arg=True)
-        def printf_like(fmt: llvm.ptr_t(ctx)) -> i32: ...
+        def printf_like(fmt: llvm.types.ptr(ctx)) -> i32: ...
 
         assert "declare i32 @printf_like(ptr, ...)" in str(mod)
         del mod

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -41,3 +41,36 @@ def test_call_between_functions_jits():
     assert fn(40) == 42
     del jit, mod, ctx, inc, inc2, i32, fn
     assert_no_leaks()
+
+
+def test_function_options():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+
+        @llvm.function(
+            module=mod,
+            linkage=llvm.Linkage.INTERNAL,
+            attrs={"target-cpu": "znver3"},
+        )
+        def f(x: i32) -> i32:
+            return x
+
+        printed = str(mod)
+        assert "define internal i32 @f" in printed
+        assert 'target-cpu"="znver3' in printed
+        del mod
+    assert_no_leaks()
+
+
+def test_varargs_declaration():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+
+        @llvm.function(module=mod, var_arg=True)
+        def printf_like(fmt: llvm.ptr_t(ctx)) -> i32: ...
+
+        assert "declare i32 @printf_like(ptr, ...)" in str(mod)
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -1,0 +1,43 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ctypes
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_declaration_has_no_body():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+
+        @llvm.function(module=mod)
+        def extern(a: i32) -> i32: ...
+
+        printed = str(mod)
+        assert "declare i32 @extern(i32)" in printed
+        assert extern.name == "extern"
+        del mod
+    assert_no_leaks()
+
+
+def test_call_between_functions_jits():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.i32(ctx)
+
+    @llvm.function(module=mod)
+    def inc(x: i32) -> i32:
+        return x + 1
+
+    @llvm.function(module=mod)
+    def inc2(x: i32) -> i32:
+        return inc(inc(x))
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("inc2"))
+    assert fn(40) == 42
+    del jit, mod, ctx, inc, inc2, i32, fn
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/test_dsl_func.py
@@ -102,3 +102,87 @@ def test_varargs_declaration():
         assert "declare i32 @printf_like(ptr, ...)" in str(mod)
         del mod
     assert_no_leaks()
+
+
+def test_declaration_with_docstring_only():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def extern(a: i32) -> i32:
+            """An external function."""
+
+        assert "declare i32 @extern(i32)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_real_body_is_not_treated_as_empty():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod)
+        def f(x: i32) -> i32:
+            return x + 1
+
+        assert "define i32 @f" in str(mod)
+        assert "add i32" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_call_declared_extern_from_function_body():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def add_one(x: i32) -> i32:
+        return x + 1
+
+    @llvm.function(module=mod)
+    def extern(x: i32) -> i32: ...
+
+    @llvm.function(module=mod)
+    def caller(x: i32) -> i32:
+        return add_one(extern(x))
+
+    printed = str(mod)
+    assert "call i32 @extern" in printed
+    assert "call i32 @add_one" in printed
+    del mod, ctx, add_one, extern, caller, i32
+    assert_no_leaks()
+
+
+def test_zero_arg_function():
+    ctx = llvm.Context()
+    mod = llvm.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.function(module=mod)
+    def constant() -> i32:
+        return llvm.const_int(i32, 42)
+
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32)(jit.lookup("constant"))
+    assert fn() == 42
+    del jit, mod, ctx, constant, i32, fn
+    assert_no_leaks()
+
+
+def test_name_override():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.function(module=mod, name="custom_name")
+        def f(x: i32) -> i32:
+            return x
+
+        assert "define i32 @custom_name" in str(mod)
+        assert f.name == "custom_name"
+        del mod
+    assert_no_leaks()


### PR DESCRIPTION
Adds the `@function` decorator: function definitions, empty-body declarations, calls through `__call__`, returns, and linkage, calling-convention, attribute, and varargs specification.
