### PR TITLE
[eudsl-llvmpy] C++ object layer: Instruction subclasses and PHINode incoming values

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -101,6 +101,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Types.cpp
   src/IR/Kinds.cpp
   src/IR/Values.cpp
+  src/IR/Instructions.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -1,0 +1,162 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+
+#include <llvm/IR/InstrTypes.h>
+#include <llvm/IR/Instructions.h>
+
+void populate_instructions(nb::module_ &m) {
+  // ICmp and FCmp share the C++ enum llvm::CmpInst::Predicate, and nanobind
+  // keys enum registration by C++ type, so register it once and expose the two
+  // Python names as aliases.
+  nb::enum_<llvm::CmpInst::Predicate>(m, "CmpPredicate")
+      .value("EQ", llvm::CmpInst::ICMP_EQ)
+      .value("NE", llvm::CmpInst::ICMP_NE)
+      .value("UGT", llvm::CmpInst::ICMP_UGT)
+      .value("UGE", llvm::CmpInst::ICMP_UGE)
+      .value("ULT", llvm::CmpInst::ICMP_ULT)
+      .value("ULE", llvm::CmpInst::ICMP_ULE)
+      .value("SGT", llvm::CmpInst::ICMP_SGT)
+      .value("SGE", llvm::CmpInst::ICMP_SGE)
+      .value("SLT", llvm::CmpInst::ICMP_SLT)
+      .value("SLE", llvm::CmpInst::ICMP_SLE)
+      .value("OEQ", llvm::CmpInst::FCMP_OEQ)
+      .value("OGT", llvm::CmpInst::FCMP_OGT)
+      .value("OGE", llvm::CmpInst::FCMP_OGE)
+      .value("OLT", llvm::CmpInst::FCMP_OLT)
+      .value("OLE", llvm::CmpInst::FCMP_OLE)
+      .value("ONE", llvm::CmpInst::FCMP_ONE)
+      .value("UEQ", llvm::CmpInst::FCMP_UEQ)
+      .value("UNE", llvm::CmpInst::FCMP_UNE);
+  m.attr("ICmpPredicate") = m.attr("CmpPredicate");
+  m.attr("FCmpPredicate") = m.attr("CmpPredicate");
+
+  // Intermediate bases (the Value type_hook never names these, but leaf classes
+  // need them registered as their nanobind base).
+  nb::class_<llvm::UnaryInstruction, llvm::Instruction>(m, "UnaryInstruction");
+  nb::class_<llvm::UnaryOperator, llvm::UnaryInstruction>(m, "UnaryOperator");
+  nb::class_<llvm::BinaryOperator, llvm::Instruction>(m, "BinaryOperator");
+  nb::class_<llvm::CastInst, llvm::UnaryInstruction>(m, "CastInst");
+  nb::class_<llvm::FuncletPadInst, llvm::Instruction>(m, "FuncletPadInst");
+
+  nb::class_<llvm::CmpInst, llvm::Instruction>(m, "CmpInst")
+      .def_prop_ro("predicate", &llvm::CmpInst::getPredicate);
+
+  nb::class_<llvm::CallBase, llvm::Instruction>(m, "CallBase")
+      .def_prop_ro("num_args", &llvm::CallBase::arg_size)
+      .def(
+          "arg_operand",
+          [](llvm::CallBase &self, unsigned i) {
+            return self.getArgOperand(i);
+          },
+          "index"_a, nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "called_operand",
+          [](llvm::CallBase &self) { return self.getCalledOperand(); },
+          nb::rv_policy::reference_internal);
+
+  nb::class_<llvm::ICmpInst, llvm::CmpInst>(m, "ICmpInst");
+  nb::class_<llvm::FCmpInst, llvm::CmpInst>(m, "FCmpInst");
+  nb::class_<llvm::CallInst, llvm::CallBase>(m, "CallInst");
+  nb::class_<llvm::InvokeInst, llvm::CallBase>(m, "InvokeInst");
+  nb::class_<llvm::CallBrInst, llvm::CallBase>(m, "CallBrInst");
+
+  nb::class_<llvm::PHINode, llvm::Instruction>(m, "PHINode")
+      .def_prop_ro("num_incoming", &llvm::PHINode::getNumIncomingValues)
+      .def(
+          "incoming_value",
+          [](llvm::PHINode &self, unsigned i) {
+            return self.getIncomingValue(i);
+          },
+          "index"_a, nb::rv_policy::reference_internal)
+      .def(
+          "incoming_block",
+          [](llvm::PHINode &self, unsigned i) {
+            return self.getIncomingBlock(i);
+          },
+          "index"_a, nb::rv_policy::reference_internal)
+      .def("add_incoming", &llvm::PHINode::addIncoming, "value"_a, "block"_a);
+
+  nb::class_<llvm::AllocaInst, llvm::UnaryInstruction>(m, "AllocaInst")
+      .def_prop_ro(
+          "allocated_type",
+          [](llvm::AllocaInst &self) { return self.getAllocatedType(); },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::LoadInst, llvm::UnaryInstruction>(m, "LoadInst")
+      .def_prop_ro(
+          "pointer_operand",
+          [](llvm::LoadInst &self) { return self.getPointerOperand(); },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::StoreInst, llvm::Instruction>(m, "StoreInst")
+      .def_prop_ro(
+          "pointer_operand",
+          [](llvm::StoreInst &self) { return self.getPointerOperand(); },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::GetElementPtrInst, llvm::Instruction>(m, "GetElementPtrInst")
+      .def_prop_ro(
+          "source_element_type",
+          [](llvm::GetElementPtrInst &self) {
+            return self.getSourceElementType();
+          },
+          nb::rv_policy::reference_internal);
+
+  nb::class_<llvm::ReturnInst, llvm::Instruction>(m, "ReturnInst")
+      .def_prop_ro(
+          "return_value",
+          [](llvm::ReturnInst &self) { return self.getReturnValue(); },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::UncondBrInst, llvm::Instruction>(m, "UncondBrInst")
+      .def_prop_ro("is_conditional", [](llvm::UncondBrInst &) { return false; });
+  nb::class_<llvm::CondBrInst, llvm::Instruction>(m, "CondBrInst")
+      .def_prop_ro("is_conditional", [](llvm::CondBrInst &) { return true; })
+      .def_prop_ro(
+          "condition",
+          [](llvm::CondBrInst &self) { return self.getCondition(); },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::SwitchInst, llvm::Instruction>(m, "SwitchInst");
+  nb::class_<llvm::IndirectBrInst, llvm::Instruction>(m, "IndirectBrInst");
+  nb::class_<llvm::ResumeInst, llvm::Instruction>(m, "ResumeInst");
+  nb::class_<llvm::UnreachableInst, llvm::Instruction>(m, "UnreachableInst");
+  nb::class_<llvm::SelectInst, llvm::Instruction>(m, "SelectInst");
+  nb::class_<llvm::VAArgInst, llvm::UnaryInstruction>(m, "VAArgInst");
+  nb::class_<llvm::ExtractElementInst, llvm::Instruction>(m,
+                                                         "ExtractElementInst");
+  nb::class_<llvm::InsertElementInst, llvm::Instruction>(m,
+                                                        "InsertElementInst");
+  nb::class_<llvm::ShuffleVectorInst, llvm::Instruction>(m,
+                                                        "ShuffleVectorInst");
+  nb::class_<llvm::ExtractValueInst, llvm::UnaryInstruction>(m,
+                                                            "ExtractValueInst");
+  nb::class_<llvm::InsertValueInst, llvm::Instruction>(m, "InsertValueInst");
+  nb::class_<llvm::LandingPadInst, llvm::Instruction>(m, "LandingPadInst");
+  nb::class_<llvm::FreezeInst, llvm::UnaryInstruction>(m, "FreezeInst");
+  nb::class_<llvm::FenceInst, llvm::Instruction>(m, "FenceInst");
+  nb::class_<llvm::AtomicCmpXchgInst, llvm::Instruction>(m,
+                                                        "AtomicCmpXchgInst");
+  nb::class_<llvm::AtomicRMWInst, llvm::Instruction>(m, "AtomicRMWInst");
+  nb::class_<llvm::CleanupPadInst, llvm::FuncletPadInst>(m, "CleanupPadInst");
+  nb::class_<llvm::CatchPadInst, llvm::FuncletPadInst>(m, "CatchPadInst");
+  nb::class_<llvm::CatchReturnInst, llvm::Instruction>(m, "CatchReturnInst");
+  nb::class_<llvm::CleanupReturnInst, llvm::Instruction>(m,
+                                                        "CleanupReturnInst");
+  nb::class_<llvm::CatchSwitchInst, llvm::Instruction>(m, "CatchSwitchInst");
+  nb::class_<llvm::TruncInst, llvm::CastInst>(m, "TruncInst");
+  nb::class_<llvm::ZExtInst, llvm::CastInst>(m, "ZExtInst");
+  nb::class_<llvm::SExtInst, llvm::CastInst>(m, "SExtInst");
+  nb::class_<llvm::FPToUIInst, llvm::CastInst>(m, "FPToUIInst");
+  nb::class_<llvm::FPToSIInst, llvm::CastInst>(m, "FPToSIInst");
+  nb::class_<llvm::UIToFPInst, llvm::CastInst>(m, "UIToFPInst");
+  nb::class_<llvm::SIToFPInst, llvm::CastInst>(m, "SIToFPInst");
+  nb::class_<llvm::FPTruncInst, llvm::CastInst>(m, "FPTruncInst");
+  nb::class_<llvm::FPExtInst, llvm::CastInst>(m, "FPExtInst");
+  nb::class_<llvm::PtrToIntInst, llvm::CastInst>(m, "PtrToIntInst");
+  nb::class_<llvm::PtrToAddrInst, llvm::CastInst>(m, "PtrToAddrInst");
+  nb::class_<llvm::IntToPtrInst, llvm::CastInst>(m, "IntToPtrInst");
+  nb::class_<llvm::BitCastInst, llvm::CastInst>(m, "BitCastInst");
+  nb::class_<llvm::AddrSpaceCastInst, llvm::CastInst>(m, "AddrSpaceCastInst");
+  nb::class_<llvm::FPUnaryOperator, llvm::UnaryOperator>(m, "FPUnaryOperator");
+  nb::class_<llvm::FPBinaryOperator, llvm::BinaryOperator>(m,
+                                                          "FPBinaryOperator");
+}

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -49,6 +49,8 @@ void populate_instructions(nb::module_ &m) {
       .def(
           "arg_operand",
           [](llvm::CallBase &self, unsigned i) {
+            if (i >= self.arg_size())
+              throw nb::index_error("argument index out of range");
             return self.getArgOperand(i);
           },
           "index"_a, nb::rv_policy::reference_internal)
@@ -68,12 +70,16 @@ void populate_instructions(nb::module_ &m) {
       .def(
           "incoming_value",
           [](llvm::PHINode &self, unsigned i) {
+            if (i >= self.getNumIncomingValues())
+              throw nb::index_error("incoming index out of range");
             return self.getIncomingValue(i);
           },
           "index"_a, nb::rv_policy::reference_internal)
       .def(
           "incoming_block",
           [](llvm::PHINode &self, unsigned i) {
+            if (i >= self.getNumIncomingValues())
+              throw nb::index_error("incoming index out of range");
             return self.getIncomingBlock(i);
           },
           "index"_a, nb::rv_policy::reference_internal)

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -20,6 +20,7 @@
 
 #include <nanobind/nanobind.h>
 
+#include <type_traits>
 #include <typeinfo>
 
 namespace eudsl {
@@ -27,16 +28,27 @@ const std::type_info *typeTypeInfo(llvm::Type::TypeID id);
 const std::type_info *valueTypeInfo(unsigned valueID);
 } // namespace eudsl
 
-template <> struct nanobind::detail::type_hook<llvm::Type> {
-  static const std::type_info *get(llvm::Type *t) {
-    // The hook IS consulted for null pointers (a null-returning accessor that
-    // nanobind renders as None), so map null to the base type.
-    return t ? eudsl::typeTypeInfo(t->getTypeID()) : &typeid(llvm::Type);
+// type_hook is keyed on the *static* pointer type being converted, so a hook on
+// llvm::Value alone would not fire when a binding returns e.g. an
+// llvm::Instruction* or llvm::User*. These SFINAE partial specializations cover
+// every class in the Value and Type hierarchies, downcasting from any base. The
+// hook IS consulted for null pointers (an accessor such as Function.entry_block
+// returns a null BasicBlock* that nanobind renders as None), so map null to the
+// static type T and let nanobind produce None.
+template <typename T>
+struct nanobind::detail::type_hook<
+    T, std::enable_if_t<std::is_base_of_v<llvm::Value, T>, int>> {
+  static const std::type_info *get(T *v) {
+    return v ? eudsl::valueTypeInfo(static_cast<llvm::Value *>(v)->getValueID())
+             : &typeid(T);
   }
 };
 
-template <> struct nanobind::detail::type_hook<llvm::Value> {
-  static const std::type_info *get(llvm::Value *v) {
-    return v ? eudsl::valueTypeInfo(v->getValueID()) : &typeid(llvm::Value);
+template <typename T>
+struct nanobind::detail::type_hook<
+    T, std::enable_if_t<std::is_base_of_v<llvm::Type, T>, int>> {
+  static const std::type_info *get(T *t) {
+    return t ? eudsl::typeTypeInfo(static_cast<llvm::Type *>(t)->getTypeID())
+             : &typeid(T);
   }
 };

--- a/projects/eudsl-llvmpy/src/IR/Ownership.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.cpp
@@ -10,7 +10,7 @@ namespace eudsl {
 
 static int64_t gLiveContexts = 0;
 
-Context::Context() : ctx(std::make_unique<llvm::LLVMContext>()) {
+Context::Context() : ctx(std::make_shared<llvm::LLVMContext>()) {
   ++gLiveContexts;
 }
 
@@ -32,10 +32,11 @@ llvm::LLVMContext &Context::get() const {
 }
 
 Module::Module(const std::string &name, Context &ctx)
-    : mod(std::make_unique<llvm::Module>(name, ctx.get())), owner(&ctx) {}
+    : ctxKeepAlive(ctx.shared()),
+      mod(std::make_unique<llvm::Module>(name, ctx.get())), owner(&ctx) {}
 
 Module::Module(std::unique_ptr<llvm::Module> m, Context &ctx)
-    : mod(std::move(m)), owner(&ctx) {}
+    : ctxKeepAlive(ctx.shared()), mod(std::move(m)), owner(&ctx) {}
 
 llvm::Module &Module::get() const {
   if (!mod) {

--- a/projects/eudsl-llvmpy/src/IR/Ownership.h
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.h
@@ -13,8 +13,11 @@
 
 namespace eudsl {
 
-/// Owns an llvm::LLVMContext. Counts live instances so tests can assert that
-/// nothing leaked, mirroring mlir/test/python/ir/*.py.
+/// Owns an llvm::LLVMContext via shared_ptr. Counts live instances so tests can
+/// assert nothing leaked, mirroring mlir/test/python/ir/*.py. The shared_ptr is
+/// so a Module (which holds its own copy) can safely outlive the Python context
+/// manager's __exit__: release() drops this object's reference and the live
+/// count, but the underlying LLVMContext survives until the last Module is gone.
 class Context {
 public:
   Context();
@@ -24,19 +27,23 @@ public:
 
   llvm::LLVMContext &get() const;
 
-  /// Destroy the underlying LLVMContext and drop the live count. Idempotent;
-  /// called by both __exit__ and the destructor.
+  /// Shared handle for a Module to keep the LLVMContext alive independently.
+  std::shared_ptr<llvm::LLVMContext> shared() const { return ctx; }
+
+  /// Drop this object's reference and the live count. Idempotent; called by
+  /// both __exit__ and the destructor.
   void release();
   bool isReleased() const { return ctx == nullptr; }
 
   static int64_t liveCount();
 
 private:
-  std::unique_ptr<llvm::LLVMContext> ctx;
+  std::shared_ptr<llvm::LLVMContext> ctx;
 };
 
-/// Owns an llvm::Module. `get()` throws once the module has been handed to the
-/// JIT, so a stale reference is a Python exception rather than a segfault.
+/// Owns an llvm::Module plus a shared reference to the LLVMContext it was built
+/// in, so destruction order is safe regardless of when the Context manager
+/// exits. `get()` throws once the module has been handed to the JIT.
 class Module {
 public:
   Module(const std::string &name, Context &ctx);
@@ -50,6 +57,7 @@ public:
   Context &context() const { return *owner; }
 
 private:
+  std::shared_ptr<llvm::LLVMContext> ctxKeepAlive;
   std::unique_ptr<llvm::Module> mod;
   Context *owner;
 };

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -9,6 +9,7 @@ namespace nb = nanobind;
 void populate_context(nb::module_ &m);
 void populate_types(nb::module_ &m);
 void populate_values(nb::module_ &m);
+void populate_instructions(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -16,4 +17,5 @@ NB_MODULE(eudslllvm_ext, m) {
   nb::module_ types = m.def_submodule("types");
   populate_types(types);
   populate_values(m);
+  populate_instructions(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_instructions.py
+++ b/projects/eudsl-llvmpy/tests/test_instructions.py
@@ -1,0 +1,78 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_PHI_SRC = dedent(
+    """\
+    define i32 @f(i1 %c) {
+    entry:
+      br i1 %c, label %a, label %b
+    a:
+      br label %join
+    b:
+      br label %join
+    join:
+      %p = phi i32 [ 1, %a ], [ 2, %b ]
+      %eq = icmp eq i32 %p, 1
+      ret i32 %p
+    }
+    """
+)
+
+
+def _insts_by_class(mod, name):
+    out = []
+    for f in mod.functions:
+        for bb in f.basic_blocks:
+            for i in bb.instructions:
+                if type(i).__name__ == name:
+                    out.append(i)
+    return out
+
+
+def test_instructions_downcast():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        # add-style ops become BinaryOperator; the icmp becomes ICmpInst; the
+        # phi becomes PHINode; the conditional branch becomes CondBrInst.
+        assert len(_insts_by_class(mod, "PHINode")) == 1
+        assert len(_insts_by_class(mod, "ICmpInst")) == 1
+        assert len(_insts_by_class(mod, "CondBrInst")) == 1
+        del mod
+    assert_no_leaks()
+
+
+def test_phi_incoming():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        (phi,) = _insts_by_class(mod, "PHINode")
+        assert phi.num_incoming == 2
+        assert phi.incoming_block(0).name == "a"
+        assert phi.incoming_block(1).name == "b"
+        assert str(phi.incoming_value(0)) == "i32 1"
+        del phi, mod
+    assert_no_leaks()
+
+
+def test_icmp_predicate():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        (icmp,) = _insts_by_class(mod, "ICmpInst")
+        assert icmp.predicate == llvm.ICmpPredicate.EQ
+        del icmp, mod
+    assert_no_leaks()
+
+
+def test_conditional_branch():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        cbrs = _insts_by_class(mod, "CondBrInst")
+        assert len(cbrs) == 1
+        assert cbrs[0].is_conditional
+        assert cbrs[0].num_successors == 2
+        del cbrs, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_instructions.py
+++ b/projects/eudsl-llvmpy/tests/test_instructions.py
@@ -3,6 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from textwrap import dedent
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -23,6 +25,26 @@ _PHI_SRC = dedent(
     """
 )
 
+# Exercises the memory, call, cast and fcmp accessors that _PHI_SRC does not
+# reach. Several results (%gep, %fc) are intentionally unused; the parser keeps
+# them and that is all these accessor tests need.
+_MEM_SRC = dedent(
+    """\
+    declare i32 @g(i32, i32)
+
+    define i32 @f(i32 %x, ptr %p) {
+    entry:
+      %slot = alloca i32
+      store i32 %x, ptr %slot
+      %ld = load i32, ptr %slot
+      %gep = getelementptr i32, ptr %p, i32 2
+      %cl = call i32 @g(i32 %x, i32 %ld)
+      %fc = fcmp ogt float 1.0, 2.0
+      ret i32 %cl
+    }
+    """
+)
+
 
 def _insts_by_class(mod, name):
     out = []
@@ -32,6 +54,11 @@ def _insts_by_class(mod, name):
                 if type(i).__name__ == name:
                     out.append(i)
     return out
+
+
+def _only(mod, name):
+    (inst,) = _insts_by_class(mod, name)
+    return inst
 
 
 def test_instructions_downcast():
@@ -54,7 +81,30 @@ def test_phi_incoming():
         assert phi.incoming_block(0).name == "a"
         assert phi.incoming_block(1).name == "b"
         assert str(phi.incoming_value(0)) == "i32 1"
+        assert str(phi.incoming_value(1)) == "i32 2"
         del phi, mod
+    assert_no_leaks()
+
+
+def test_phi_add_incoming():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        phi = _only(mod, "PHINode")
+        entry = mod.get_function("f").entry_block
+        # add_incoming(value, block) is the write path. Feed back an existing
+        # i32 incoming value (the phi's own operand 0) so the added type matches
+        # the phi type; a debug LLVM would assert on a mismatch.
+        v = phi.incoming_value(0)
+        phi.add_incoming(v, entry)
+        assert phi.num_incoming == 3
+        assert phi.incoming_value(2) == v
+        assert phi.incoming_block(2) == entry
+        # Out-of-range indices raise rather than crash.
+        with pytest.raises(IndexError):
+            phi.incoming_value(99)
+        with pytest.raises(IndexError):
+            phi.incoming_block(99)
+        del phi, entry, v, mod
     assert_no_leaks()
 
 
@@ -74,5 +124,69 @@ def test_conditional_branch():
         assert len(cbrs) == 1
         assert cbrs[0].is_conditional
         assert cbrs[0].num_successors == 2
+        # The condition is the i1 argument %c.
+        assert cbrs[0].condition.name == "c"
         del cbrs, mod
+    assert_no_leaks()
+
+
+def test_unconditional_branch():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        # The a->join and b->join branches are unconditional.
+        ubrs = _insts_by_class(mod, "UncondBrInst")
+        assert len(ubrs) == 2
+        assert ubrs[0].is_conditional is False
+        assert ubrs[0].num_successors == 1
+        del ubrs, mod
+    assert_no_leaks()
+
+
+def test_return_value():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_PHI_SRC, ctx, "m")
+        ret = _only(mod, "ReturnInst")
+        assert ret.return_value.name == "p"
+        del ret, mod
+    assert_no_leaks()
+
+
+def test_memory_accessors():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_MEM_SRC, ctx, "m")
+        alloca = _only(mod, "AllocaInst")
+        assert str(alloca.allocated_type) == "i32"
+        load = _only(mod, "LoadInst")
+        # pointer_operand downcasts to the alloca it loads from.
+        assert type(load.pointer_operand).__name__ == "AllocaInst"
+        assert load.pointer_operand.name == "slot"
+        store = _only(mod, "StoreInst")
+        assert store.pointer_operand.name == "slot"
+        gep = _only(mod, "GetElementPtrInst")
+        assert str(gep.source_element_type) == "i32"
+        del alloca, load, store, gep, mod
+    assert_no_leaks()
+
+
+def test_call_accessors():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_MEM_SRC, ctx, "m")
+        call = _only(mod, "CallInst")
+        assert call.num_args == 2
+        assert call.arg_operand(0).name == "x"
+        assert call.arg_operand(1).name == "ld"
+        # The called operand is the @g function.
+        assert call.called_operand.name == "g"
+        with pytest.raises(IndexError):
+            call.arg_operand(99)
+        del call, mod
+    assert_no_leaks()
+
+
+def test_fcmp_predicate():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_MEM_SRC, ctx, "m")
+        fcmp = _only(mod, "FCmpInst")
+        assert fcmp.predicate == llvm.FCmpPredicate.OGT
+        del fcmp, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -3,6 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from textwrap import dedent
 
+import gc
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -168,4 +170,25 @@ def test_function_type_accessor():
         assert f.function_type.num_params == 2
         assert str(f.function_type.return_type) == "i32"
         del f, mod
+    assert_no_leaks()
+
+
+def test_module_outlives_released_context():
+    # A Module holds a shared_ptr to the LLVMContext, so it stays usable after
+    # the Python context manager's __exit__ releases the Context. The live count
+    # drops at __exit__ (nothing leaked), but the underlying LLVMContext survives
+    # until the module itself is gone. Under a unique_ptr Context, dereferencing
+    # the module here would be a use-after-free.
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+    # Context released; the live count is already back to zero.
+    assert llvm.Context._get_live_count() == 0
+    # Dereference the still-live module: print it and walk its instructions.
+    assert "define i32 @f(i32 %x, i32 %y)" in str(mod)
+    for f in mod.functions:
+        for bb in f.basic_blocks:
+            for inst in bb.instructions:
+                assert str(inst)
+    del mod
+    gc.collect()
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_values.py
+++ b/projects/eudsl-llvmpy/tests/test_values.py
@@ -58,9 +58,8 @@ def test_basic_block_and_instruction_traversal():
         # add, ret
         assert len(insts) == 2
         assert entry.terminator == insts[-1]
-        # Instruction is registered (the spine); concrete opcode downcasting
-        # (BinaryOperator) activates once the instruction classes are bound.
-        assert type(insts[0]).__name__ == "Instruction"
+        # The Value type_hook downcasts the add to its concrete class.
+        assert type(insts[0]).__name__ == "BinaryOperator"
         del f, entry, blocks, insts, mod
     assert_no_leaks()
 
@@ -73,6 +72,7 @@ def test_value_users_and_operands():
         # %x is used by the add.
         assert x.num_uses == 1
         add = x.users[0]
+        assert type(add).__name__ == "BinaryOperator"
         assert add.num_operands == 2
         assert add.operand(0) == x
         del f, x, add, mod


### PR DESCRIPTION
Two fixes surfaced by concrete instruction downcasting:
- type_hook is keyed on the static pointer type, so specialize it across the
  whole Value/Type hierarchy (SFINAE on is_base_of) rather than only the
  base classes; otherwise accessors returning Instruction*/User* never
  downcast.
- LLVMContext is now held by shared_ptr and kept alive by each Module, so a
  Value/Module lingering past the Context manager's __exit__ no longer
  dereferences a freed context.
