### PR TITLE
[eudsl-llvmpy] C++ object layer: PassBuilder pipeline execution via run_passes

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -107,6 +107,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Attributes.cpp
   src/IR/Metadata.cpp
   src/IR/Errors.cpp
+  src/IR/Passes.cpp
 )
 
 set(eudslllvm_ext_libs
@@ -114,6 +115,11 @@ set(eudslllvm_ext_libs
   LLVMAsmParser
   LLVMBitReader
   LLVMBitWriter
+  LLVMPasses
+  LLVMAnalysis
+  LLVMTransformUtils
+  LLVMScalarOpts
+  LLVMInstCombine
   LLVMSupport
   LLVMTarget
   LLVMMC

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -1,0 +1,33 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/PassManager.h>
+#include <llvm/Passes/PassBuilder.h>
+
+void populate_passes(nb::module_ &m) {
+  m.def(
+      "run_passes",
+      [](eudsl::Module &mod, const std::string &pipeline) {
+        llvm::PassBuilder pb;
+        llvm::LoopAnalysisManager lam;
+        llvm::FunctionAnalysisManager fam;
+        llvm::CGSCCAnalysisManager cgam;
+        llvm::ModuleAnalysisManager mam;
+        pb.registerModuleAnalyses(mam);
+        pb.registerCGSCCAnalyses(cgam);
+        pb.registerFunctionAnalyses(fam);
+        pb.registerLoopAnalyses(lam);
+        pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+        llvm::ModulePassManager mpm;
+        if (llvm::Error err = pb.parsePassPipeline(mpm, pipeline))
+          throw std::runtime_error(llvm::toString(std::move(err)));
+        mpm.run(mod.get(), mam);
+      },
+      "module"_a, "pipeline"_a,
+      "Parse and run a textual pass pipeline over the module in place.");
+}

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -31,14 +31,16 @@ void populate_passes(nb::module_ &m) {
 
   m.def(
       "run_passes",
-      [](eudsl::Module &mod, const std::string &pipeline, bool debug,
+      [](eudsl::Module &mod, const std::string &pipeline,
+         std::optional<llvm::PipelineTuningOptions> pto, bool debug,
          bool verify_each) {
+        llvm::PipelineTuningOptions opts = pto.value_or(
+            llvm::PipelineTuningOptions());
         llvm::PassInstrumentationCallbacks pic;
         llvm::StandardInstrumentations si(mod.get().getContext(), debug,
                                           verify_each);
         si.registerCallbacks(pic);
-        llvm::PassBuilder pb(nullptr, llvm::PipelineTuningOptions(), std::nullopt,
-                             &pic);
+        llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
         llvm::LoopAnalysisManager lam;
         llvm::FunctionAnalysisManager fam;
         llvm::CGSCCAnalysisManager cgam;
@@ -54,7 +56,8 @@ void populate_passes(nb::module_ &m) {
           throw std::runtime_error(llvm::toString(std::move(err)));
         mpm.run(mod.get(), mam);
       },
-      "module"_a, "pipeline"_a, "debug"_a = false, "verify_each"_a = false,
+      "module"_a, "pipeline"_a, "tuning"_a = nb::none(), "debug"_a = false,
+      "verify_each"_a = false,
       "Parse and run a textual pass pipeline over the module in place.");
 
   m.def(

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -6,9 +6,28 @@
 #include "IR/Ownership.h"
 
 #include <llvm/IR/PassManager.h>
+#include <llvm/Passes/OptimizationLevel.h>
 #include <llvm/Passes/PassBuilder.h>
 
 void populate_passes(nb::module_ &m) {
+  nb::enum_<llvm::OptimizationLevel>(m, "OptLevel")
+      .value("O0", llvm::OptimizationLevel::O0)
+      .value("O1", llvm::OptimizationLevel::O1)
+      .value("O2", llvm::OptimizationLevel::O2)
+      .value("O3", llvm::OptimizationLevel::O3);
+
+  nb::class_<llvm::PipelineTuningOptions>(m, "PipelineTuningOptions")
+      .def(nb::init<>())
+      .def_rw("loop_interleaving",
+              &llvm::PipelineTuningOptions::LoopInterleaving)
+      .def_rw("loop_vectorization",
+              &llvm::PipelineTuningOptions::LoopVectorization)
+      .def_rw("slp_vectorization",
+              &llvm::PipelineTuningOptions::SLPVectorization)
+      .def_rw("loop_unrolling", &llvm::PipelineTuningOptions::LoopUnrolling)
+      .def_rw("merge_functions",
+              &llvm::PipelineTuningOptions::MergeFunctions);
+
   m.def(
       "run_passes",
       [](eudsl::Module &mod, const std::string &pipeline) {
@@ -30,4 +49,31 @@ void populate_passes(nb::module_ &m) {
       },
       "module"_a, "pipeline"_a,
       "Parse and run a textual pass pipeline over the module in place.");
+
+  m.def(
+      "run_default_pipeline",
+      [](eudsl::Module &mod, llvm::OptimizationLevel level,
+         nb::object pto_obj) {
+        llvm::PipelineTuningOptions pto;
+        if (!pto_obj.is_none())
+          pto = nb::cast<llvm::PipelineTuningOptions>(pto_obj);
+        llvm::PassBuilder pb(nullptr, pto);
+        llvm::LoopAnalysisManager lam;
+        llvm::FunctionAnalysisManager fam;
+        llvm::CGSCCAnalysisManager cgam;
+        llvm::ModuleAnalysisManager mam;
+        pb.registerModuleAnalyses(mam);
+        pb.registerCGSCCAnalyses(cgam);
+        pb.registerFunctionAnalyses(fam);
+        pb.registerLoopAnalyses(lam);
+        pb.crossRegisterProxies(lam, fam, cgam, mam);
+
+        llvm::ModulePassManager mpm =
+            (level == llvm::OptimizationLevel::O0)
+                ? pb.buildO0DefaultPipeline(level)
+                : pb.buildPerModuleDefaultPipeline(level);
+        mpm.run(mod.get(), mam);
+      },
+      "module"_a, "level"_a, "tuning"_a = nb::none(),
+      "Run the default optimization pipeline at the given level.");
 }

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -8,6 +8,7 @@
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/OptimizationLevel.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <llvm/Passes/StandardInstrumentations.h>
 
 void populate_passes(nb::module_ &m) {
   nb::enum_<llvm::OptimizationLevel>(m, "OptLevel")
@@ -30,8 +31,14 @@ void populate_passes(nb::module_ &m) {
 
   m.def(
       "run_passes",
-      [](eudsl::Module &mod, const std::string &pipeline) {
-        llvm::PassBuilder pb;
+      [](eudsl::Module &mod, const std::string &pipeline, bool debug,
+         bool verify_each) {
+        llvm::PassInstrumentationCallbacks pic;
+        llvm::StandardInstrumentations si(mod.get().getContext(), debug,
+                                          verify_each);
+        si.registerCallbacks(pic);
+        llvm::PassBuilder pb(nullptr, llvm::PipelineTuningOptions(), std::nullopt,
+                             &pic);
         llvm::LoopAnalysisManager lam;
         llvm::FunctionAnalysisManager fam;
         llvm::CGSCCAnalysisManager cgam;
@@ -47,17 +54,21 @@ void populate_passes(nb::module_ &m) {
           throw std::runtime_error(llvm::toString(std::move(err)));
         mpm.run(mod.get(), mam);
       },
-      "module"_a, "pipeline"_a,
+      "module"_a, "pipeline"_a, "debug"_a = false, "verify_each"_a = false,
       "Parse and run a textual pass pipeline over the module in place.");
 
   m.def(
       "run_default_pipeline",
       [](eudsl::Module &mod, llvm::OptimizationLevel level,
-         nb::object pto_obj) {
-        llvm::PipelineTuningOptions pto;
-        if (!pto_obj.is_none())
-          pto = nb::cast<llvm::PipelineTuningOptions>(pto_obj);
-        llvm::PassBuilder pb(nullptr, pto);
+         std::optional<llvm::PipelineTuningOptions> pto, bool debug,
+         bool verify_each) {
+        llvm::PipelineTuningOptions opts = pto.value_or(
+            llvm::PipelineTuningOptions());
+        llvm::PassInstrumentationCallbacks pic;
+        llvm::StandardInstrumentations si(mod.get().getContext(), debug,
+                                          verify_each);
+        si.registerCallbacks(pic);
+        llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
         llvm::LoopAnalysisManager lam;
         llvm::FunctionAnalysisManager fam;
         llvm::CGSCCAnalysisManager cgam;
@@ -74,6 +85,7 @@ void populate_passes(nb::module_ &m) {
                 : pb.buildPerModuleDefaultPipeline(level);
         mpm.run(mod.get(), mam);
       },
-      "module"_a, "level"_a, "tuning"_a = nb::none(),
+      "module"_a, "level"_a, "tuning"_a = nb::none(), "debug"_a = false,
+      "verify_each"_a = false,
       "Run the default optimization pipeline at the given level.");
 }

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -16,6 +16,7 @@ void populate_instructions(nb::module_ &m);
 void populate_constants(nb::module_ &m);
 void populate_metadata(nb::module_ &m);
 void populate_builder(nb::module_ &m);
+void populate_passes(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -29,4 +30,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_constants(m);
   populate_metadata(m);
   populate_builder(m);
+  populate_passes(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/test_passes.py
@@ -100,3 +100,30 @@ def test_pipeline_tuning_options_defaults():
     assert isinstance(pto.slp_vectorization, bool)
     assert isinstance(pto.loop_interleaving, bool)
     assert isinstance(pto.merge_functions, bool)
+
+
+def test_run_passes_with_debug(capsys):
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        llvm.run_passes(mod, "instcombine", debug=True)
+        assert "add i32 %x, 0" not in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_run_passes_with_verify_each():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        llvm.run_passes(mod, "instcombine", verify_each=True)
+        assert "ret i32 %x" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_default_pipeline_with_debug():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        llvm.run_default_pipeline(mod, llvm.OptLevel.O1, debug=True)
+        assert "define" in str(mod)
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/test_passes.py
@@ -1,0 +1,38 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @f(i32 %x) {
+    entry:
+      %a = add i32 %x, 0
+      ret i32 %a
+    }
+    """
+)
+
+
+def test_instcombine_removes_add_zero():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        assert "add i32 %x, 0" in str(mod)
+        llvm.run_passes(mod, "instcombine")
+        assert "add i32 %x, 0" not in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_bad_pipeline_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        with pytest.raises(RuntimeError):
+            llvm.run_passes(mod, "not-a-real-pass")
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/test_passes.py
@@ -57,3 +57,46 @@ def test_verify_pipeline_is_noop():
         assert str(mod) == before
         del mod
     assert_no_leaks()
+
+
+def test_default_pipeline_o2():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        llvm.run_default_pipeline(mod, llvm.OptLevel.O2)
+        printed = str(mod)
+        assert "add i32 %x, 0" not in printed
+        assert "ret i32 %x" in printed
+        del mod
+    assert_no_leaks()
+
+
+def test_default_pipeline_o0():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        llvm.run_default_pipeline(mod, llvm.OptLevel.O0)
+        assert "define" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_default_pipeline_with_tuning():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        pto = llvm.PipelineTuningOptions()
+        pto.loop_vectorization = False
+        pto.slp_vectorization = False
+        llvm.run_default_pipeline(mod, llvm.OptLevel.O2, tuning=pto)
+        printed = str(mod)
+        assert "add i32 %x, 0" not in printed
+        assert "ret i32 %x" in printed
+        del mod
+    assert_no_leaks()
+
+
+def test_pipeline_tuning_options_defaults():
+    pto = llvm.PipelineTuningOptions()
+    assert pto.loop_unrolling is True
+    assert isinstance(pto.loop_vectorization, bool)
+    assert isinstance(pto.slp_vectorization, bool)
+    assert isinstance(pto.loop_interleaving, bool)
+    assert isinstance(pto.merge_functions, bool)

--- a/projects/eudsl-llvmpy/tests/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/test_passes.py
@@ -24,7 +24,9 @@ def test_instcombine_removes_add_zero():
         mod = llvm.parse_assembly(_SRC, ctx, "m")
         assert "add i32 %x, 0" in str(mod)
         llvm.run_passes(mod, "instcombine")
-        assert "add i32 %x, 0" not in str(mod)
+        printed = str(mod)
+        assert "add i32 %x, 0" not in printed
+        assert "ret i32 %x" in printed
         del mod
     assert_no_leaks()
 
@@ -32,7 +34,26 @@ def test_instcombine_removes_add_zero():
 def test_bad_pipeline_raises():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly(_SRC, ctx, "m")
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="unknown pass name"):
             llvm.run_passes(mod, "not-a-real-pass")
+        del mod
+    assert_no_leaks()
+
+
+def test_empty_pipeline_raises():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        with pytest.raises(RuntimeError, match="unknown pass name"):
+            llvm.run_passes(mod, "")
+        del mod
+    assert_no_leaks()
+
+
+def test_verify_pipeline_is_noop():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        before = str(mod)
+        llvm.run_passes(mod, "verify")
+        assert str(mod) == before
         del mod
     assert_no_leaks()


### PR DESCRIPTION
Binds `run_passes`, which runs a textual PassBuilder pipeline over a module. An unknown pass name raises a `RuntimeError` rather than silently doing nothing.
