### PR TITLE
[eudsl-llvmpy] C++ object layer: Constant subclasses and constant construction

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -102,6 +102,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Kinds.cpp
   src/IR/Values.cpp
   src/IR/Instructions.cpp
+  src/IR/Constants.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -63,8 +63,20 @@ void populate_constants(nb::module_ &m) {
       "const_int",
       [](llvm::Type *ty, int64_t value, bool isSigned) -> llvm::Constant * {
         auto *ity = llvm::cast<llvm::IntegerType>(ty);
-        return llvm::ConstantInt::get(ity, static_cast<uint64_t>(value),
-                                      isSigned);
+        unsigned bitWidth = ity->getBitWidth();
+        uint64_t uvalue = static_cast<uint64_t>(value);
+        // ConstantInt::get asserts (aborts the process) rather than raising
+        // if the value doesn't fit the type's bit width; check first so an
+        // out-of-range value surfaces as a catchable Python exception.
+        bool fits = isSigned ? llvm::isIntN(bitWidth, value)
+                              : llvm::isUIntN(bitWidth, uvalue);
+        if (!fits)
+          throw nb::value_error(
+              ("value " + std::to_string(value) + " does not fit in a " +
+               std::to_string(bitWidth) + "-bit " +
+               (isSigned ? "signed" : "unsigned") + " integer")
+                  .c_str());
+        return llvm::ConstantInt::get(ity, uvalue, isSigned);
       },
       "type"_a, "value"_a, "signed"_a = false, nb::rv_policy::reference,
       nb::keep_alive<0, 1>());

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -1,0 +1,102 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/GlobalAlias.h>
+#include <llvm/IR/GlobalIFunc.h>
+#include <llvm/IR/GlobalVariable.h>
+
+void populate_constants(nb::module_ &m) {
+  nb::class_<llvm::ConstantData, llvm::Constant>(m, "ConstantData");
+  nb::class_<llvm::ConstantAggregate, llvm::Constant>(m, "ConstantAggregate");
+
+  nb::class_<llvm::ConstantInt, llvm::ConstantData>(m, "ConstantInt")
+      .def_prop_ro("value",
+                   [](llvm::ConstantInt &self) {
+                     return self.getValue().getSExtValue();
+                   })
+      .def_prop_ro("zext_value", [](llvm::ConstantInt &self) {
+        return self.getValue().getZExtValue();
+      });
+
+  nb::class_<llvm::ConstantFP, llvm::ConstantData>(m, "ConstantFP")
+      .def_prop_ro("double_value", [](llvm::ConstantFP &self) {
+        return self.getValueAPF().convertToDouble();
+      });
+
+  nb::class_<llvm::UndefValue, llvm::ConstantData>(m, "UndefValue");
+  nb::class_<llvm::PoisonValue, llvm::UndefValue>(m, "PoisonValue");
+  nb::class_<llvm::ConstantPointerNull, llvm::ConstantData>(
+      m, "ConstantPointerNull");
+  nb::class_<llvm::ConstantAggregateZero, llvm::ConstantData>(
+      m, "ConstantAggregateZero");
+  nb::class_<llvm::ConstantTokenNone, llvm::ConstantData>(m,
+                                                         "ConstantTokenNone");
+  nb::class_<llvm::ConstantArray, llvm::ConstantAggregate>(m, "ConstantArray");
+  nb::class_<llvm::ConstantStruct, llvm::ConstantAggregate>(m, "ConstantStruct");
+  nb::class_<llvm::ConstantVector, llvm::ConstantAggregate>(m, "ConstantVector");
+  nb::class_<llvm::ConstantDataSequential, llvm::ConstantData>(
+      m, "ConstantDataSequential");
+  nb::class_<llvm::ConstantDataArray, llvm::ConstantDataSequential>(
+      m, "ConstantDataArray");
+  nb::class_<llvm::ConstantDataVector, llvm::ConstantDataSequential>(
+      m, "ConstantDataVector");
+  nb::class_<llvm::ConstantExpr, llvm::Constant>(m, "ConstantExpr");
+  nb::class_<llvm::BlockAddress, llvm::Constant>(m, "BlockAddress");
+
+  nb::class_<llvm::GlobalVariable, llvm::GlobalObject>(m, "GlobalVariable")
+      .def_prop_ro("is_constant", &llvm::GlobalVariable::isConstant)
+      .def_prop_ro(
+          "initializer",
+          [](llvm::GlobalVariable &self) -> llvm::Constant * {
+            return self.hasInitializer() ? self.getInitializer() : nullptr;
+          },
+          nb::rv_policy::reference_internal);
+  nb::class_<llvm::GlobalAlias, llvm::GlobalValue>(m, "GlobalAlias");
+  nb::class_<llvm::GlobalIFunc, llvm::GlobalObject>(m, "GlobalIFunc");
+
+  m.def(
+      "const_int",
+      [](llvm::Type *ty, int64_t value, bool isSigned) -> llvm::Constant * {
+        auto *ity = llvm::cast<llvm::IntegerType>(ty);
+        return llvm::ConstantInt::get(ity, static_cast<uint64_t>(value),
+                                      isSigned);
+      },
+      "type"_a, "value"_a, "signed"_a = false, nb::rv_policy::reference,
+      nb::keep_alive<0, 1>());
+  m.def(
+      "const_bool",
+      [](eudsl::Context &ctx, bool b) -> llvm::Constant * {
+        return llvm::ConstantInt::getBool(ctx.get(), b);
+      },
+      "context"_a, "value"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "const_fp",
+      [](llvm::Type *ty, double value) -> llvm::Constant * {
+        return llvm::ConstantFP::get(ty, value);
+      },
+      "type"_a, "value"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "undef",
+      [](llvm::Type *ty) -> llvm::Constant * {
+        return llvm::UndefValue::get(ty);
+      },
+      "type"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "poison",
+      [](llvm::Type *ty) -> llvm::Constant * {
+        return llvm::PoisonValue::get(ty);
+      },
+      "type"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.def(
+      "null",
+      [](llvm::Type *ty) -> llvm::Constant * {
+        return llvm::Constant::getNullValue(ty);
+      },
+      "type"_a, nb::rv_policy::reference, nb::keep_alive<0, 1>());
+  m.attr("const_null") = m.attr("null");
+}

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -8,6 +8,7 @@
 
 #include <llvm/AsmParser/Parser.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalVariable.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/SourceMgr.h>
 
@@ -68,6 +69,19 @@ void populate_context(nb::module_ &m) {
           "get_function",
           [](eudsl::Module &self, const std::string &name) {
             return self.get().getFunction(name);
+          },
+          "name"_a, nb::rv_policy::reference)
+      .def_prop_ro("globals",
+                   [](eudsl::Module &self) {
+                     std::vector<llvm::GlobalVariable *> out;
+                     for (llvm::GlobalVariable &g : self.get().globals())
+                       out.push_back(&g);
+                     return out;
+                   })
+      .def(
+          "get_global_variable",
+          [](eudsl::Module &self, const std::string &name) {
+            return self.get().getNamedGlobal(name);
           },
           "name"_a, nb::rv_policy::reference)
       .def("__str__", [](eudsl::Module &self) {

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -10,6 +10,7 @@ void populate_context(nb::module_ &m);
 void populate_types(nb::module_ &m);
 void populate_values(nb::module_ &m);
 void populate_instructions(nb::module_ &m);
+void populate_constants(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -18,4 +19,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_types(types);
   populate_values(m);
   populate_instructions(m);
+  populate_constants(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_constants.py
+++ b/projects/eudsl-llvmpy/tests/test_constants.py
@@ -7,11 +7,11 @@ from llvm.testing import assert_no_leaks
 
 def test_const_int():
     with llvm.Context() as ctx:
-        c = llvm.const_int(llvm.i32(ctx), 42)
+        c = llvm.const_int(llvm.types.i32(ctx), 42)
         assert type(c).__name__ == "ConstantInt"
         assert c.value == 42
         assert str(c) == "i32 42"
-        neg = llvm.const_int(llvm.i32(ctx), -1, signed=True)
+        neg = llvm.const_int(llvm.types.i32(ctx), -1, signed=True)
         assert neg.value == -1
     assert_no_leaks()
 
@@ -21,7 +21,7 @@ def test_const_bool_and_fp():
         t = llvm.const_bool(ctx, True)
         assert type(t).__name__ == "ConstantInt"
         assert str(t) == "i1 true"
-        f = llvm.const_fp(llvm.f64(ctx), 1.5)
+        f = llvm.const_fp(llvm.types.f64(ctx), 1.5)
         assert type(f).__name__ == "ConstantFP"
         assert f.double_value == 1.5
         assert str(f) == "double 1.500000e+00"
@@ -30,8 +30,8 @@ def test_const_bool_and_fp():
 
 def test_undef_poison_null():
     with llvm.Context() as ctx:
-        assert type(llvm.undef(llvm.i32(ctx))).__name__ == "UndefValue"
-        assert type(llvm.poison(llvm.i32(ctx))).__name__ == "PoisonValue"
-        assert type(llvm.null(llvm.ptr_t(ctx))).__name__ == "ConstantPointerNull"
-        assert str(llvm.undef(llvm.i32(ctx))) == "i32 undef"
+        assert type(llvm.undef(llvm.types.i32(ctx))).__name__ == "UndefValue"
+        assert type(llvm.poison(llvm.types.i32(ctx))).__name__ == "PoisonValue"
+        assert type(llvm.null(llvm.types.ptr(ctx))).__name__ == "ConstantPointerNull"
+        assert str(llvm.undef(llvm.types.i32(ctx))) == "i32 undef"
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_constants.py
+++ b/projects/eudsl-llvmpy/tests/test_constants.py
@@ -1,8 +1,31 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
+
+_GLOBALS_SRC = dedent(
+    """\
+    @g_const  = constant i32 42
+    @g_var    = global i32 7
+    @g_noinit = external global i32
+    """
+)
+
+_AGGREGATE_SRC = dedent(
+    """\
+    @g_var  = global i32 7
+    @arr    = constant [6 x i8] c"hello\\00"
+    @zero   = constant [4 x i32] zeroinitializer
+    @vec    = constant <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+    @strukt = constant { i32, float } { i32 1, float 2.0 }
+    @expr   = constant i32* getelementptr (i32, i32* @g_var, i32 1)
+    """
+)
 
 
 def test_const_int():
@@ -13,6 +36,22 @@ def test_const_int():
         assert str(c) == "i32 42"
         neg = llvm.const_int(llvm.types.i32(ctx), -1, signed=True)
         assert neg.value == -1
+        assert neg.zext_value == 4294967295
+    assert_no_leaks()
+
+
+def test_const_int_out_of_range_raises():
+    with llvm.Context() as ctx:
+        i8 = llvm.types.i8(ctx)
+        with pytest.raises(ValueError):
+            llvm.const_int(i8, 300, signed=False)
+        with pytest.raises(ValueError):
+            llvm.const_int(i8, -1, signed=False)
+        with pytest.raises(ValueError):
+            llvm.const_int(i8, 200, signed=True)
+        # in-range values on both sides of zero still work
+        assert llvm.const_int(i8, 255, signed=False).zext_value == 255
+        assert llvm.const_int(i8, -128, signed=True).value == -128
     assert_no_leaks()
 
 
@@ -24,7 +63,6 @@ def test_const_bool_and_fp():
         f = llvm.const_fp(llvm.types.f64(ctx), 1.5)
         assert type(f).__name__ == "ConstantFP"
         assert f.double_value == 1.5
-        assert str(f) == "double 1.500000e+00"
     assert_no_leaks()
 
 
@@ -33,5 +71,52 @@ def test_undef_poison_null():
         assert type(llvm.undef(llvm.types.i32(ctx))).__name__ == "UndefValue"
         assert type(llvm.poison(llvm.types.i32(ctx))).__name__ == "PoisonValue"
         assert type(llvm.null(llvm.types.ptr(ctx))).__name__ == "ConstantPointerNull"
+        assert llvm.null is llvm.const_null
         assert str(llvm.undef(llvm.types.i32(ctx))) == "i32 undef"
+    assert_no_leaks()
+
+
+def test_global_variable_is_constant_and_initializer():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_GLOBALS_SRC, ctx, "m")
+
+        g_const = mod.get_global_variable("g_const")
+        assert g_const.is_constant is True
+        assert type(g_const.initializer).__name__ == "ConstantInt"
+        assert g_const.initializer.value == 42
+
+        g_var = mod.get_global_variable("g_var")
+        assert g_var.is_constant is False
+        assert type(g_var.initializer).__name__ == "ConstantInt"
+        assert g_var.initializer.value == 7
+
+        g_noinit = mod.get_global_variable("g_noinit")
+        assert g_noinit.is_constant is False
+        assert g_noinit.initializer is None
+
+        assert {g.name for g in mod.globals} == {"g_const", "g_var", "g_noinit"}
+        del mod
+    assert_no_leaks()
+
+
+def test_aggregate_and_expr_constant_downcasts():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_AGGREGATE_SRC, ctx, "m")
+
+        assert type(mod.get_global_variable("arr").initializer).__name__ == (
+            "ConstantDataArray"
+        )
+        assert type(mod.get_global_variable("zero").initializer).__name__ == (
+            "ConstantAggregateZero"
+        )
+        assert type(mod.get_global_variable("vec").initializer).__name__ == (
+            "ConstantDataVector"
+        )
+        assert type(mod.get_global_variable("strukt").initializer).__name__ == (
+            "ConstantStruct"
+        )
+        assert type(mod.get_global_variable("expr").initializer).__name__ == (
+            "ConstantExpr"
+        )
+        del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_constants.py
+++ b/projects/eudsl-llvmpy/tests/test_constants.py
@@ -1,0 +1,37 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_const_int():
+    with llvm.Context() as ctx:
+        c = llvm.const_int(llvm.i32(ctx), 42)
+        assert type(c).__name__ == "ConstantInt"
+        assert c.value == 42
+        assert str(c) == "i32 42"
+        neg = llvm.const_int(llvm.i32(ctx), -1, signed=True)
+        assert neg.value == -1
+    assert_no_leaks()
+
+
+def test_const_bool_and_fp():
+    with llvm.Context() as ctx:
+        t = llvm.const_bool(ctx, True)
+        assert type(t).__name__ == "ConstantInt"
+        assert str(t) == "i1 true"
+        f = llvm.const_fp(llvm.f64(ctx), 1.5)
+        assert type(f).__name__ == "ConstantFP"
+        assert f.double_value == 1.5
+        assert str(f) == "double 1.500000e+00"
+    assert_no_leaks()
+
+
+def test_undef_poison_null():
+    with llvm.Context() as ctx:
+        assert type(llvm.undef(llvm.i32(ctx))).__name__ == "UndefValue"
+        assert type(llvm.poison(llvm.i32(ctx))).__name__ == "PoisonValue"
+        assert type(llvm.null(llvm.ptr_t(ctx))).__name__ == "ConstantPointerNull"
+        assert str(llvm.undef(llvm.i32(ctx))) == "i32 undef"
+    assert_no_leaks()


### PR DESCRIPTION
Binds the `llvm::Constant` subclasses and constant construction: ConstantInt and ConstantFP, the aggregate and data constants, ConstantExpr, and the global-value constants. `const_int` guards against a value that doesn't fit the target integer type's bit width (interpreted per `signed`), which would otherwise trip an APInt assertion and abort the process; it now raises `ValueError` instead.