### PR TITLE
[eudsl-llvmpy] C++ object layer: Target, TargetMachine, DataLayout, asm and object emission

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -108,6 +108,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Metadata.cpp
   src/IR/Errors.cpp
   src/IR/Passes.cpp
+  src/IR/Target.cpp
 )
 
 set(eudslllvm_ext_libs
@@ -120,6 +121,7 @@ set(eudslllvm_ext_libs
   LLVMTransformUtils
   LLVMScalarOpts
   LLVMInstCombine
+  LLVMAsmPrinter
   LLVMSupport
   LLVMTarget
   LLVMMC

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -17,6 +17,13 @@
 #include <llvm/MC/TargetRegistry.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
+#include <llvm/Target/TargetMachine.h>
+
+namespace eudsl {
+struct TargetMachine {
+  std::unique_ptr<llvm::TargetMachine> tm;
+};
+} // namespace eudsl
 
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
@@ -129,11 +136,8 @@ void populate_context(nb::module_ &m) {
       })
       .def(
           "set_data_layout_from",
-          [](eudsl::Module &self, nb::handle tm) {
-            // TargetMachine lives in Target.cpp; fetch its data-layout string
-            // through the bound property to avoid a cross-file C++ dependency.
-            std::string dl = nb::cast<std::string>(tm.attr("data_layout_str"));
-            self.get().setDataLayout(dl);
+          [](eudsl::Module &self, eudsl::TargetMachine &tm) {
+            self.get().setDataLayout(tm.tm->createDataLayout());
           },
           "target_machine"_a);
 

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -126,7 +126,16 @@ void populate_context(nb::module_ &m) {
         llvm::WriteBitcodeToFile(self.get(), os);
         os.flush();
         return nb::bytes(buf.data(), buf.size());
-      });
+      })
+      .def(
+          "set_data_layout_from",
+          [](eudsl::Module &self, nb::handle tm) {
+            // TargetMachine lives in Target.cpp; fetch its data-layout string
+            // through the bound property to avoid a cross-file C++ dependency.
+            std::string dl = nb::cast<std::string>(tm.attr("data_layout_str"));
+            self.get().setDataLayout(dl);
+          },
+          "target_machine"_a);
 
   m.def(
       "parse_assembly",

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -19,12 +19,6 @@
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/Target/TargetMachine.h>
 
-namespace eudsl {
-struct TargetMachine {
-  std::unique_ptr<llvm::TargetMachine> tm;
-};
-} // namespace eudsl
-
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -136,8 +130,8 @@ void populate_context(nb::module_ &m) {
       })
       .def(
           "set_data_layout_from",
-          [](eudsl::Module &self, eudsl::TargetMachine &tm) {
-            self.get().setDataLayout(tm.tm->createDataLayout());
+          [](eudsl::Module &self, llvm::TargetMachine &tm) {
+            self.get().setDataLayout(tm.createDataLayout());
           },
           "target_machine"_a);
 

--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -16,12 +16,15 @@
 #include <memory>
 #include <optional>
 
-namespace {
-struct TM {
+namespace eudsl {
+struct TargetMachine {
   std::unique_ptr<llvm::TargetMachine> tm;
 };
+} // namespace eudsl
 
-std::string emit(TM &self, eudsl::Module &mod, llvm::CodeGenFileType type) {
+namespace {
+std::string emit(eudsl::TargetMachine &self, eudsl::Module &mod,
+                 llvm::CodeGenFileType type) {
   std::string buf;
   llvm::raw_string_ostream os(buf);
   llvm::buffer_ostream bos(os);
@@ -36,13 +39,23 @@ std::string emit(TM &self, eudsl::Module &mod, llvm::CodeGenFileType type) {
 void populate_target(nb::module_ &m) {
   m.def("host_triple", []() { return llvm::sys::getDefaultTargetTriple(); });
 
-  nb::class_<TM>(m, "TargetMachine")
+  nb::class_<eudsl::TargetMachine>(m, "TargetMachine")
       .def(
           "__init__",
-          [](TM *self, const std::string &triple, const std::string &cpu,
-             const std::string &features) {
+          [](eudsl::TargetMachine *self, std::optional<std::string> triple,
+             std::optional<std::string> cpu,
+             std::optional<std::vector<std::string>> features) {
             std::string tripleStr =
-                triple.empty() ? llvm::sys::getDefaultTargetTriple() : triple;
+                triple.value_or(llvm::sys::getDefaultTargetTriple());
+            std::string cpuStr = cpu.value_or("");
+            std::string featStr;
+            if (features) {
+              for (size_t i = 0; i < features->size(); ++i) {
+                if (i > 0)
+                  featStr += ",";
+                featStr += (*features)[i];
+              }
+            }
             llvm::Triple tt(tripleStr);
             std::string err;
             const llvm::Target *target =
@@ -51,30 +64,35 @@ void populate_target(nb::module_ &m) {
               throw std::runtime_error(err);
             llvm::TargetOptions opts;
             llvm::TargetMachine *tm = target->createTargetMachine(
-                tt, cpu, features, opts, std::nullopt);
+                tt, cpuStr, featStr, opts, std::nullopt);
             if (!tm)
               throw std::runtime_error("could not create TargetMachine for " +
                                        tripleStr);
-            new (self) TM{std::unique_ptr<llvm::TargetMachine>(tm)};
+            new (self) eudsl::TargetMachine{
+                std::unique_ptr<llvm::TargetMachine>(tm)};
           },
-          "triple"_a = "", "cpu"_a = "", "features"_a = "")
+          "triple"_a = nb::none(), "cpu"_a = nb::none(),
+          "features"_a = nb::none())
       .def_prop_ro("triple",
-                   [](TM &self) { return self.tm->getTargetTriple().str(); })
+                   [](eudsl::TargetMachine &self) {
+                     return self.tm->getTargetTriple().str();
+                   })
       .def_prop_ro("data_layout_str",
-                   [](TM &self) {
+                   [](eudsl::TargetMachine &self) {
                      return self.tm->createDataLayout()
                          .getStringRepresentation();
                    })
       .def(
           "emit_assembly",
-          [](TM &self, eudsl::Module &mod) {
+          [](eudsl::TargetMachine &self, eudsl::Module &mod) {
             return emit(self, mod, llvm::CodeGenFileType::AssemblyFile);
           },
           "module"_a)
       .def(
           "emit_object",
-          [](TM &self, eudsl::Module &mod) {
-            std::string obj = emit(self, mod, llvm::CodeGenFileType::ObjectFile);
+          [](eudsl::TargetMachine &self, eudsl::Module &mod) {
+            std::string obj =
+                emit(self, mod, llvm::CodeGenFileType::ObjectFile);
             return nb::bytes(obj.data(), obj.size());
           },
           "module"_a);

--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -16,20 +16,14 @@
 #include <memory>
 #include <optional>
 
-namespace eudsl {
-struct TargetMachine {
-  std::unique_ptr<llvm::TargetMachine> tm;
-};
-} // namespace eudsl
-
 namespace {
-std::string emit(eudsl::TargetMachine &self, eudsl::Module &mod,
+std::string emit(llvm::TargetMachine &self, eudsl::Module &mod,
                  llvm::CodeGenFileType type) {
   std::string buf;
   llvm::raw_string_ostream os(buf);
   llvm::buffer_ostream bos(os);
   llvm::legacy::PassManager pm;
-  if (self.tm->addPassesToEmitFile(pm, bos, nullptr, type))
+  if (self.addPassesToEmitFile(pm, bos, nullptr, type))
     throw std::runtime_error("target cannot emit this file type");
   pm.run(mod.get());
   return buf;
@@ -39,58 +33,57 @@ std::string emit(eudsl::TargetMachine &self, eudsl::Module &mod,
 void populate_target(nb::module_ &m) {
   m.def("host_triple", []() { return llvm::sys::getDefaultTargetTriple(); });
 
-  nb::class_<eudsl::TargetMachine>(m, "TargetMachine")
+  nb::class_<llvm::TargetMachine>(m, "TargetMachine")
       .def(
-          "__init__",
-          [](eudsl::TargetMachine *self, std::optional<std::string> triple,
-             std::optional<std::string> cpu,
-             std::optional<std::vector<std::string>> features) {
-            std::string tripleStr =
-                triple.value_or(llvm::sys::getDefaultTargetTriple());
-            std::string cpuStr = cpu.value_or("");
-            std::string featStr;
-            if (features) {
-              for (size_t i = 0; i < features->size(); ++i) {
-                if (i > 0)
-                  featStr += ",";
-                featStr += (*features)[i];
-              }
-            }
-            llvm::Triple tt(tripleStr);
-            std::string err;
-            const llvm::Target *target =
-                llvm::TargetRegistry::lookupTarget(tt, err);
-            if (!target)
-              throw std::runtime_error(err);
-            llvm::TargetOptions opts;
-            llvm::TargetMachine *tm = target->createTargetMachine(
-                tt, cpuStr, featStr, opts, std::nullopt);
-            if (!tm)
-              throw std::runtime_error("could not create TargetMachine for " +
-                                       tripleStr);
-            new (self) eudsl::TargetMachine{
-                std::unique_ptr<llvm::TargetMachine>(tm)};
-          },
+          nb::new_(
+              [](std::optional<std::string> triple,
+                 std::optional<std::string> cpu,
+                 std::optional<std::vector<std::string>> features)
+                  -> llvm::TargetMachine * {
+                std::string tripleStr =
+                    triple.value_or(llvm::sys::getDefaultTargetTriple());
+                std::string cpuStr = cpu.value_or("");
+                std::string featStr;
+                if (features) {
+                  for (size_t i = 0; i < features->size(); ++i) {
+                    if (i > 0)
+                      featStr += ",";
+                    featStr += (*features)[i];
+                  }
+                }
+                llvm::Triple tt(tripleStr);
+                std::string err;
+                const llvm::Target *target =
+                    llvm::TargetRegistry::lookupTarget(tt, err);
+                if (!target)
+                  throw std::runtime_error(err);
+                llvm::TargetOptions opts;
+                llvm::TargetMachine *tm = target->createTargetMachine(
+                    tt, cpuStr, featStr, opts, std::nullopt);
+                if (!tm)
+                  throw std::runtime_error(
+                      "could not create TargetMachine for " + tripleStr);
+                return tm;
+              }),
           "triple"_a = nb::none(), "cpu"_a = nb::none(),
           "features"_a = nb::none())
       .def_prop_ro("triple",
-                   [](eudsl::TargetMachine &self) {
-                     return self.tm->getTargetTriple().str();
+                   [](llvm::TargetMachine &self) {
+                     return self.getTargetTriple().str();
                    })
       .def_prop_ro("data_layout_str",
-                   [](eudsl::TargetMachine &self) {
-                     return self.tm->createDataLayout()
-                         .getStringRepresentation();
+                   [](llvm::TargetMachine &self) {
+                     return self.createDataLayout().getStringRepresentation();
                    })
       .def(
           "emit_assembly",
-          [](eudsl::TargetMachine &self, eudsl::Module &mod) {
+          [](llvm::TargetMachine &self, eudsl::Module &mod) {
             return emit(self, mod, llvm::CodeGenFileType::AssemblyFile);
           },
           "module"_a)
       .def(
           "emit_object",
-          [](eudsl::TargetMachine &self, eudsl::Module &mod) {
+          [](llvm::TargetMachine &self, eudsl::Module &mod) {
             std::string obj =
                 emit(self, mod, llvm::CodeGenFileType::ObjectFile);
             return nb::bytes(obj.data(), obj.size());

--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -1,0 +1,81 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/MC/TargetRegistry.h>
+#include <llvm/Support/CodeGen.h>
+#include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
+#include <llvm/TargetParser/Host.h>
+#include <llvm/TargetParser/Triple.h>
+
+#include <memory>
+#include <optional>
+
+namespace {
+struct TM {
+  std::unique_ptr<llvm::TargetMachine> tm;
+};
+
+std::string emit(TM &self, eudsl::Module &mod, llvm::CodeGenFileType type) {
+  std::string buf;
+  llvm::raw_string_ostream os(buf);
+  llvm::buffer_ostream bos(os);
+  llvm::legacy::PassManager pm;
+  if (self.tm->addPassesToEmitFile(pm, bos, nullptr, type))
+    throw std::runtime_error("target cannot emit this file type");
+  pm.run(mod.get());
+  return buf;
+}
+} // namespace
+
+void populate_target(nb::module_ &m) {
+  m.def("host_triple", []() { return llvm::sys::getDefaultTargetTriple(); });
+
+  nb::class_<TM>(m, "TargetMachine")
+      .def(
+          "__init__",
+          [](TM *self, const std::string &triple, const std::string &cpu,
+             const std::string &features) {
+            std::string tripleStr =
+                triple.empty() ? llvm::sys::getDefaultTargetTriple() : triple;
+            llvm::Triple tt(tripleStr);
+            std::string err;
+            const llvm::Target *target =
+                llvm::TargetRegistry::lookupTarget(tt, err);
+            if (!target)
+              throw std::runtime_error(err);
+            llvm::TargetOptions opts;
+            llvm::TargetMachine *tm = target->createTargetMachine(
+                tt, cpu, features, opts, std::nullopt);
+            if (!tm)
+              throw std::runtime_error("could not create TargetMachine for " +
+                                       tripleStr);
+            new (self) TM{std::unique_ptr<llvm::TargetMachine>(tm)};
+          },
+          "triple"_a = "", "cpu"_a = "", "features"_a = "")
+      .def_prop_ro("triple",
+                   [](TM &self) { return self.tm->getTargetTriple().str(); })
+      .def_prop_ro("data_layout_str",
+                   [](TM &self) {
+                     return self.tm->createDataLayout()
+                         .getStringRepresentation();
+                   })
+      .def(
+          "emit_assembly",
+          [](TM &self, eudsl::Module &mod) {
+            return emit(self, mod, llvm::CodeGenFileType::AssemblyFile);
+          },
+          "module"_a)
+      .def(
+          "emit_object",
+          [](TM &self, eudsl::Module &mod) {
+            std::string obj = emit(self, mod, llvm::CodeGenFileType::ObjectFile);
+            return nb::bytes(obj.data(), obj.size());
+          },
+          "module"_a);
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -17,6 +17,7 @@ void populate_constants(nb::module_ &m);
 void populate_metadata(nb::module_ &m);
 void populate_builder(nb::module_ &m);
 void populate_passes(nb::module_ &m);
+void populate_target(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -31,4 +32,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_metadata(m);
   populate_builder(m);
   populate_passes(m);
+  populate_target(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_target.py
+++ b/projects/eudsl-llvmpy/tests/test_target.py
@@ -1,7 +1,11 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import platform
+import sys
 from textwrap import dedent
+
+import pytest
 
 import llvm
 from llvm.testing import assert_no_leaks
@@ -22,16 +26,47 @@ def test_host_triple_is_nonempty():
     assert llvm.host_triple()
 
 
+def test_target_machine_triple_roundtrips():
+    triple = llvm.host_triple()
+    tm = llvm.TargetMachine(triple)
+    assert tm.triple == triple
+
+
+def test_target_machine_bad_triple_raises():
+    with pytest.raises(RuntimeError, match="No available targets"):
+        llvm.TargetMachine("not-a-real-triple-xyz")
+
+
+def test_target_machine_features_as_list():
+    tm = llvm.TargetMachine(features=["+sse2", "+avx"])
+    assert tm.triple == llvm.host_triple()
+
+
+def test_set_data_layout_from_mutates_module():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        tm = llvm.TargetMachine()
+        mod.set_data_layout_from(tm)
+        assert str(mod).startswith(f'; ModuleID = ')
+        assert "target datalayout" in str(mod)
+        del tm, mod
+    assert_no_leaks()
+
+
 def test_emit_assembly_and_object():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly(_SRC, ctx, "m")
-        tm = llvm.TargetMachine(llvm.host_triple())
-        assert tm.data_layout_str
+        tm = llvm.TargetMachine()
         mod.set_data_layout_from(tm)
-        asm = tm.emit_assembly(mod)
-        assert "add" in asm
+        asm_out = tm.emit_assembly(mod)
+        assert "%s = add" not in asm_out
+        assert "ret" in asm_out.lower() or "bx" in asm_out.lower() or "blr" in asm_out.lower()
         obj = tm.emit_object(mod)
         assert isinstance(obj, bytes)
-        assert len(obj) > 0
+        assert len(obj) > 4
+        if sys.platform == "darwin":
+            assert obj[:4] == b"\xcf\xfa\xed\xfe" or obj[:4] == b"\xfe\xed\xfa\xcf"
+        elif sys.platform == "linux":
+            assert obj[:4] == b"\x7fELF"
         del tm, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_target.py
+++ b/projects/eudsl-llvmpy/tests/test_target.py
@@ -1,0 +1,37 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """
+)
+
+
+def test_host_triple_is_nonempty():
+    assert isinstance(llvm.host_triple(), str)
+    assert llvm.host_triple()
+
+
+def test_emit_assembly_and_object():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        tm = llvm.TargetMachine(llvm.host_triple())
+        assert tm.data_layout_str
+        mod.set_data_layout_from(tm)
+        asm = tm.emit_assembly(mod)
+        assert "add" in asm
+        obj = tm.emit_object(mod)
+        assert isinstance(obj, bytes)
+        assert len(obj) > 0
+        del tm, mod
+    assert_no_leaks()


### PR DESCRIPTION
Binds the codegen target surface: `Target`, `TargetMachine`, and `DataLayout`, host-triple lookup, and assembly and object emission from a module.
