### PR TITLE
[eudsl-llvmpy] C++ object layer: llvm::Type hierarchy, factories, and type_hook downcasting

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -99,6 +99,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Ownership.cpp
   src/IR/Context.cpp
   src/IR/Types.cpp
+  src/IR/Kinds.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -98,6 +98,7 @@ nanobind_add_module(eudslllvm_ext
   src/eudslllvm_ext.cpp
   src/IR/Ownership.cpp
   src/IR/Context.cpp
+  src/IR/Types.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/pyproject.toml
+++ b/projects/eudsl-llvmpy/pyproject.toml
@@ -26,7 +26,7 @@ build-dir = "build/{wheel_tag}"
 cmake.source-dir = "."
 wheel.packages = ["src/llvm"]
 wheel.py-api = "cp312"
-editable.mode = "inplace"
+editable.mode = "redirect"
 editable.verbose = true
 editable.rebuild = false
 

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -8,6 +8,9 @@
 #include <llvm/Support/raw_ostream.h>
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 
 #include <cstdint>
 #include <string>

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -44,3 +44,8 @@ inline void unwrap(llvm::Error &&e) {
 }
 
 } // namespace eudsl
+
+// Pulled in here so every translation unit that returns an llvm::Type* or
+// llvm::Value* sees the downcasting type_hook specializations. Without this a
+// TU would silently fall back to base-class conversion.
+#include "IR/Kinds.h"

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -9,6 +9,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/projects/eudsl-llvmpy/src/IR/Kinds.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.cpp
@@ -8,11 +8,6 @@
 
 namespace eudsl {
 
-const std::type_info *pick(const std::type_info *concrete,
-                           const std::type_info *base) {
-  return nanobind::detail::nb_type_lookup(concrete) ? concrete : base;
-}
-
 const std::type_info *typeTypeInfo(llvm::Type::TypeID id) {
   switch (id) {
   case llvm::Type::IntegerTyID:
@@ -26,8 +21,9 @@ const std::type_info *typeTypeInfo(llvm::Type::TypeID id) {
   case llvm::Type::ArrayTyID:
     return &typeid(llvm::ArrayType);
   case llvm::Type::FixedVectorTyID:
+    return &typeid(llvm::FixedVectorType);
   case llvm::Type::ScalableVectorTyID:
-    return &typeid(llvm::VectorType);
+    return &typeid(llvm::ScalableVectorType);
   default:
     // Void, Label, Metadata, Token, the float kinds, TypedPointer and
     // TargetExtType have no bound subclass; they stay llvm::Type.

--- a/projects/eudsl-llvmpy/src/IR/Kinds.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.cpp
@@ -1,0 +1,38 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Kinds.h"
+
+#include <llvm/IR/DerivedTypes.h>
+
+namespace eudsl {
+
+const std::type_info *pick(const std::type_info *concrete,
+                           const std::type_info *base) {
+  return nanobind::detail::nb_type_lookup(concrete) ? concrete : base;
+}
+
+const std::type_info *typeTypeInfo(llvm::Type::TypeID id) {
+  switch (id) {
+  case llvm::Type::IntegerTyID:
+    return &typeid(llvm::IntegerType);
+  case llvm::Type::FunctionTyID:
+    return &typeid(llvm::FunctionType);
+  case llvm::Type::PointerTyID:
+    return &typeid(llvm::PointerType);
+  case llvm::Type::StructTyID:
+    return &typeid(llvm::StructType);
+  case llvm::Type::ArrayTyID:
+    return &typeid(llvm::ArrayType);
+  case llvm::Type::FixedVectorTyID:
+  case llvm::Type::ScalableVectorTyID:
+    return &typeid(llvm::VectorType);
+  default:
+    // Void, Label, Metadata, Token, the float kinds, TypedPointer and
+    // TargetExtType have no bound subclass; they stay llvm::Type.
+    return &typeid(llvm::Type);
+  }
+}
+
+} // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -1,0 +1,43 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Downcasting support. llvm::Value and llvm::Type are deliberately
+// non-polymorphic (Value.h documents the non-virtual destructor), so
+// nanobind's RTTI-based downcast cannot see through a base pointer.
+// nanobind::detail::type_hook is the documented hook for this case.
+//
+// INVARIANT: every std::type_info returned here must name a class registered
+// with nanobind, otherwise the conversion raises "Unable to convert function
+// return value to a Python type". valueTypeInfo() guards each return with
+// pick() so a not-yet-registered class falls back to base Value, keeping every
+// commit green while later tasks register the leaves.
+
+#pragma once
+
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Value.h>
+
+#include <nanobind/nanobind.h>
+
+#include <typeinfo>
+
+namespace eudsl {
+const std::type_info *typeTypeInfo(llvm::Type::TypeID id);
+const std::type_info *valueTypeInfo(unsigned valueID);
+/// Return `concrete` if a nanobind class is registered for it, else `base`.
+const std::type_info *pick(const std::type_info *concrete,
+                           const std::type_info *base);
+} // namespace eudsl
+
+template <> struct nanobind::detail::type_hook<llvm::Type> {
+  static const std::type_info *get(llvm::Type *t) {
+    return t ? eudsl::typeTypeInfo(t->getTypeID()) : &typeid(llvm::Type);
+  }
+};
+
+template <> struct nanobind::detail::type_hook<llvm::Value> {
+  static const std::type_info *get(llvm::Value *v) {
+    return v ? eudsl::valueTypeInfo(v->getValueID()) : &typeid(llvm::Value);
+  }
+};

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -2,42 +2,36 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Downcasting support. llvm::Value and llvm::Type are deliberately
-// non-polymorphic (Value.h documents the non-virtual destructor), so
-// nanobind's RTTI-based downcast cannot see through a base pointer.
-// nanobind::detail::type_hook is the documented hook for this case.
+// Downcasting support for llvm::Type. llvm::Type is deliberately
+// non-polymorphic (Type.h has no virtual destructor), so nanobind's RTTI-based
+// downcast cannot see through a base pointer. nanobind::detail::type_hook is
+// the documented hook for this case. The llvm::Value analogue (valueTypeInfo
+// and type_hook<llvm::Value>) lives with the Value bindings, the PR that
+// registers the leaf Value classes it names.
 //
 // INVARIANT: every std::type_info returned here must name a class registered
 // with nanobind, otherwise the conversion raises "Unable to convert function
-// return value to a Python type". valueTypeInfo() guards each return with
-// pick() so a not-yet-registered class falls back to base Value, keeping every
-// commit green while later tasks register the leaves.
+// return value to a Python type". typeTypeInfo only names classes registered in
+// this PR.
 
 #pragma once
 
 #include <llvm/IR/Type.h>
-#include <llvm/IR/Value.h>
 
 #include <nanobind/nanobind.h>
 
+#include <cassert>
 #include <typeinfo>
 
 namespace eudsl {
 const std::type_info *typeTypeInfo(llvm::Type::TypeID id);
-const std::type_info *valueTypeInfo(unsigned valueID);
-/// Return `concrete` if a nanobind class is registered for it, else `base`.
-const std::type_info *pick(const std::type_info *concrete,
-                           const std::type_info *base);
 } // namespace eudsl
 
 template <> struct nanobind::detail::type_hook<llvm::Type> {
   static const std::type_info *get(llvm::Type *t) {
-    return t ? eudsl::typeTypeInfo(t->getTypeID()) : &typeid(llvm::Type);
-  }
-};
-
-template <> struct nanobind::detail::type_hook<llvm::Value> {
-  static const std::type_info *get(llvm::Value *v) {
-    return v ? eudsl::valueTypeInfo(v->getValueID()) : &typeid(llvm::Value);
+    // nanobind resolves a null pointer to None before consulting the hook, so
+    // a non-null argument is an invariant here.
+    assert(t && "type_hook<llvm::Type> invoked with a null pointer");
+    return eudsl::typeTypeInfo(t->getTypeID());
   }
 };

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -49,8 +49,8 @@ void populate_types(nb::module_ &m) {
       },                                                                       \
       "context"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>())
 
-  EUDSL_PRIMITIVE_TYPE("void_t", getVoidTy);
-  EUDSL_PRIMITIVE_TYPE("label_t", getLabelTy);
+  EUDSL_PRIMITIVE_TYPE("void", getVoidTy);
+  EUDSL_PRIMITIVE_TYPE("label", getLabelTy);
   EUDSL_PRIMITIVE_TYPE("i1", getInt1Ty);
   EUDSL_PRIMITIVE_TYPE("i8", getInt8Ty);
   EUDSL_PRIMITIVE_TYPE("i16", getInt16Ty);
@@ -102,6 +102,13 @@ void populate_types(nb::module_ &m) {
       .def_prop_ro("element_type", &llvm::VectorType::getElementType,
                    nb::rv_policy::reference);
 
+  nb::class_<llvm::FixedVectorType, llvm::VectorType>(m, "FixedVectorType")
+      .def_prop_ro("num_elements", &llvm::FixedVectorType::getNumElements);
+
+  nb::class_<llvm::ScalableVectorType, llvm::VectorType>(m, "ScalableVectorType")
+      .def_prop_ro("min_num_elements",
+                   &llvm::ScalableVectorType::getMinNumElements);
+
   nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType")
       .def_prop_ro("return_type", &llvm::FunctionType::getReturnType,
                    nb::rv_policy::reference)
@@ -116,20 +123,20 @@ void populate_types(nb::module_ &m) {
       .def_prop_ro("is_var_arg", &llvm::FunctionType::isVarArg);
 
   m.def(
-      "int_t",
+      "int",
       [](eudsl::Context &ctx, unsigned bits) -> llvm::Type * {
         return llvm::IntegerType::get(ctx.get(), bits);
       },
       "context"_a, "bits"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
   m.def(
-      "ptr_t",
+      "ptr",
       [](eudsl::Context &ctx, unsigned addressSpace) -> llvm::Type * {
         return llvm::PointerType::get(ctx.get(), addressSpace);
       },
       "context"_a, "address_space"_a = 0, nb::rv_policy::reference,
       nb::keep_alive<0, 1>());
   m.def(
-      "struct_t",
+      "struct",
       [](eudsl::Context &ctx, std::vector<llvm::Type *> elts,
          bool packed) -> llvm::Type * {
         return llvm::StructType::get(ctx.get(), elts, packed);
@@ -137,27 +144,27 @@ void populate_types(nb::module_ &m) {
       "context"_a, "element_types"_a, "packed"_a = false,
       nb::rv_policy::reference, nb::keep_alive<0, 1>());
   m.def(
-      "named_struct_t",
+      "named_struct",
       [](eudsl::Context &ctx, const std::string &name) -> llvm::Type * {
         return llvm::StructType::create(ctx.get(), name);
       },
       "context"_a, "name"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
   m.def(
-      "array_t",
+      "array",
       [](llvm::Type *elt, uint64_t n) -> llvm::Type * {
         return llvm::ArrayType::get(elt, n);
       },
       "element_type"_a, "num_elements"_a, nb::rv_policy::reference,
       nb::keep_alive<0, 1>());
   m.def(
-      "vector_t",
+      "vector",
       [](llvm::Type *elt, unsigned n, bool scalable) -> llvm::Type * {
         return llvm::VectorType::get(elt, n, scalable);
       },
       "element_type"_a, "num_elements"_a, "scalable"_a = false,
       nb::rv_policy::reference, nb::keep_alive<0, 1>());
   m.def(
-      "function_t",
+      "function",
       [](llvm::Type *ret, std::vector<llvm::Type *> params,
          bool varArg) -> llvm::Type * {
         return llvm::FunctionType::get(ret, params, varArg);

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -1,0 +1,57 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/Type.h>
+
+#include <nanobind/stl/string.h>
+
+void populate_types(nb::module_ &m) {
+  nb::class_<llvm::Type>(m, "Type")
+      .def_prop_ro("is_void", &llvm::Type::isVoidTy)
+      .def_prop_ro("is_label", &llvm::Type::isLabelTy)
+      .def_prop_ro("is_integer",
+                   [](llvm::Type &self) { return self.isIntegerTy(); })
+      .def_prop_ro("is_floating_point", &llvm::Type::isFloatingPointTy)
+      .def_prop_ro("is_pointer", &llvm::Type::isPointerTy)
+      .def_prop_ro("is_sized", [](llvm::Type &self) { return self.isSized(); })
+      .def("__str__", [](llvm::Type &self) { return eudsl::toString(self); })
+      .def("__eq__",
+           [](llvm::Type &self, nb::handle other) {
+             llvm::Type *o;
+             if (!nb::try_cast<llvm::Type *>(other, o))
+               return false;
+             return &self == o;
+           })
+      .def("__hash__", [](llvm::Type &self) {
+        return static_cast<Py_ssize_t>(
+            reinterpret_cast<std::uintptr_t>(&self));
+      });
+
+  // Primitive type factories. Each takes the owning context and returns an
+  // interned Type*, non-owning, kept alive by the context (keep_alive<0,1>:
+  // the returned type keeps its context argument alive). reference_internal is
+  // not usable here because these are free functions with no bound self.
+#define EUDSL_PRIMITIVE_TYPE(pyName, getter)                                   \
+  m.def(                                                                       \
+      pyName,                                                                  \
+      [](eudsl::Context &ctx) -> llvm::Type * {                                \
+        return llvm::Type::getter(ctx.get());                                  \
+      },                                                                       \
+      "context"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>())
+
+  EUDSL_PRIMITIVE_TYPE("void_t", getVoidTy);
+  EUDSL_PRIMITIVE_TYPE("label_t", getLabelTy);
+  EUDSL_PRIMITIVE_TYPE("i1", getInt1Ty);
+  EUDSL_PRIMITIVE_TYPE("i8", getInt8Ty);
+  EUDSL_PRIMITIVE_TYPE("i16", getInt16Ty);
+  EUDSL_PRIMITIVE_TYPE("i32", getInt32Ty);
+  EUDSL_PRIMITIVE_TYPE("i64", getInt64Ty);
+  EUDSL_PRIMITIVE_TYPE("f16", getHalfTy);
+  EUDSL_PRIMITIVE_TYPE("f32", getFloatTy);
+  EUDSL_PRIMITIVE_TYPE("f64", getDoubleTy);
+#undef EUDSL_PRIMITIVE_TYPE
+}

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -5,9 +5,15 @@
 #include "IR/Common.h"
 #include "IR/Ownership.h"
 
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Type.h>
 
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <optional>
+#include <vector>
 
 void populate_types(nb::module_ &m) {
   nb::class_<llvm::Type>(m, "Type")
@@ -54,4 +60,109 @@ void populate_types(nb::module_ &m) {
   EUDSL_PRIMITIVE_TYPE("f32", getFloatTy);
   EUDSL_PRIMITIVE_TYPE("f64", getDoubleTy);
 #undef EUDSL_PRIMITIVE_TYPE
+
+  nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType")
+      .def_prop_ro("bit_width", &llvm::IntegerType::getBitWidth);
+
+  nb::class_<llvm::PointerType, llvm::Type>(m, "PointerType")
+      .def_prop_ro("address_space", &llvm::PointerType::getAddressSpace);
+
+  nb::class_<llvm::StructType, llvm::Type>(m, "StructType")
+      .def_prop_ro("name",
+                   [](llvm::StructType &self) -> std::optional<std::string> {
+                     if (!self.hasName())
+                       return std::nullopt;
+                     return self.getName().str();
+                   })
+      .def_prop_ro("num_elements", &llvm::StructType::getNumElements)
+      .def("element_type", &llvm::StructType::getElementType, "index"_a,
+           nb::rv_policy::reference)
+      .def_prop_ro("is_packed", &llvm::StructType::isPacked)
+      .def_prop_ro("is_opaque", &llvm::StructType::isOpaque)
+      .def(
+          "set_body",
+          [](llvm::StructType &self, std::vector<llvm::Type *> elts,
+             bool packed) { self.setBody(elts, packed); },
+          "element_types"_a, "packed"_a = false);
+
+  nb::class_<llvm::ArrayType, llvm::Type>(m, "ArrayType")
+      .def_prop_ro("num_elements", &llvm::ArrayType::getNumElements)
+      .def_prop_ro("element_type", &llvm::ArrayType::getElementType,
+                   nb::rv_policy::reference);
+
+  nb::class_<llvm::VectorType, llvm::Type>(m, "VectorType")
+      .def_prop_ro("min_num_elements",
+                   [](llvm::VectorType &self) {
+                     return self.getElementCount().getKnownMinValue();
+                   })
+      .def_prop_ro("is_scalable",
+                   [](llvm::VectorType &self) {
+                     return self.getElementCount().isScalable();
+                   })
+      .def_prop_ro("element_type", &llvm::VectorType::getElementType,
+                   nb::rv_policy::reference);
+
+  nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType")
+      .def_prop_ro("return_type", &llvm::FunctionType::getReturnType,
+                   nb::rv_policy::reference)
+      .def_prop_ro("num_params", &llvm::FunctionType::getNumParams)
+      .def("param_type", &llvm::FunctionType::getParamType, "index"_a,
+           nb::rv_policy::reference)
+      .def_prop_ro("params",
+                   [](llvm::FunctionType &self) {
+                     return std::vector<llvm::Type *>(self.param_begin(),
+                                                      self.param_end());
+                   })
+      .def_prop_ro("is_var_arg", &llvm::FunctionType::isVarArg);
+
+  m.def(
+      "int_t",
+      [](eudsl::Context &ctx, unsigned bits) -> llvm::Type * {
+        return llvm::IntegerType::get(ctx.get(), bits);
+      },
+      "context"_a, "bits"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "ptr_t",
+      [](eudsl::Context &ctx, unsigned addressSpace) -> llvm::Type * {
+        return llvm::PointerType::get(ctx.get(), addressSpace);
+      },
+      "context"_a, "address_space"_a = 0, nb::rv_policy::reference,
+      nb::keep_alive<0, 1>());
+  m.def(
+      "struct_t",
+      [](eudsl::Context &ctx, std::vector<llvm::Type *> elts,
+         bool packed) -> llvm::Type * {
+        return llvm::StructType::get(ctx.get(), elts, packed);
+      },
+      "context"_a, "element_types"_a, "packed"_a = false,
+      nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "named_struct_t",
+      [](eudsl::Context &ctx, const std::string &name) -> llvm::Type * {
+        return llvm::StructType::create(ctx.get(), name);
+      },
+      "context"_a, "name"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "array_t",
+      [](llvm::Type *elt, uint64_t n) -> llvm::Type * {
+        return llvm::ArrayType::get(elt, n);
+      },
+      "element_type"_a, "num_elements"_a, nb::rv_policy::reference,
+      nb::keep_alive<0, 1>());
+  m.def(
+      "vector_t",
+      [](llvm::Type *elt, unsigned n, bool scalable) -> llvm::Type * {
+        return llvm::VectorType::get(elt, n, scalable);
+      },
+      "element_type"_a, "num_elements"_a, "scalable"_a = false,
+      nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "function_t",
+      [](llvm::Type *ret, std::vector<llvm::Type *> params,
+         bool varArg) -> llvm::Type * {
+        return llvm::FunctionType::get(ret, params, varArg);
+      },
+      "return_type"_a, "params"_a, "var_arg"_a = false,
+      nb::rv_policy::reference, nb::keep_alive<0, 1>());
 }
+

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -7,8 +7,10 @@
 namespace nb = nanobind;
 
 void populate_context(nb::module_ &m);
+void populate_types(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
   populate_context(m);
+  populate_types(m);
 }

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -12,5 +12,6 @@ void populate_types(nb::module_ &m);
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
   populate_context(m);
-  populate_types(m);
+  nb::module_ types = m.def_submodule("types");
+  populate_types(types);
 }

--- a/projects/eudsl-llvmpy/tests/test_types.py
+++ b/projects/eudsl-llvmpy/tests/test_types.py
@@ -1,0 +1,37 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_primitive_types_print():
+    with llvm.Context() as ctx:
+        assert str(llvm.void_t(ctx)) == "void"
+        assert str(llvm.i1(ctx)) == "i1"
+        assert str(llvm.i32(ctx)) == "i32"
+        assert str(llvm.f32(ctx)) == "float"
+        assert str(llvm.f64(ctx)) == "double"
+        assert str(llvm.f16(ctx)) == "half"
+    assert_no_leaks()
+
+
+def test_type_predicates():
+    with llvm.Context() as ctx:
+        assert llvm.void_t(ctx).is_void
+        assert not llvm.void_t(ctx).is_sized
+        assert llvm.i32(ctx).is_integer
+        assert not llvm.i32(ctx).is_floating_point
+        assert llvm.f64(ctx).is_floating_point
+        assert llvm.i32(ctx).is_sized
+    assert_no_leaks()
+
+
+def test_types_are_uniqued_and_hashable():
+    with llvm.Context() as a, llvm.Context() as b:
+        assert llvm.i32(a) == llvm.i32(a)
+        assert llvm.i32(a) != llvm.i64(a)
+        # Types are interned per context, so two contexts give distinct types.
+        assert llvm.i32(a) != llvm.i32(b)
+        assert len({llvm.i32(a), llvm.i32(a), llvm.i64(a)}) == 2
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_types.py
+++ b/projects/eudsl-llvmpy/tests/test_types.py
@@ -72,3 +72,55 @@ def test_named_struct_prints_opaque():
         # once the Type type_hook makes named_struct_t return a StructType.
         assert str(named) == "%Pair = type opaque"
     assert_no_leaks()
+
+
+def test_types_downcast_to_concrete_classes():
+    with llvm.Context() as ctx:
+        assert type(llvm.i32(ctx)).__name__ == "IntegerType"
+        assert type(llvm.ptr_t(ctx)).__name__ == "PointerType"
+        assert type(llvm.array_t(llvm.i32(ctx), 2)).__name__ == "ArrayType"
+        assert type(llvm.vector_t(llvm.i32(ctx), 2)).__name__ == "VectorType"
+        assert type(llvm.struct_t(ctx, [llvm.i32(ctx)])).__name__ == "StructType"
+        assert (
+            type(llvm.function_t(llvm.void_t(ctx), [])).__name__ == "FunctionType"
+        )
+        # Types with no concrete subclass stay Type.
+        assert type(llvm.void_t(ctx)).__name__ == "Type"
+        assert type(llvm.f64(ctx)).__name__ == "Type"
+    assert_no_leaks()
+
+
+def test_concrete_type_accessors():
+    with llvm.Context() as ctx:
+        assert llvm.int_t(ctx, 7).bit_width == 7
+        assert llvm.ptr_t(ctx, 3).address_space == 3
+        a = llvm.array_t(llvm.i32(ctx), 4)
+        assert a.num_elements == 4
+        assert a.element_type == llvm.i32(ctx)
+        v = llvm.vector_t(llvm.f32(ctx), 8)
+        assert v.min_num_elements == 8
+        assert not v.is_scalable
+        assert llvm.vector_t(llvm.f32(ctx), 8, scalable=True).is_scalable
+        s = llvm.struct_t(ctx, [llvm.i32(ctx), llvm.f64(ctx)])
+        assert s.num_elements == 2
+        assert s.element_type(1) == llvm.f64(ctx)
+        assert not s.is_packed
+        assert llvm.struct_t(ctx, [llvm.i8(ctx)], packed=True).is_packed
+        ft = llvm.function_t(llvm.i32(ctx), [llvm.i32(ctx), llvm.f32(ctx)])
+        assert ft.return_type == llvm.i32(ctx)
+        assert ft.num_params == 2
+        assert ft.param_type(1) == llvm.f32(ctx)
+        assert ft.params == [llvm.i32(ctx), llvm.f32(ctx)]
+        assert not ft.is_var_arg
+    assert_no_leaks()
+
+
+def test_named_struct_set_body_and_name():
+    with llvm.Context() as ctx:
+        named = llvm.named_struct_t(ctx, "Pair")
+        assert named.name == "Pair"
+        assert named.is_opaque
+        named.set_body([llvm.i32(ctx), llvm.i32(ctx)])
+        assert not named.is_opaque
+        assert named.num_elements == 2
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_types.py
+++ b/projects/eudsl-llvmpy/tests/test_types.py
@@ -35,3 +35,40 @@ def test_types_are_uniqued_and_hashable():
         assert llvm.i32(a) != llvm.i32(b)
         assert len({llvm.i32(a), llvm.i32(a), llvm.i64(a)}) == 2
     assert_no_leaks()
+
+
+# Derived-type str() round-trips. Concrete-subclass accessors (.bit_width etc.)
+# and downcasting are validated in test_types_downcast (added with the Type
+# type_hook), since until the hook lands the factories return base Type objects.
+def test_derived_types_print():
+    with llvm.Context() as ctx:
+        assert str(llvm.int_t(ctx, 7)) == "i7"
+        assert str(llvm.ptr_t(ctx)) == "ptr"
+        assert str(llvm.ptr_t(ctx, 3)) == "ptr addrspace(3)"
+        assert str(llvm.array_t(llvm.i32(ctx), 4)) == "[4 x i32]"
+        assert str(llvm.vector_t(llvm.f32(ctx), 8)) == "<8 x float>"
+        assert str(llvm.vector_t(llvm.f32(ctx), 8, scalable=True)) == "<vscale x 8 x float>"
+        assert str(llvm.struct_t(ctx, [llvm.i32(ctx), llvm.f64(ctx)])) == "{ i32, double }"
+        assert (
+            str(llvm.struct_t(ctx, [llvm.i8(ctx), llvm.i32(ctx)], packed=True))
+            == "<{ i8, i32 }>"
+        )
+        assert (
+            str(llvm.function_t(llvm.i32(ctx), [llvm.i32(ctx), llvm.f32(ctx)]))
+            == "i32 (i32, float)"
+        )
+        assert (
+            str(llvm.function_t(llvm.void_t(ctx), [llvm.ptr_t(ctx)], var_arg=True))
+            == "void (ptr, ...)"
+        )
+    assert_no_leaks()
+
+
+def test_named_struct_prints_opaque():
+    with llvm.Context() as ctx:
+        named = llvm.named_struct_t(ctx, "Pair")
+        # An opaque named struct prints its full definition. set_body and the
+        # concrete-subclass accessors are validated in test_types_downcast,
+        # once the Type type_hook makes named_struct_t return a StructType.
+        assert str(named) == "%Pair = type opaque"
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_types.py
+++ b/projects/eudsl-llvmpy/tests/test_types.py
@@ -7,33 +7,33 @@ from llvm.testing import assert_no_leaks
 
 def test_primitive_types_print():
     with llvm.Context() as ctx:
-        assert str(llvm.void_t(ctx)) == "void"
-        assert str(llvm.i1(ctx)) == "i1"
-        assert str(llvm.i32(ctx)) == "i32"
-        assert str(llvm.f32(ctx)) == "float"
-        assert str(llvm.f64(ctx)) == "double"
-        assert str(llvm.f16(ctx)) == "half"
+        assert str(llvm.types.void(ctx)) == "void"
+        assert str(llvm.types.i1(ctx)) == "i1"
+        assert str(llvm.types.i32(ctx)) == "i32"
+        assert str(llvm.types.f32(ctx)) == "float"
+        assert str(llvm.types.f64(ctx)) == "double"
+        assert str(llvm.types.f16(ctx)) == "half"
     assert_no_leaks()
 
 
 def test_type_predicates():
     with llvm.Context() as ctx:
-        assert llvm.void_t(ctx).is_void
-        assert not llvm.void_t(ctx).is_sized
-        assert llvm.i32(ctx).is_integer
-        assert not llvm.i32(ctx).is_floating_point
-        assert llvm.f64(ctx).is_floating_point
-        assert llvm.i32(ctx).is_sized
+        assert llvm.types.void(ctx).is_void
+        assert not llvm.types.void(ctx).is_sized
+        assert llvm.types.i32(ctx).is_integer
+        assert not llvm.types.i32(ctx).is_floating_point
+        assert llvm.types.f64(ctx).is_floating_point
+        assert llvm.types.i32(ctx).is_sized
     assert_no_leaks()
 
 
 def test_types_are_uniqued_and_hashable():
     with llvm.Context() as a, llvm.Context() as b:
-        assert llvm.i32(a) == llvm.i32(a)
-        assert llvm.i32(a) != llvm.i64(a)
+        assert llvm.types.i32(a) == llvm.types.i32(a)
+        assert llvm.types.i32(a) != llvm.types.i64(a)
         # Types are interned per context, so two contexts give distinct types.
-        assert llvm.i32(a) != llvm.i32(b)
-        assert len({llvm.i32(a), llvm.i32(a), llvm.i64(a)}) == 2
+        assert llvm.types.i32(a) != llvm.types.i32(b)
+        assert len({llvm.types.i32(a), llvm.types.i32(a), llvm.types.i64(a)}) == 2
     assert_no_leaks()
 
 
@@ -42,23 +42,23 @@ def test_types_are_uniqued_and_hashable():
 # type_hook), since until the hook lands the factories return base Type objects.
 def test_derived_types_print():
     with llvm.Context() as ctx:
-        assert str(llvm.int_t(ctx, 7)) == "i7"
-        assert str(llvm.ptr_t(ctx)) == "ptr"
-        assert str(llvm.ptr_t(ctx, 3)) == "ptr addrspace(3)"
-        assert str(llvm.array_t(llvm.i32(ctx), 4)) == "[4 x i32]"
-        assert str(llvm.vector_t(llvm.f32(ctx), 8)) == "<8 x float>"
-        assert str(llvm.vector_t(llvm.f32(ctx), 8, scalable=True)) == "<vscale x 8 x float>"
-        assert str(llvm.struct_t(ctx, [llvm.i32(ctx), llvm.f64(ctx)])) == "{ i32, double }"
+        assert str(llvm.types.int(ctx, 7)) == "i7"
+        assert str(llvm.types.ptr(ctx)) == "ptr"
+        assert str(llvm.types.ptr(ctx, 3)) == "ptr addrspace(3)"
+        assert str(llvm.types.array(llvm.types.i32(ctx), 4)) == "[4 x i32]"
+        assert str(llvm.types.vector(llvm.types.f32(ctx), 8)) == "<8 x float>"
+        assert str(llvm.types.vector(llvm.types.f32(ctx), 8, scalable=True)) == "<vscale x 8 x float>"
+        assert str(llvm.types.struct(ctx, [llvm.types.i32(ctx), llvm.types.f64(ctx)])) == "{ i32, double }"
         assert (
-            str(llvm.struct_t(ctx, [llvm.i8(ctx), llvm.i32(ctx)], packed=True))
+            str(llvm.types.struct(ctx, [llvm.types.i8(ctx), llvm.types.i32(ctx)], packed=True))
             == "<{ i8, i32 }>"
         )
         assert (
-            str(llvm.function_t(llvm.i32(ctx), [llvm.i32(ctx), llvm.f32(ctx)]))
+            str(llvm.types.function(llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)]))
             == "i32 (i32, float)"
         )
         assert (
-            str(llvm.function_t(llvm.void_t(ctx), [llvm.ptr_t(ctx)], var_arg=True))
+            str(llvm.types.function(llvm.types.void(ctx), [llvm.types.ptr(ctx)], var_arg=True))
             == "void (ptr, ...)"
         )
     assert_no_leaks()
@@ -66,7 +66,7 @@ def test_derived_types_print():
 
 def test_named_struct_prints_opaque():
     with llvm.Context() as ctx:
-        named = llvm.named_struct_t(ctx, "Pair")
+        named = llvm.types.named_struct(ctx, "Pair")
         # An opaque named struct prints its full definition. set_body and the
         # concrete-subclass accessors are validated in test_types_downcast,
         # once the Type type_hook makes named_struct_t return a StructType.
@@ -76,51 +76,61 @@ def test_named_struct_prints_opaque():
 
 def test_types_downcast_to_concrete_classes():
     with llvm.Context() as ctx:
-        assert type(llvm.i32(ctx)).__name__ == "IntegerType"
-        assert type(llvm.ptr_t(ctx)).__name__ == "PointerType"
-        assert type(llvm.array_t(llvm.i32(ctx), 2)).__name__ == "ArrayType"
-        assert type(llvm.vector_t(llvm.i32(ctx), 2)).__name__ == "VectorType"
-        assert type(llvm.struct_t(ctx, [llvm.i32(ctx)])).__name__ == "StructType"
+        assert type(llvm.types.i32(ctx)).__name__ == "IntegerType"
+        assert type(llvm.types.ptr(ctx)).__name__ == "PointerType"
+        assert type(llvm.types.array(llvm.types.i32(ctx), 2)).__name__ == "ArrayType"
+        # A non-scalable vector downcasts to FixedVectorType, a scalable one to
+        # ScalableVectorType; both are VectorType subclasses.
         assert (
-            type(llvm.function_t(llvm.void_t(ctx), [])).__name__ == "FunctionType"
+            type(llvm.types.vector(llvm.types.i32(ctx), 2)).__name__
+            == "FixedVectorType"
+        )
+        assert (
+            type(llvm.types.vector(llvm.types.i32(ctx), 2, scalable=True)).__name__
+            == "ScalableVectorType"
+        )
+        assert isinstance(llvm.types.vector(llvm.types.i32(ctx), 2), llvm.types.VectorType)
+        assert type(llvm.types.struct(ctx, [llvm.types.i32(ctx)])).__name__ == "StructType"
+        assert (
+            type(llvm.types.function(llvm.types.void(ctx), [])).__name__ == "FunctionType"
         )
         # Types with no concrete subclass stay Type.
-        assert type(llvm.void_t(ctx)).__name__ == "Type"
-        assert type(llvm.f64(ctx)).__name__ == "Type"
+        assert type(llvm.types.void(ctx)).__name__ == "Type"
+        assert type(llvm.types.f64(ctx)).__name__ == "Type"
     assert_no_leaks()
 
 
 def test_concrete_type_accessors():
     with llvm.Context() as ctx:
-        assert llvm.int_t(ctx, 7).bit_width == 7
-        assert llvm.ptr_t(ctx, 3).address_space == 3
-        a = llvm.array_t(llvm.i32(ctx), 4)
+        assert llvm.types.int(ctx, 7).bit_width == 7
+        assert llvm.types.ptr(ctx, 3).address_space == 3
+        a = llvm.types.array(llvm.types.i32(ctx), 4)
         assert a.num_elements == 4
-        assert a.element_type == llvm.i32(ctx)
-        v = llvm.vector_t(llvm.f32(ctx), 8)
+        assert a.element_type == llvm.types.i32(ctx)
+        v = llvm.types.vector(llvm.types.f32(ctx), 8)
         assert v.min_num_elements == 8
         assert not v.is_scalable
-        assert llvm.vector_t(llvm.f32(ctx), 8, scalable=True).is_scalable
-        s = llvm.struct_t(ctx, [llvm.i32(ctx), llvm.f64(ctx)])
+        assert llvm.types.vector(llvm.types.f32(ctx), 8, scalable=True).is_scalable
+        s = llvm.types.struct(ctx, [llvm.types.i32(ctx), llvm.types.f64(ctx)])
         assert s.num_elements == 2
-        assert s.element_type(1) == llvm.f64(ctx)
+        assert s.element_type(1) == llvm.types.f64(ctx)
         assert not s.is_packed
-        assert llvm.struct_t(ctx, [llvm.i8(ctx)], packed=True).is_packed
-        ft = llvm.function_t(llvm.i32(ctx), [llvm.i32(ctx), llvm.f32(ctx)])
-        assert ft.return_type == llvm.i32(ctx)
+        assert llvm.types.struct(ctx, [llvm.types.i8(ctx)], packed=True).is_packed
+        ft = llvm.types.function(llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)])
+        assert ft.return_type == llvm.types.i32(ctx)
         assert ft.num_params == 2
-        assert ft.param_type(1) == llvm.f32(ctx)
-        assert ft.params == [llvm.i32(ctx), llvm.f32(ctx)]
+        assert ft.param_type(1) == llvm.types.f32(ctx)
+        assert ft.params == [llvm.types.i32(ctx), llvm.types.f32(ctx)]
         assert not ft.is_var_arg
     assert_no_leaks()
 
 
 def test_named_struct_set_body_and_name():
     with llvm.Context() as ctx:
-        named = llvm.named_struct_t(ctx, "Pair")
+        named = llvm.types.named_struct(ctx, "Pair")
         assert named.name == "Pair"
         assert named.is_opaque
-        named.set_body([llvm.i32(ctx), llvm.i32(ctx)])
+        named.set_body([llvm.types.i32(ctx), llvm.types.i32(ctx)])
         assert not named.is_opaque
         assert named.num_elements == 2
     assert_no_leaks()


### PR DESCRIPTION
Binds the `llvm::Type` hierarchy.

- The `llvm::Type` base and the primitive types (void, label, integer widths, half/bfloat/float/double).
- Derived types with their factories: integer, pointer, struct (literal and named), array, vector, function.
- A `type_hook` that downcasts an `llvm::Type*` to its concrete bound Python class from its `TypeID`, so an accessor returning a base `Type` surfaces as the right subclass.
