### PR TITLE
[eudsl-llvmpy] C++ object layer: Linker via link_into with moved-from tracking

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -109,6 +109,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Errors.cpp
   src/IR/Passes.cpp
   src/IR/Target.cpp
+  src/IR/Linker.cpp
 )
 
 set(eudslllvm_ext_libs
@@ -122,6 +123,7 @@ set(eudslllvm_ext_libs
   LLVMScalarOpts
   LLVMInstCombine
   LLVMAsmPrinter
+  LLVMLinker
   LLVMSupport
   LLVMTarget
   LLVMMC

--- a/projects/eudsl-llvmpy/src/IR/Linker.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Linker.cpp
@@ -1,0 +1,23 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/Linker/Linker.h>
+
+#include <memory>
+
+void populate_linker(nb::module_ &m) {
+  m.def(
+      "link_into",
+      [](eudsl::Module &dest, eudsl::Module &src) {
+        // linkModules consumes the source module; take() marks the Python
+        // wrapper moved-from so later use raises rather than segfaults.
+        std::unique_ptr<llvm::Module> srcOwned = src.take();
+        if (llvm::Linker::linkModules(dest.get(), std::move(srcOwned)))
+          throw std::runtime_error("linkModules failed");
+      },
+      "dest"_a, "src"_a);
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -18,6 +18,7 @@ void populate_metadata(nb::module_ &m);
 void populate_builder(nb::module_ &m);
 void populate_passes(nb::module_ &m);
 void populate_target(nb::module_ &m);
+void populate_linker(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -33,4 +34,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_builder(m);
   populate_passes(m);
   populate_target(m);
+  populate_linker(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_linker.py
+++ b/projects/eudsl-llvmpy/tests/test_linker.py
@@ -1,0 +1,32 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def test_link_two_modules():
+    with llvm.Context() as ctx:
+        dest = llvm.parse_assembly("declare i32 @a()\n", ctx, "dest")
+        src = llvm.parse_assembly(
+            dedent(
+                """\
+                define i32 @a() {
+                  ret i32 7
+                }
+                """
+            ),
+            ctx,
+            "src",
+        )
+        llvm.link_into(dest, src)
+        assert src._is_consumed
+        assert "define i32 @a()" in str(dest)
+        with pytest.raises(RuntimeError, match="has been consumed"):
+            str(src)
+        del dest, src
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_linker.py
+++ b/projects/eudsl-llvmpy/tests/test_linker.py
@@ -30,3 +30,25 @@ def test_link_two_modules():
             str(src)
         del dest, src
     assert_no_leaks()
+
+
+def test_consumed_source_cannot_be_linked_again():
+    with llvm.Context() as ctx:
+        dest = llvm.parse_assembly("declare i32 @a()\n", ctx, "dest")
+        src = llvm.parse_assembly(
+            dedent(
+                """\
+                define i32 @a() {
+                  ret i32 7
+                }
+                """
+            ),
+            ctx,
+            "src",
+        )
+        llvm.link_into(dest, src)
+        dest2 = llvm.parse_assembly("declare i32 @b()\n", ctx, "dest2")
+        with pytest.raises(RuntimeError, match="has been consumed"):
+            llvm.link_into(dest2, src)
+        del dest, dest2, src
+    assert_no_leaks()


### PR DESCRIPTION
Binds the LLVM `Linker` via `link_into`, which moves one module into another. The source module is marked moved-from afterward, so further use raises instead of touching freed IR.
