### PR TITLE
[eudsl-llvmpy] C++ object layer: verifyModule, bitcode read and write

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -112,6 +112,8 @@ nanobind_add_module(eudslllvm_ext
 set(eudslllvm_ext_libs
   LLVMCore
   LLVMAsmParser
+  LLVMBitReader
+  LLVMBitWriter
   LLVMSupport
   LLVMTarget
   LLVMMC

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -8,10 +8,14 @@
 #include "IR/TargetInit.h"
 
 #include <llvm/AsmParser/Parser.h>
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/Metadata.h>
+#include <llvm/IR/Verifier.h>
 #include <llvm/MC/TargetRegistry.h>
+#include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 
 #include <nanobind/stl/string.h>
@@ -102,11 +106,26 @@ void populate_context(nb::module_ &m) {
             return out;
           },
           "name"_a)
-      .def("__str__", [](eudsl::Module &self) {
-        std::string s;
-        llvm::raw_string_ostream os(s);
-        self.get().print(os, nullptr);
-        return s;
+      .def("__str__",
+           [](eudsl::Module &self) {
+             std::string s;
+             llvm::raw_string_ostream os(s);
+             self.get().print(os, nullptr);
+             return s;
+           })
+      .def("verify",
+           [](eudsl::Module &self) {
+             std::string msg;
+             llvm::raw_string_ostream os(msg);
+             if (llvm::verifyModule(self.get(), &os))
+               throw eudsl::VerifyError(msg);
+           })
+      .def("to_bitcode", [](eudsl::Module &self) {
+        std::string buf;
+        llvm::raw_string_ostream os(buf);
+        llvm::WriteBitcodeToFile(self.get(), os);
+        os.flush();
+        return nb::bytes(buf.data(), buf.size());
       });
 
   m.def(
@@ -130,6 +149,20 @@ void populate_context(nb::module_ &m) {
       "ir"_a, "context"_a, "module_identifier"_a = "<string>",
       "source_filename"_a = "", nb::keep_alive<0, 2>(),
       "Parse LLVM textual IR into a new Module.");
+
+  m.def(
+      "parse_bitcode",
+      [](nb::bytes data, eudsl::Context &ctx) {
+        llvm::StringRef ref(data.c_str(), data.size());
+        auto buf = llvm::MemoryBuffer::getMemBuffer(ref, "<bitcode>", false);
+        llvm::Expected<std::unique_ptr<llvm::Module>> mod =
+            llvm::parseBitcodeFile(buf->getMemBufferRef(), ctx.get());
+        if (!mod)
+          throw eudsl::ParseError(llvm::toString(mod.takeError()));
+        return new eudsl::Module(std::move(*mod), ctx);
+      },
+      "data"_a, "context"_a, nb::keep_alive<0, 2>(),
+      "Parse an LLVM bitcode buffer into a new Module.");
 
   eudsl::initializeTargets();
 

--- a/projects/eudsl-llvmpy/tests/test_verify_bitcode.py
+++ b/projects/eudsl-llvmpy/tests/test_verify_bitcode.py
@@ -3,6 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from textwrap import dedent
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
@@ -19,8 +21,40 @@ _GOOD = dedent(
 def test_verify_accepts_good_module():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly(_GOOD, ctx, "m")
-        assert mod.verify() is None
+        mod.verify()
         del mod
+    assert_no_leaks()
+
+
+def test_verify_rejects_bad_module():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                define i32 @f(i32 %x) {
+                entry:
+                  br label %body
+                body:
+                  ret i32 %y
+                unreachable:
+                  %y = add i32 %x, 1
+                  br label %body
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        with pytest.raises(llvm.VerifyError):
+            mod.verify()
+        del mod
+    assert_no_leaks()
+
+
+def test_parse_bitcode_rejects_garbage():
+    with llvm.Context() as ctx:
+        with pytest.raises(llvm.ParseError, match="Invalid bitcode signature"):
+            llvm.parse_bitcode(b"not bitcode", ctx)
     assert_no_leaks()
 
 
@@ -33,6 +67,9 @@ def test_bitcode_round_trip():
         del mod
     with llvm.Context() as ctx2:
         mod2 = llvm.parse_bitcode(data, ctx2)
-        assert "define i32 @f(i32 %x)" in str(mod2)
+        mod2.verify()
+        printed = str(mod2)
+        assert "define i32 @f(i32 %x)" in printed
+        assert "ret i32 %x" in printed
         del mod2
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_verify_bitcode.py
+++ b/projects/eudsl-llvmpy/tests/test_verify_bitcode.py
@@ -1,0 +1,38 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_GOOD = dedent(
+    """\
+    define i32 @f(i32 %x) {
+    entry:
+      ret i32 %x
+    }
+    """
+)
+
+
+def test_verify_accepts_good_module():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_GOOD, ctx, "m")
+        assert mod.verify() is None
+        del mod
+    assert_no_leaks()
+
+
+def test_bitcode_round_trip():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_GOOD, ctx, "m")
+        data = mod.to_bitcode()
+        assert isinstance(data, bytes)
+        assert data[:2] == b"BC"
+        del mod
+    with llvm.Context() as ctx2:
+        mod2 = llvm.parse_bitcode(data, ctx2)
+        assert "define i32 @f(i32 %x)" in str(mod2)
+        del mod2
+    assert_no_leaks()


### PR DESCRIPTION
Binds module verification and bitcode I/O: `verifyModule`, reading a module from bitcode, and writing a module to bitcode.
