### PR TITLE
[eudsl-llvmpy] C++ object layer: Value/User spine, Function, Argument, BasicBlock

### DIFF
--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -14,6 +14,22 @@ both. Do not collapse them into one `name`, and do not set the source filename
 as a side effect of setting the identifier. If a rename genuinely seems
 worthwhile, raise it rather than doing it silently.
 
+## Bind the full API; do not hardcode assumptions
+
+Expose the LLVM API's parameters to the user rather than fixing them to a
+default in C++. For example, `Function.create` takes a `linkage` argument
+(defaulting to `ExternalLinkage`) instead of hardcoding the linkage; likewise
+for calling convention, visibility, address space, and similar. If a binding
+would silently bake in one choice from a set the LLVM API offers, surface that
+choice as an argument.
+
+## No forward-reference comments
+
+Do not write comments that reference future work, later PRs, or task numbers
+("added in Task 10", "activates once X lands"). They go stale as the stack is
+rebased and squash-merged. Describe what the code does now; if something is
+intentionally a stub, say so without pointing at a future commit.
+
 ## C++ coding style (LLVM)
 
 Follow the LLVM coding standards. A conditional takes braces whenever its

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -100,6 +100,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Context.cpp
   src/IR/Types.cpp
   src/IR/Kinds.cpp
+  src/IR/Values.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -43,13 +43,6 @@ inline void unwrap(llvm::Error &&e) {
     throw std::runtime_error(llvm::toString(std::move(e)));
 }
 
-/// Fetch an already-registered nanobind class so a later translation unit can
-/// add methods to it. Used because the Value hierarchy is registered as a spine
-/// in Values.cpp and filled in by Instructions.cpp / Constants.cpp.
-template <typename T> nb::class_<T> reopen() {
-  return nb::borrow<nb::class_<T>>(nb::type<T>());
-}
-
 } // namespace eudsl
 
 // Pulled in here so every translation unit that returns an llvm::Type* or

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -43,6 +43,13 @@ inline void unwrap(llvm::Error &&e) {
     throw std::runtime_error(llvm::toString(std::move(e)));
 }
 
+/// Fetch an already-registered nanobind class so a later translation unit can
+/// add methods to it. Used because the Value hierarchy is registered as a spine
+/// in Values.cpp and filled in by Instructions.cpp / Constants.cpp.
+template <typename T> nb::class_<T> reopen() {
+  return nb::borrow<nb::class_<T>>(nb::type<T>());
+}
+
 } // namespace eudsl
 
 // Pulled in here so every translation unit that returns an llvm::Type* or

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -7,6 +7,7 @@
 #include "IR/TargetInit.h"
 
 #include <llvm/AsmParser/Parser.h>
+#include <llvm/IR/Function.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/SourceMgr.h>
 
@@ -56,6 +57,19 @@ void populate_context(nb::module_ &m) {
           "context",
           [](eudsl::Module &self) -> eudsl::Context & { return self.context(); },
           nb::rv_policy::reference_internal)
+      .def_prop_ro("functions",
+                   [](eudsl::Module &self) {
+                     std::vector<llvm::Function *> out;
+                     for (llvm::Function &f : self.get().functions())
+                       out.push_back(&f);
+                     return out;
+                   })
+      .def(
+          "get_function",
+          [](eudsl::Module &self, const std::string &name) {
+            return self.get().getFunction(name);
+          },
+          "name"_a, nb::rv_policy::reference)
       .def("__str__", [](eudsl::Module &self) {
         std::string s;
         llvm::raw_string_ostream os(s);

--- a/projects/eudsl-llvmpy/src/IR/Kinds.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.cpp
@@ -23,6 +23,10 @@ const std::type_info *pick(const std::type_info *concrete,
   return nanobind::detail::nb_type_lookup(concrete) ? concrete : base;
 }
 
+// `id` is an llvm::Value::getValueID() result, which is an `unsigned` rather
+// than the Value::ValueTy enum: instruction IDs are `InstructionVal + opcode`
+// and run past the ValueTy enumerators, so `unsigned` is what the LLVM API
+// hands back here.
 const std::type_info *valueTypeInfo(unsigned id) {
   const std::type_info *base = &typeid(llvm::Value);
 

--- a/projects/eudsl-llvmpy/src/IR/Kinds.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.cpp
@@ -4,9 +4,53 @@
 
 #include "IR/Kinds.h"
 
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalAlias.h>
+#include <llvm/IR/GlobalIFunc.h>
+#include <llvm/IR/GlobalVariable.h>
+#include <llvm/IR/InlineAsm.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Metadata.h>
 
 namespace eudsl {
+
+const std::type_info *pick(const std::type_info *concrete,
+                           const std::type_info *base) {
+  return nanobind::detail::nb_type_lookup(concrete) ? concrete : base;
+}
+
+const std::type_info *valueTypeInfo(unsigned id) {
+  const std::type_info *base = &typeid(llvm::Value);
+
+  if (id >= llvm::Value::InstructionVal) {
+    switch (id - llvm::Value::InstructionVal) {
+#define HANDLE_INST(num, opcode, Class)                                        \
+  case num:                                                                    \
+    return pick(&typeid(llvm::Class), base);
+#include "llvm/IR/Instruction.def"
+    default:
+      return &typeid(llvm::Instruction);
+    }
+  }
+
+  switch (id) {
+// MemoryUse/MemoryDef/MemoryPhi are MemorySSA classes, not IR Value subclasses
+// reachable from a Module; map their enum slots to base Value.
+#define HANDLE_MEMORY_VALUE(Name)                                              \
+  case llvm::Value::Name##Val:                                                 \
+    return base;
+#define HANDLE_VALUE(Name)                                                     \
+  case llvm::Value::Name##Val:                                                 \
+    return pick(&typeid(llvm::Name), base);
+#include "llvm/IR/Value.def"
+  default:
+    return base;
+  }
+}
 
 const std::type_info *typeTypeInfo(llvm::Type::TypeID id) {
   switch (id) {

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -20,7 +20,6 @@
 
 #include <nanobind/nanobind.h>
 
-#include <cassert>
 #include <typeinfo>
 
 namespace eudsl {
@@ -30,16 +29,14 @@ const std::type_info *valueTypeInfo(unsigned valueID);
 
 template <> struct nanobind::detail::type_hook<llvm::Type> {
   static const std::type_info *get(llvm::Type *t) {
-    // nanobind resolves a null pointer to None before consulting the hook, so
-    // a non-null argument is an invariant here.
-    assert(t && "type_hook<llvm::Type> invoked with a null pointer");
-    return eudsl::typeTypeInfo(t->getTypeID());
+    // The hook IS consulted for null pointers (a null-returning accessor that
+    // nanobind renders as None), so map null to the base type.
+    return t ? eudsl::typeTypeInfo(t->getTypeID()) : &typeid(llvm::Type);
   }
 };
 
 template <> struct nanobind::detail::type_hook<llvm::Value> {
   static const std::type_info *get(llvm::Value *v) {
-    assert(v && "type_hook<llvm::Value> invoked with a null pointer");
-    return eudsl::valueTypeInfo(v->getValueID());
+    return v ? eudsl::valueTypeInfo(v->getValueID()) : &typeid(llvm::Value);
   }
 };

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -2,21 +2,21 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Downcasting support for llvm::Type. llvm::Type is deliberately
-// non-polymorphic (Type.h has no virtual destructor), so nanobind's RTTI-based
-// downcast cannot see through a base pointer. nanobind::detail::type_hook is
-// the documented hook for this case. The llvm::Value analogue (valueTypeInfo
-// and type_hook<llvm::Value>) lives with the Value bindings, the PR that
-// registers the leaf Value classes it names.
+// Downcasting support. llvm::Value and llvm::Type are deliberately
+// non-polymorphic (Value.h documents the non-virtual destructor), so nanobind's
+// RTTI-based downcast cannot see through a base pointer.
+// nanobind::detail::type_hook is the documented hook for this case.
 //
 // INVARIANT: every std::type_info returned here must name a class registered
 // with nanobind, otherwise the conversion raises "Unable to convert function
-// return value to a Python type". typeTypeInfo only names classes registered in
-// this PR.
+// return value to a Python type". valueTypeInfo() guards each return with pick()
+// so a not-yet-registered class falls back to base Value, keeping every commit
+// green while later tasks register the leaves.
 
 #pragma once
 
 #include <llvm/IR/Type.h>
+#include <llvm/IR/Value.h>
 
 #include <nanobind/nanobind.h>
 
@@ -25,6 +25,7 @@
 
 namespace eudsl {
 const std::type_info *typeTypeInfo(llvm::Type::TypeID id);
+const std::type_info *valueTypeInfo(unsigned valueID);
 } // namespace eudsl
 
 template <> struct nanobind::detail::type_hook<llvm::Type> {
@@ -33,5 +34,12 @@ template <> struct nanobind::detail::type_hook<llvm::Type> {
     // a non-null argument is an invariant here.
     assert(t && "type_hook<llvm::Type> invoked with a null pointer");
     return eudsl::typeTypeInfo(t->getTypeID());
+  }
+};
+
+template <> struct nanobind::detail::type_hook<llvm::Value> {
+  static const std::type_info *get(llvm::Value *v) {
+    assert(v && "type_hook<llvm::Value> invoked with a null pointer");
+    return eudsl::valueTypeInfo(v->getValueID());
   }
 };

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -4,6 +4,12 @@
 
 #include "IR/Common.h"
 
+#include <llvm/IR/Constant.h>
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/GlobalObject.h>
+#include <llvm/IR/GlobalValue.h>
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instruction.h>
 #include <llvm/IR/User.h>
 #include <llvm/IR/Value.h>
 
@@ -46,4 +52,12 @@ void populate_values(nb::module_ &m) {
           out.push_back(self.getOperand(i));
         return out;
       });
+
+  // Structural spine of the Value hierarchy. Leaf method bindings are added by
+  // Tasks 9-11, which reopen these classes via reopen<T>(). Registering them
+  // here lets the Value type_hook name them without raising.
+  nb::class_<llvm::Constant, llvm::User>(m, "Constant");
+  nb::class_<llvm::GlobalValue, llvm::Constant>(m, "GlobalValue");
+  nb::class_<llvm::GlobalObject, llvm::GlobalValue>(m, "GlobalObject");
+  nb::class_<llvm::Instruction, llvm::User>(m, "Instruction");
 }

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -58,12 +58,27 @@ void populate_values(nb::module_ &m) {
         return out;
       });
 
-  // Structural spine of the Value hierarchy. Leaf method bindings are added by
-  // Tasks 9-11, which reopen these classes via reopen<T>(). Registering them
-  // here lets the Value type_hook name them without raising.
+  // Structural spine of the Value hierarchy. These base classes are registered
+  // bare so the concrete subclasses bound in Instructions.cpp / Constants.cpp
+  // can name them as their nanobind base, and so the Value type_hook can name
+  // them without raising.
   nb::class_<llvm::Constant, llvm::User>(m, "Constant");
   nb::class_<llvm::GlobalValue, llvm::Constant>(m, "GlobalValue");
   nb::class_<llvm::GlobalObject, llvm::GlobalValue>(m, "GlobalObject");
+
+  // GlobalValue linkage kinds (llvm::GlobalValue::LinkageTypes). Bound with the
+  // GlobalValue hierarchy so Function.create and the global factories can take a
+  // linkage argument rather than hardcoding one.
+  nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
+      .value("EXTERNAL", llvm::GlobalValue::ExternalLinkage)
+      .value("INTERNAL", llvm::GlobalValue::InternalLinkage)
+      .value("PRIVATE", llvm::GlobalValue::PrivateLinkage)
+      .value("LINKONCE", llvm::GlobalValue::LinkOnceAnyLinkage)
+      .value("LINKONCE_ODR", llvm::GlobalValue::LinkOnceODRLinkage)
+      .value("WEAK", llvm::GlobalValue::WeakAnyLinkage)
+      .value("COMMON", llvm::GlobalValue::CommonLinkage)
+      .value("APPENDING", llvm::GlobalValue::AppendingLinkage)
+      .value("EXTERNAL_WEAK", llvm::GlobalValue::ExternalWeakLinkage);
   nb::class_<llvm::Instruction, llvm::User>(m, "Instruction")
       .def_prop_ro("num_successors",
                    [](llvm::Instruction &self) {
@@ -110,12 +125,12 @@ void populate_values(nb::module_ &m) {
       .def_static(
           "create",
           [](llvm::FunctionType *ft, const std::string &name,
-             eudsl::Module &mod) {
-            return llvm::Function::Create(
-                ft, llvm::GlobalValue::ExternalLinkage, name, mod.get());
+             eudsl::Module &mod, llvm::GlobalValue::LinkageTypes linkage) {
+            return llvm::Function::Create(ft, linkage, name, mod.get());
           },
-          "function_type"_a, "name"_a, "module"_a, nb::rv_policy::reference,
-          nb::keep_alive<0, 3>())
+          "function_type"_a, "name"_a, "module"_a,
+          "linkage"_a = llvm::GlobalValue::ExternalLinkage,
+          nb::rv_policy::reference, nb::keep_alive<0, 3>())
       .def_prop_ro("function_type", &llvm::Function::getFunctionType,
                    nb::rv_policy::reference_internal)
       .def_prop_ro("return_type", &llvm::Function::getReturnType,

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -3,9 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "IR/Common.h"
+#include "IR/Ownership.h"
 
+#include <llvm/IR/Argument.h>
+#include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalObject.h>
 #include <llvm/IR/GlobalValue.h>
 #include <llvm/IR/InstrTypes.h>
@@ -20,7 +25,7 @@ void populate_values(nb::module_ &m) {
       .def_prop_rw(
           "name", [](llvm::Value &self) { return self.getName().str(); },
           [](llvm::Value &self, const std::string &n) { self.setName(n); })
-      .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference)
+      .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference_internal)
       .def_prop_ro("num_uses",
                    [](llvm::Value &self) { return self.getNumUses(); })
       .def_prop_ro("users",
@@ -45,7 +50,7 @@ void populate_values(nb::module_ &m) {
   nb::class_<llvm::User, llvm::Value>(m, "User")
       .def_prop_ro("num_operands", &llvm::User::getNumOperands)
       .def("operand", &llvm::User::getOperand, "index"_a,
-           nb::rv_policy::reference)
+           nb::rv_policy::reference_internal)
       .def_prop_ro("operands", [](llvm::User &self) {
         std::vector<llvm::Value *> out;
         for (unsigned i = 0, n = self.getNumOperands(); i < n; ++i)
@@ -59,5 +64,92 @@ void populate_values(nb::module_ &m) {
   nb::class_<llvm::Constant, llvm::User>(m, "Constant");
   nb::class_<llvm::GlobalValue, llvm::Constant>(m, "GlobalValue");
   nb::class_<llvm::GlobalObject, llvm::GlobalValue>(m, "GlobalObject");
-  nb::class_<llvm::Instruction, llvm::User>(m, "Instruction");
+  nb::class_<llvm::Instruction, llvm::User>(m, "Instruction")
+      .def_prop_ro("num_successors",
+                   [](llvm::Instruction &self) {
+                     return self.getNumSuccessors();
+                   })
+      .def("successor", &llvm::Instruction::getSuccessor, "index"_a,
+           nb::rv_policy::reference_internal)
+      .def_prop_ro("is_terminator",
+                   [](llvm::Instruction &self) { return self.isTerminator(); })
+      .def_prop_ro(
+          "parent", [](llvm::Instruction &self) { return self.getParent(); },
+          nb::rv_policy::reference_internal);
+
+  nb::class_<llvm::Argument, llvm::Value>(m, "Argument")
+      .def_prop_ro("arg_no", &llvm::Argument::getArgNo)
+      .def_prop_ro(
+          "parent", [](llvm::Argument &self) { return self.getParent(); },
+          nb::rv_policy::reference_internal);
+
+  nb::class_<llvm::BasicBlock, llvm::Value>(m, "BasicBlock")
+      .def_static(
+          "create",
+          [](eudsl::Context &ctx, const std::string &name,
+             llvm::Function *parent) {
+            return llvm::BasicBlock::Create(ctx.get(), name, parent);
+          },
+          "context"_a, "name"_a = "", "parent"_a = nullptr,
+          nb::rv_policy::reference)
+      .def_prop_ro(
+          "parent", [](llvm::BasicBlock &self) { return self.getParent(); },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "terminator",
+          [](llvm::BasicBlock &self) { return self.getTerminatorOrNull(); },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("instructions", [](llvm::BasicBlock &self) {
+        std::vector<llvm::Instruction *> out;
+        for (llvm::Instruction &i : self)
+          out.push_back(&i);
+        return out;
+      });
+
+  nb::class_<llvm::Function, llvm::GlobalObject>(m, "Function")
+      .def_static(
+          "create",
+          [](llvm::FunctionType *ft, const std::string &name,
+             eudsl::Module &mod) {
+            return llvm::Function::Create(
+                ft, llvm::GlobalValue::ExternalLinkage, name, mod.get());
+          },
+          "function_type"_a, "name"_a, "module"_a, nb::rv_policy::reference,
+          nb::keep_alive<0, 3>())
+      .def_prop_ro("function_type", &llvm::Function::getFunctionType,
+                   nb::rv_policy::reference_internal)
+      .def_prop_ro("return_type", &llvm::Function::getReturnType,
+                   nb::rv_policy::reference_internal)
+      .def_prop_ro("is_var_arg", &llvm::Function::isVarArg)
+      .def_prop_ro("is_declaration", &llvm::Function::isDeclaration)
+      .def_prop_ro("num_args", &llvm::Function::arg_size)
+      .def("arg", &llvm::Function::getArg, "index"_a, nb::rv_policy::reference_internal)
+      .def_prop_ro("args",
+                   [](llvm::Function &self) {
+                     std::vector<llvm::Argument *> out;
+                     for (llvm::Argument &a : self.args())
+                       out.push_back(&a);
+                     return out;
+                   })
+      .def_prop_ro("basic_blocks",
+                   [](llvm::Function &self) {
+                     std::vector<llvm::BasicBlock *> out;
+                     for (llvm::BasicBlock &b : self)
+                       out.push_back(&b);
+                     return out;
+                   })
+      .def_prop_ro(
+          "entry_block",
+          [](llvm::Function &self) -> llvm::BasicBlock * {
+            if (self.empty())
+              return nullptr;
+            return &self.getEntryBlock();
+          },
+          nb::rv_policy::reference_internal)
+      .def(
+          "append_basic_block",
+          [](llvm::Function &self, const std::string &name) {
+            return llvm::BasicBlock::Create(self.getContext(), name, &self);
+          },
+          "name"_a = "", nb::rv_policy::reference_internal);
 }

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -1,0 +1,49 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+
+#include <llvm/IR/User.h>
+#include <llvm/IR/Value.h>
+
+#include <vector>
+
+void populate_values(nb::module_ &m) {
+  nb::class_<llvm::Value>(m, "Value")
+      .def_prop_rw(
+          "name", [](llvm::Value &self) { return self.getName().str(); },
+          [](llvm::Value &self, const std::string &n) { self.setName(n); })
+      .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference)
+      .def_prop_ro("num_uses",
+                   [](llvm::Value &self) { return self.getNumUses(); })
+      .def_prop_ro("users",
+                   [](llvm::Value &self) {
+                     return std::vector<llvm::User *>(self.user_begin(),
+                                                      self.user_end());
+                   })
+      .def("replace_all_uses_with", &llvm::Value::replaceAllUsesWith, "value"_a)
+      .def("__str__", [](llvm::Value &self) { return eudsl::toString(self); })
+      .def("__eq__",
+           [](llvm::Value &self, nb::handle other) {
+             llvm::Value *o;
+             if (!nb::try_cast<llvm::Value *>(other, o))
+               return false;
+             return &self == o;
+           })
+      .def("__hash__", [](llvm::Value &self) {
+        return static_cast<Py_ssize_t>(
+            reinterpret_cast<std::uintptr_t>(&self));
+      });
+
+  nb::class_<llvm::User, llvm::Value>(m, "User")
+      .def_prop_ro("num_operands", &llvm::User::getNumOperands)
+      .def("operand", &llvm::User::getOperand, "index"_a,
+           nb::rv_policy::reference)
+      .def_prop_ro("operands", [](llvm::User &self) {
+        std::vector<llvm::Value *> out;
+        for (unsigned i = 0, n = self.getNumOperands(); i < n; ++i)
+          out.push_back(self.getOperand(i));
+        return out;
+      });
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -8,10 +8,12 @@ namespace nb = nanobind;
 
 void populate_context(nb::module_ &m);
 void populate_types(nb::module_ &m);
+void populate_values(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
   populate_context(m);
   nb::module_ types = m.def_submodule("types");
   populate_types(types);
+  populate_values(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -29,3 +29,69 @@ def test_value_and_user_registered():
         assert "define i32 @f(i32 %x, i32 %y)" in str(mod)
         del mod
     assert_no_leaks()
+
+
+def test_function_traversal():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        assert [f.name for f in mod.functions] == ["f"]
+        f = mod.get_function("f")
+        assert f is not None
+        assert mod.get_function("nope") is None
+        assert f.num_args == 2
+        assert [a.name for a in f.args] == ["x", "y"]
+        assert f.arg(0).arg_no == 0
+        assert f.arg(1).parent == f
+        assert not f.is_declaration
+        assert str(f.return_type) == "i32"
+        del f, mod
+    assert_no_leaks()
+
+
+def test_basic_block_and_instruction_traversal():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        blocks = f.basic_blocks
+        assert [b.name for b in blocks] == ["entry"]
+        entry = f.entry_block
+        assert entry.name == "entry"
+        assert entry == blocks[0]
+        insts = entry.instructions
+        # add, ret
+        assert len(insts) == 2
+        assert entry.terminator == insts[-1]
+        # Instruction is registered (the spine); concrete opcode downcasting
+        # (BinaryOperator) activates once the instruction classes are bound.
+        assert type(insts[0]).__name__ == "Instruction"
+        del f, entry, blocks, insts, mod
+    assert_no_leaks()
+
+
+def test_value_users_and_operands():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        x = f.arg(0)
+        # %x is used by the add.
+        assert x.num_uses == 1
+        add = x.users[0]
+        # Concrete opcode downcast (BinaryOperator) activates in Task 10; here
+        # the add arrives as a registered base (User/Instruction).
+        assert add.num_operands == 2
+        assert add.operand(0) == x
+        del f, x, add, mod
+    assert_no_leaks()
+
+
+def test_append_basic_block():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly("declare void @g()\n", ctx, "m")
+        ft = llvm.function_t(llvm.void_t(ctx), [])
+        fn = llvm.Function.create(ft, "h", mod)
+        bb = fn.append_basic_block("entry")
+        assert bb.name == "entry"
+        assert fn.entry_block == bb
+        assert bb.parent == fn
+        del fn, bb, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -18,10 +18,7 @@ _SRC = dedent(
 
 
 def test_value_and_user_registered():
-    # Value/User accessors only become reachable once a Value can be obtained
-    # from Python (functions()/traversal in Task 9). This test confirms
-    # populate_values did not break module round-tripping and that the classes
-    # exist on the module.
+    # The Value/User classes are registered and module round-tripping works.
     assert hasattr(llvm, "Value")
     assert hasattr(llvm, "User")
     with llvm.Context() as ctx:
@@ -76,8 +73,6 @@ def test_value_users_and_operands():
         # %x is used by the add.
         assert x.num_uses == 1
         add = x.users[0]
-        # Concrete opcode downcast (BinaryOperator) activates in Task 10; here
-        # the add arrives as a registered base (User/Instruction).
         assert add.num_operands == 2
         assert add.operand(0) == x
         del f, x, add, mod
@@ -94,4 +89,17 @@ def test_append_basic_block():
         assert fn.entry_block == bb
         assert bb.parent == fn
         del fn, bb, mod
+    assert_no_leaks()
+
+
+def test_function_create_linkage():
+    # Function.create takes a linkage argument (default external); selecting
+    # internal linkage is reflected in the printed IR.
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        ft = llvm.types.function(llvm.types.void(ctx), [])
+        fn = llvm.Function.create(ft, "priv", mod, linkage=llvm.Linkage.INTERNAL)
+        fn.append_basic_block("entry")
+        assert "define internal void @priv" in str(mod)
+        del fn, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -87,7 +87,7 @@ def test_value_users_and_operands():
 def test_append_basic_block():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly("declare void @g()\n", ctx, "m")
-        ft = llvm.function_t(llvm.void_t(ctx), [])
+        ft = llvm.types.function(llvm.types.void(ctx), [])
         fn = llvm.Function.create(ft, "h", mod)
         bb = fn.append_basic_block("entry")
         assert bb.name == "entry"

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -1,0 +1,31 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @f(i32 %x, i32 %y) {
+    entry:
+      %sum = add i32 %x, %y
+      ret i32 %sum
+    }
+    """
+)
+
+
+def test_value_and_user_registered():
+    # Value/User accessors only become reachable once a Value can be obtained
+    # from Python (functions()/traversal in Task 9). This test confirms
+    # populate_values did not break module round-tripping and that the classes
+    # exist on the module.
+    assert hasattr(llvm, "Value")
+    assert hasattr(llvm, "User")
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        assert "define i32 @f(i32 %x, i32 %y)" in str(mod)
+        del mod
+    assert_no_leaks()


### PR DESCRIPTION
Binds the `llvm::Value` hierarchy spine.

- The `llvm::Value` base and `llvm::User`.
- The Value class-hierarchy registration and a `reopen<T>` helper for adding methods to an already-registered class.
- `Function`, `Argument`, and `BasicBlock`, with traversal iterators (a function's blocks, a block's instructions, a function's arguments).
