### PR TITLE
[eudsl-llvmpy] C++ object layer: IRBuilder with an insertion-point context manager

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -103,6 +103,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Values.cpp
   src/IR/Instructions.cpp
   src/IR/Constants.cpp
+  src/IR/Builder.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -74,12 +74,17 @@ void populate_builder(nb::module_ &m) {
       [](B &self, llvm::Value *l, llvm::Value *r, const std::string &name)     \
           -> llvm::Value * { return self.method(l, r, name); },                \
       "lhs"_a, "rhs"_a, "name"_a = "", nb::rv_policy::reference_internal)
-          EUDSL_BIN("add", CreateAdd) EUDSL_BIN("fadd", CreateFAdd)
-              EUDSL_BIN("sub", CreateSub) EUDSL_BIN("fsub", CreateFSub)
-                  EUDSL_BIN("mul", CreateMul) EUDSL_BIN("fmul", CreateFMul)
-                      EUDSL_BIN("sdiv", CreateSDiv)
-                          EUDSL_BIN("udiv", CreateUDiv)
-                              EUDSL_BIN("fdiv", CreateFDiv)
+      // clang-format off
+      EUDSL_BIN("add", CreateAdd)
+      EUDSL_BIN("fadd", CreateFAdd)
+      EUDSL_BIN("sub", CreateSub)
+      EUDSL_BIN("fsub", CreateFSub)
+      EUDSL_BIN("mul", CreateMul)
+      EUDSL_BIN("fmul", CreateFMul)
+      EUDSL_BIN("sdiv", CreateSDiv)
+      EUDSL_BIN("udiv", CreateUDiv)
+      EUDSL_BIN("fdiv", CreateFDiv)
+      // clang-format on
 #undef EUDSL_BIN
       .def(
           "icmp",

--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -1,0 +1,149 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IRBuilder.h>
+
+#include <vector>
+
+namespace {
+// Owns a saved insertion point so `with builder.at_end_of(bb)` positions the
+// builder on __enter__ (restoring is unnecessary for the DSL's usage, which
+// always sets a fresh insertion point per block).
+struct InsertGuard {
+  llvm::IRBuilder<> *builder;
+  llvm::BasicBlock *block;
+};
+} // namespace
+
+void populate_builder(nb::module_ &m) {
+  using B = llvm::IRBuilder<>;
+
+  nb::class_<InsertGuard>(m, "_InsertGuard")
+      .def("__enter__",
+           [](InsertGuard &g) { g.builder->SetInsertPoint(g.block); })
+      .def(
+          "__exit__",
+          [](InsertGuard &, nb::object, nb::object, nb::object) {},
+          nb::arg("exc_type").none(), nb::arg("exc_value").none(),
+          nb::arg("traceback").none());
+
+  nb::class_<B>(m, "IRBuilder")
+      .def(
+          "__init__",
+          [](B *self, eudsl::Context &ctx) { new (self) B(ctx.get()); },
+          "context"_a, nb::keep_alive<1, 2>())
+      .def(
+          "set_insert_point",
+          [](B &self, llvm::BasicBlock *bb) { self.SetInsertPoint(bb); },
+          "block"_a)
+      .def(
+          "at_end_of",
+          [](B &self, llvm::BasicBlock *bb) { return InsertGuard{&self, bb}; },
+          "block"_a, nb::keep_alive<0, 1>())
+      .def_prop_ro(
+          "insert_block", [](B &self) { return self.GetInsertBlock(); },
+          nb::rv_policy::reference_internal)
+      .def(
+          "ret",
+          [](B &self, llvm::Value *v) -> llvm::Value * {
+            return v ? self.CreateRet(v) : self.CreateRetVoid();
+          },
+          "value"_a = nullptr, nb::rv_policy::reference_internal)
+      .def(
+          "br",
+          [](B &self, llvm::BasicBlock *dest) -> llvm::Value * {
+            return self.CreateBr(dest);
+          },
+          "dest"_a, nb::rv_policy::reference_internal)
+      .def(
+          "cond_br",
+          [](B &self, llvm::Value *c, llvm::BasicBlock *t,
+             llvm::BasicBlock *f) -> llvm::Value * {
+            return self.CreateCondBr(c, t, f);
+          },
+          "cond"_a, "true_dest"_a, "false_dest"_a,
+          nb::rv_policy::reference_internal)
+#define EUDSL_BIN(pyName, method)                                              \
+  .def(                                                                        \
+      pyName,                                                                  \
+      [](B &self, llvm::Value *l, llvm::Value *r, const std::string &name)     \
+          -> llvm::Value * { return self.method(l, r, name); },                \
+      "lhs"_a, "rhs"_a, "name"_a = "", nb::rv_policy::reference_internal)
+          EUDSL_BIN("add", CreateAdd) EUDSL_BIN("fadd", CreateFAdd)
+              EUDSL_BIN("sub", CreateSub) EUDSL_BIN("fsub", CreateFSub)
+                  EUDSL_BIN("mul", CreateMul) EUDSL_BIN("fmul", CreateFMul)
+                      EUDSL_BIN("sdiv", CreateSDiv)
+                          EUDSL_BIN("udiv", CreateUDiv)
+                              EUDSL_BIN("fdiv", CreateFDiv)
+#undef EUDSL_BIN
+      .def(
+          "icmp",
+          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l, llvm::Value *r,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateICmp(p, l, r, name);
+          },
+          "predicate"_a, "lhs"_a, "rhs"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "fcmp",
+          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l, llvm::Value *r,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateFCmp(p, l, r, name);
+          },
+          "predicate"_a, "lhs"_a, "rhs"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "alloca",
+          [](B &self, llvm::Type *ty, const std::string &name) -> llvm::Value * {
+            return self.CreateAlloca(ty, nullptr, name);
+          },
+          "type"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "load",
+          [](B &self, llvm::Type *ty, llvm::Value *ptr,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateLoad(ty, ptr, name);
+          },
+          "type"_a, "ptr"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "store",
+          [](B &self, llvm::Value *v, llvm::Value *ptr) -> llvm::Value * {
+            return self.CreateStore(v, ptr);
+          },
+          "value"_a, "ptr"_a, nb::rv_policy::reference_internal)
+      .def(
+          "gep",
+          [](B &self, llvm::Type *ty, llvm::Value *ptr,
+             std::vector<llvm::Value *> idxs,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateGEP(ty, ptr, idxs, name);
+          },
+          "type"_a, "ptr"_a, "indices"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "call",
+          [](B &self, llvm::Function *fn, std::vector<llvm::Value *> args,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateCall(fn->getFunctionType(), fn, args, name);
+          },
+          "fn"_a, "args"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "phi",
+          [](B &self, llvm::Type *ty, const std::string &name) {
+            return self.CreatePHI(ty, 0, name);
+          },
+          "type"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "i64_const",
+          [](B &self, int64_t v) -> llvm::Value * { return self.getInt64(v); },
+          "value"_a, nb::rv_policy::reference_internal)
+      .def(
+          "i32_const",
+          [](B &self, int32_t v) -> llvm::Value * { return self.getInt32(v); },
+          "value"_a, nb::rv_policy::reference_internal);
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -11,6 +11,7 @@ void populate_types(nb::module_ &m);
 void populate_values(nb::module_ &m);
 void populate_instructions(nb::module_ &m);
 void populate_constants(nb::module_ &m);
+void populate_builder(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -20,4 +21,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_values(m);
   populate_instructions(m);
   populate_constants(m);
+  populate_builder(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_builder.py
+++ b/projects/eudsl-llvmpy/tests/test_builder.py
@@ -8,8 +8,8 @@ from llvm.testing import assert_no_leaks
 def test_build_add_function():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        fn = llvm.Function.create(llvm.function_t(i32, [i32, i32]), "add2", mod)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32, i32]), "add2", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.IRBuilder(ctx)
         with b.at_end_of(bb):
@@ -26,9 +26,9 @@ def test_build_add_function():
 def test_build_conditional_with_phi():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        i1 = llvm.i1(ctx)
-        fn = llvm.Function.create(llvm.function_t(i32, [i1]), "sel", mod)
+        i32 = llvm.types.i32(ctx)
+        i1 = llvm.types.i1(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i1]), "sel", mod)
         entry = fn.append_basic_block("entry")
         a = fn.append_basic_block("a")
         b_ = fn.append_basic_block("b")
@@ -54,8 +54,8 @@ def test_build_conditional_with_phi():
 def test_alloca_load_store():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        fn = llvm.Function.create(llvm.function_t(i32, []), "f", mod)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, []), "f", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.IRBuilder(ctx)
         with b.at_end_of(bb):

--- a/projects/eudsl-llvmpy/tests/test_builder.py
+++ b/projects/eudsl-llvmpy/tests/test_builder.py
@@ -1,0 +1,71 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_build_add_function():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        fn = llvm.Function.create(llvm.function_t(i32, [i32, i32]), "add2", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            s = b.add(fn.arg(0), fn.arg(1), "s")
+            b.ret(s)
+        printed = str(mod)
+        assert "define i32 @add2(i32 %0, i32 %1)" in printed
+        assert "%s = add i32 %0, %1" in printed
+        assert "ret i32 %s" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_build_conditional_with_phi():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        i1 = llvm.i1(ctx)
+        fn = llvm.Function.create(llvm.function_t(i32, [i1]), "sel", mod)
+        entry = fn.append_basic_block("entry")
+        a = fn.append_basic_block("a")
+        b_ = fn.append_basic_block("b")
+        join = fn.append_basic_block("join")
+        bld = llvm.IRBuilder(ctx)
+        with bld.at_end_of(entry):
+            bld.cond_br(fn.arg(0), a, b_)
+        with bld.at_end_of(a):
+            bld.br(join)
+        with bld.at_end_of(b_):
+            bld.br(join)
+        with bld.at_end_of(join):
+            p = bld.phi(i32, "p")
+            p.add_incoming(llvm.const_int(i32, 1), a)
+            p.add_incoming(llvm.const_int(i32, 2), b_)
+            bld.ret(p)
+        printed = str(mod)
+        assert "phi i32 [ 1, %a ], [ 2, %b ]" in printed
+        del bld, fn, entry, a, b_, join, p, mod
+    assert_no_leaks()
+
+
+def test_alloca_load_store():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        fn = llvm.Function.create(llvm.function_t(i32, []), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            slot = b.alloca(i32, "slot")
+            b.store(llvm.const_int(i32, 5), slot)
+            loaded = b.load(i32, slot, "loaded")
+            b.ret(loaded)
+        printed = str(mod)
+        assert "alloca i32" in printed
+        assert "store i32 5" in printed
+        assert "load i32" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_builder.py
+++ b/projects/eudsl-llvmpy/tests/test_builder.py
@@ -1,6 +1,8 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -64,8 +66,235 @@ def test_alloca_load_store():
             loaded = b.load(i32, slot, "loaded")
             b.ret(loaded)
         printed = str(mod)
-        assert "alloca i32" in printed
-        assert "store i32 5" in printed
-        assert "load i32" in printed
+        assert "%slot = alloca i32" in printed
+        assert "store i32 5, ptr %slot" in printed
+        assert "%loaded = load i32, ptr %slot" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_void_ret():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        void = llvm.types.void(ctx)
+        fn = llvm.Function.create(llvm.types.function(void, []), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            b.ret()
+        printed = str(mod)
+        assert "ret void" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_binary_ops_int():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(i32, [i32, i32]), "binops", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        x, y = fn.arg(0), fn.arg(1)
+        with b.at_end_of(bb):
+            r_sub = b.sub(x, y, "r_sub")
+            r_mul = b.mul(x, y, "r_mul")
+            r_sdiv = b.sdiv(x, y, "r_sdiv")
+            r_udiv = b.udiv(x, y, "r_udiv")
+            b.ret(r_sub)
+        printed = str(mod)
+        assert "%r_sub = sub i32 %0, %1" in printed
+        assert "%r_mul = mul i32 %0, %1" in printed
+        assert "%r_sdiv = sdiv i32 %0, %1" in printed
+        assert "%r_udiv = udiv i32 %0, %1" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_binary_ops_float():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f32 = llvm.types.f32(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(f32, [f32, f32]), "fbinops", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        x, y = fn.arg(0), fn.arg(1)
+        with b.at_end_of(bb):
+            r_fadd = b.fadd(x, y, "r_fadd")
+            r_fsub = b.fsub(x, y, "r_fsub")
+            r_fmul = b.fmul(x, y, "r_fmul")
+            r_fdiv = b.fdiv(x, y, "r_fdiv")
+            b.ret(r_fadd)
+        printed = str(mod)
+        assert "%r_fadd = fadd float %0, %1" in printed
+        assert "%r_fsub = fsub float %0, %1" in printed
+        assert "%r_fmul = fmul float %0, %1" in printed
+        assert "%r_fdiv = fdiv float %0, %1" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_icmp():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        i1 = llvm.types.i1(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(i1, [i32, i32]), "cmp", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            result = b.icmp(llvm.CmpPredicate.SLT, fn.arg(0), fn.arg(1), "lt")
+            b.ret(result)
+        printed = str(mod)
+        assert "%lt = icmp slt i32 %0, %1" in printed
+        assert isinstance(result, llvm.ICmpInst)
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_fcmp():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f64 = llvm.types.f64(ctx)
+        i1 = llvm.types.i1(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(i1, [f64, f64]), "fcmp", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            result = b.fcmp(llvm.CmpPredicate.OGT, fn.arg(0), fn.arg(1), "gt")
+            b.ret(result)
+        printed = str(mod)
+        assert "%gt = fcmp ogt double %0, %1" in printed
+        assert isinstance(result, llvm.FCmpInst)
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_gep():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        ptr = llvm.types.ptr(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(ptr, [ptr, i32]), "gep_test", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            result = b.gep(i32, fn.arg(0), [fn.arg(1)], "elem")
+            b.ret(result)
+        printed = str(mod)
+        assert "%elem = getelementptr i32, ptr %0, i32 %1" in printed
+        assert isinstance(result, llvm.GetElementPtrInst)
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_call():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        callee = llvm.Function.create(
+            llvm.types.function(i32, [i32]), "callee", mod
+        )
+        fn = llvm.Function.create(
+            llvm.types.function(i32, [i32]), "caller", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            result = b.call(callee, [fn.arg(0)], "r")
+            b.ret(result)
+        printed = str(mod)
+        assert "%r = call i32 @callee(i32 %0)" in printed
+        assert isinstance(result, llvm.CallInst)
+        del b, fn, bb, callee, mod
+    assert_no_leaks()
+
+
+def test_i32_const_and_i64_const():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i64 = llvm.types.i64(ctx)
+        fn = llvm.Function.create(
+            llvm.types.function(i64, []), "consts", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb):
+            c32 = b.i32_const(42)
+            c64 = b.i64_const(100)
+            b.ret(c64)
+        assert isinstance(c32, llvm.ConstantInt)
+        assert isinstance(c64, llvm.ConstantInt)
+        printed = str(mod)
+        assert "ret i64 100" in printed
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_set_insert_point():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        b.set_insert_point(bb)
+        assert b.insert_block is bb
+        b.ret(fn.arg(0))
+        assert "ret i32 %0" in str(mod)
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_context_manager_does_not_restore():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        void = llvm.types.void(ctx)
+        fn = llvm.Function.create(llvm.types.function(void, []), "f", mod)
+        outer = fn.append_basic_block("outer")
+        inner = fn.append_basic_block("inner")
+        b = llvm.IRBuilder(ctx)
+        b.set_insert_point(outer)
+        assert b.insert_block is outer
+        with b.at_end_of(inner):
+            assert b.insert_block is inner
+        assert b.insert_block is inner
+        del b, fn, outer, inner, mod
+    assert_no_leaks()
+
+
+def test_context_manager_propagates_exceptions():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        void = llvm.types.void(ctx)
+        fn = llvm.Function.create(llvm.types.function(void, []), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with pytest.raises(ValueError, match="test error"):
+            with b.at_end_of(bb):
+                raise ValueError("test error")
+        del b, fn, bb, mod
+    assert_no_leaks()
+
+
+def test_context_manager_enter_returns_none():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        void = llvm.types.void(ctx)
+        fn = llvm.Function.create(llvm.types.function(void, []), "f", mod)
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        with b.at_end_of(bb) as guard:
+            assert guard is None
         del b, fn, bb, mod
     assert_no_leaks()


### PR DESCRIPTION
Binds `IRBuilder` with a Python context manager for the insertion point. Entering positions the builder at a basic block; the builder exposes the create-instruction methods used to emit IR.
