### PR TITLE
[eudsl-llvmpy] C++ object layer: ORC LLJIT with module add, lookup, and execution

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -110,6 +110,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Passes.cpp
   src/IR/Target.cpp
   src/IR/Linker.cpp
+  src/IR/JIT.cpp
 )
 
 set(eudslllvm_ext_libs
@@ -124,6 +125,12 @@ set(eudslllvm_ext_libs
   LLVMInstCombine
   LLVMAsmPrinter
   LLVMLinker
+  LLVMOrcJIT
+  LLVMExecutionEngine
+  LLVMJITLink
+  LLVMOrcTargetProcess
+  LLVMOrcShared
+  LLVMRuntimeDyld
   LLVMSupport
   LLVMTarget
   LLVMMC

--- a/projects/eudsl-llvmpy/src/IR/JIT.cpp
+++ b/projects/eudsl-llvmpy/src/IR/JIT.cpp
@@ -16,26 +16,14 @@
 #include <memory>
 #include <string>
 
-namespace {
-struct JIT {
-  std::unique_ptr<llvm::orc::LLJIT> jit;
-};
-} // namespace
-
 void populate_jit(nb::module_ &m) {
-  nb::class_<JIT>(m, "LLJIT")
-      .def("__init__",
-           [](JIT *self) {
-             auto jit = eudsl::unwrap(llvm::orc::LLJITBuilder().create());
-             new (self) JIT{std::move(jit)};
-           })
+  nb::class_<llvm::orc::LLJIT>(m, "LLJIT")
+      .def(nb::new_([]() -> llvm::orc::LLJIT * {
+             return eudsl::unwrap(llvm::orc::LLJITBuilder().create()).release();
+           }))
       .def(
           "add_module",
-          [](JIT &self, eudsl::Module &mod) {
-            // Move the module into the JIT by round-tripping through bitcode
-            // into a fresh, JIT-owned LLVMContext. This avoids extracting a
-            // unique_ptr<LLVMContext> from the shared_ptr the Context/Module
-            // lifetime model uses. The source module is then marked consumed.
+          [](llvm::orc::LLJIT &self, eudsl::Module &mod) {
             std::string buf;
             {
               llvm::raw_string_ostream os(buf);
@@ -47,15 +35,14 @@ void populate_jit(nb::module_ &m) {
             std::unique_ptr<llvm::Module> cloned = eudsl::unwrap(
                 llvm::parseBitcodeFile(memBuf->getMemBufferRef(), *ctx));
             llvm::orc::ThreadSafeModule tsm(std::move(cloned), std::move(ctx));
-            eudsl::unwrap(self.jit->addIRModule(std::move(tsm)));
-            // Mark the source module consumed so later use raises.
+            eudsl::unwrap(self.addIRModule(std::move(tsm)));
             (void)mod.take();
           },
           "module"_a)
       .def(
           "lookup",
-          [](JIT &self, const std::string &name) {
-            llvm::orc::ExecutorAddr addr = eudsl::unwrap(self.jit->lookup(name));
+          [](llvm::orc::LLJIT &self, const std::string &name) {
+            llvm::orc::ExecutorAddr addr = eudsl::unwrap(self.lookup(name));
             return static_cast<uint64_t>(addr.getValue());
           },
           "name"_a);

--- a/projects/eudsl-llvmpy/src/IR/JIT.cpp
+++ b/projects/eudsl-llvmpy/src/IR/JIT.cpp
@@ -1,0 +1,62 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/MemoryBuffer.h>
+
+#include <memory>
+#include <string>
+
+namespace {
+struct JIT {
+  std::unique_ptr<llvm::orc::LLJIT> jit;
+};
+} // namespace
+
+void populate_jit(nb::module_ &m) {
+  nb::class_<JIT>(m, "LLJIT")
+      .def("__init__",
+           [](JIT *self) {
+             auto jit = eudsl::unwrap(llvm::orc::LLJITBuilder().create());
+             new (self) JIT{std::move(jit)};
+           })
+      .def(
+          "add_module",
+          [](JIT &self, eudsl::Module &mod) {
+            // Move the module into the JIT by round-tripping through bitcode
+            // into a fresh, JIT-owned LLVMContext. This avoids extracting a
+            // unique_ptr<LLVMContext> from the shared_ptr the Context/Module
+            // lifetime model uses. The source module is then marked consumed.
+            std::string buf;
+            {
+              llvm::raw_string_ostream os(buf);
+              llvm::WriteBitcodeToFile(mod.get(), os);
+            }
+            auto ctx = std::make_unique<llvm::LLVMContext>();
+            std::unique_ptr<llvm::MemoryBuffer> memBuf =
+                llvm::MemoryBuffer::getMemBufferCopy(buf, "<jit>");
+            std::unique_ptr<llvm::Module> cloned = eudsl::unwrap(
+                llvm::parseBitcodeFile(memBuf->getMemBufferRef(), *ctx));
+            llvm::orc::ThreadSafeModule tsm(std::move(cloned), std::move(ctx));
+            eudsl::unwrap(self.jit->addIRModule(std::move(tsm)));
+            // Mark the source module consumed so later use raises.
+            (void)mod.take();
+          },
+          "module"_a)
+      .def(
+          "lookup",
+          [](JIT &self, const std::string &name) {
+            llvm::orc::ExecutorAddr addr = eudsl::unwrap(self.jit->lookup(name));
+            return static_cast<uint64_t>(addr.getValue());
+          },
+          "name"_a);
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -19,6 +19,7 @@ void populate_builder(nb::module_ &m);
 void populate_passes(nb::module_ &m);
 void populate_target(nb::module_ &m);
 void populate_linker(nb::module_ &m);
+void populate_jit(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -35,4 +36,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_passes(m);
   populate_target(m);
   populate_linker(m);
+  populate_jit(m);
 }

--- a/projects/eudsl-llvmpy/tests/test_jit.py
+++ b/projects/eudsl-llvmpy/tests/test_jit.py
@@ -4,14 +4,16 @@
 import ctypes
 from textwrap import dedent
 
+import pytest
+
 import llvm
 from llvm.testing import assert_no_leaks
 
 _SRC = dedent(
     """\
-    define i32 @add(i32 %a, i32 %b) {
+    define i32 @sub(i32 %a, i32 %b) {
     entry:
-      %s = add i32 %a, %b
+      %s = sub i32 %a, %b
       ret i32 %s
     }
     """
@@ -22,11 +24,25 @@ def test_jit_execute():
     ctx = llvm.Context()
     mod = llvm.parse_assembly(_SRC, ctx, "m")
     jit = llvm.LLJIT()
-    jit.add_module(mod)  # consumes mod
+    jit.add_module(mod)
     assert mod._is_consumed
-    addr = jit.lookup("add")
+    addr = jit.lookup("sub")
     assert addr != 0
     fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(addr)
-    assert fn(2, 40) == 42
+    assert fn(50, 8) == 42
+    assert fn(10, 3) == 7
+    del jit, mod, ctx
+    assert_no_leaks()
+
+
+def test_consumed_module_raises_on_use():
+    ctx = llvm.Context()
+    mod = llvm.parse_assembly(_SRC, ctx, "m")
+    jit = llvm.LLJIT()
+    jit.add_module(mod)
+    with pytest.raises(RuntimeError, match="has been consumed"):
+        str(mod)
+    with pytest.raises(RuntimeError, match="has been consumed"):
+        jit.add_module(mod)
     del jit, mod, ctx
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_jit.py
+++ b/projects/eudsl-llvmpy/tests/test_jit.py
@@ -1,0 +1,32 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ctypes
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """
+)
+
+
+def test_jit_execute():
+    ctx = llvm.Context()
+    mod = llvm.parse_assembly(_SRC, ctx, "m")
+    jit = llvm.LLJIT()
+    jit.add_module(mod)  # consumes mod
+    assert mod._is_consumed
+    addr = jit.lookup("add")
+    assert addr != 0
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(addr)
+    assert fn(2, 40) == 42
+    del jit, mod, ctx
+    assert_no_leaks()


### PR DESCRIPTION
add_module moves the module into a fresh JIT-owned context via a bitcode
round-trip, since the Context/Module lifetime model holds the LLVMContext by
shared_ptr and cannot hand out a unique_ptr<LLVMContext>. The source module is
marked consumed.
