### PR TITLE
[eudsl-llvmpy] C++ object layer: Intrinsic lookup/declaration and the llvm.intrinsics shim

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -111,6 +111,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Target.cpp
   src/IR/Linker.cpp
   src/IR/JIT.cpp
+  src/IR/Intrinsics.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/IR/Intrinsics.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Intrinsics.cpp
@@ -1,0 +1,35 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+#include "IR/Ownership.h"
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Intrinsics.h>
+
+#include <vector>
+
+void populate_intrinsics(nb::module_ &m) {
+  m.def(
+      "lookup_intrinsic_id",
+      [](const std::string &name) {
+        return (unsigned)llvm::Intrinsic::lookupIntrinsicID(name);
+      },
+      "name"_a);
+  m.def(
+      "intrinsic_is_overloaded",
+      [](unsigned id) {
+        return llvm::Intrinsic::isOverloaded((llvm::Intrinsic::ID)id);
+      },
+      "id"_a);
+  m.def(
+      "get_intrinsic_declaration",
+      [](eudsl::Module &mod, unsigned id,
+         std::vector<llvm::Type *> overloadTypes) -> llvm::Function * {
+        return llvm::Intrinsic::getOrInsertDeclaration(
+            &mod.get(), (llvm::Intrinsic::ID)id, overloadTypes);
+      },
+      "module"_a, "id"_a, "overload_types"_a = std::vector<llvm::Type *>{},
+      nb::rv_policy::reference, nb::keep_alive<0, 1>());
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -20,6 +20,7 @@ void populate_passes(nb::module_ &m);
 void populate_target(nb::module_ &m);
 void populate_linker(nb::module_ &m);
 void populate_jit(nb::module_ &m);
+void populate_intrinsics(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -37,4 +38,5 @@ NB_MODULE(eudslllvm_ext, m) {
   populate_target(m);
   populate_linker(m);
   populate_jit(m);
+  populate_intrinsics(m);
 }

--- a/projects/eudsl-llvmpy/src/llvm/intrinsics.py
+++ b/projects/eudsl-llvmpy/src/llvm/intrinsics.py
@@ -1,0 +1,26 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Attribute-style access to LLVM intrinsics.
+
+`llvm.intrinsics.sqrt(module, [f32])` resolves the id for `llvm.sqrt`, checks
+it exists, and emits the overloaded declaration. Overload resolution happens
+in C++ against LLVM's own tables.
+"""
+
+from . import (
+    lookup_intrinsic_id,
+    get_intrinsic_declaration,
+)
+
+
+def __getattr__(name):
+    intrinsic_id = lookup_intrinsic_id(f"llvm.{name.replace('_', '.')}")
+    if intrinsic_id == 0:
+        raise AttributeError(f"unknown intrinsic llvm.{name}")
+
+    def declare(module, overload_types=()):
+        return get_intrinsic_declaration(module, intrinsic_id, list(overload_types))
+
+    declare.__name__ = name
+    return declare

--- a/projects/eudsl-llvmpy/tests/test_intrinsics.py
+++ b/projects/eudsl-llvmpy/tests/test_intrinsics.py
@@ -16,7 +16,7 @@ def test_get_overloaded_declaration():
         mod = llvm.Module("m", ctx)
         sqrt_id = llvm.lookup_intrinsic_id("llvm.sqrt")
         assert llvm.intrinsic_is_overloaded(sqrt_id)
-        f32 = llvm.f32(ctx)
+        f32 = llvm.types.f32(ctx)
         decl = llvm.get_intrinsic_declaration(mod, sqrt_id, [f32])
         assert decl.name == "llvm.sqrt.f32"
         assert "declare float @llvm.sqrt.f32(float)" in str(mod)
@@ -27,7 +27,7 @@ def test_get_overloaded_declaration():
 def test_intrinsics_getattr_shim():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        f64 = llvm.f64(ctx)
+        f64 = llvm.types.f64(ctx)
         decl = llvm.intrinsics.sqrt(mod, [f64])
         assert decl.name == "llvm.sqrt.f64"
         del decl, mod

--- a/projects/eudsl-llvmpy/tests/test_intrinsics.py
+++ b/projects/eudsl-llvmpy/tests/test_intrinsics.py
@@ -1,0 +1,34 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import llvm
+import llvm.intrinsics
+from llvm.testing import assert_no_leaks
+
+
+def test_lookup_intrinsic_id():
+    assert llvm.lookup_intrinsic_id("llvm.sqrt") != 0
+    assert llvm.lookup_intrinsic_id("llvm.not.a.real.intrinsic") == 0
+
+
+def test_get_overloaded_declaration():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        sqrt_id = llvm.lookup_intrinsic_id("llvm.sqrt")
+        assert llvm.intrinsic_is_overloaded(sqrt_id)
+        f32 = llvm.f32(ctx)
+        decl = llvm.get_intrinsic_declaration(mod, sqrt_id, [f32])
+        assert decl.name == "llvm.sqrt.f32"
+        assert "declare float @llvm.sqrt.f32(float)" in str(mod)
+        del decl, mod
+    assert_no_leaks()
+
+
+def test_intrinsics_getattr_shim():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        f64 = llvm.f64(ctx)
+        decl = llvm.intrinsics.sqrt(mod, [f64])
+        assert decl.name == "llvm.sqrt.f64"
+        del decl, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_intrinsics.py
+++ b/projects/eudsl-llvmpy/tests/test_intrinsics.py
@@ -1,6 +1,8 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import pytest
+
 import llvm
 import llvm.intrinsics
 from llvm.testing import assert_no_leaks
@@ -32,3 +34,40 @@ def test_intrinsics_getattr_shim():
         assert decl.name == "llvm.sqrt.f64"
         del decl, mod
     assert_no_leaks()
+
+
+def test_underscore_to_dot_mangling():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        vec4i32 = llvm.types.vector(i32, 4)
+        decl = llvm.intrinsics.vector_reduce_add(mod, [vec4i32])
+        assert decl.name == "llvm.vector.reduce.add.v4i32"
+        del decl, mod
+    assert_no_leaks()
+
+
+def test_non_overloaded_intrinsic():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        trap_id = llvm.lookup_intrinsic_id("llvm.trap")
+        assert not llvm.intrinsic_is_overloaded(trap_id)
+        decl = llvm.get_intrinsic_declaration(mod, trap_id)
+        assert decl.name == "llvm.trap"
+        assert "declare void @llvm.trap()" in str(mod)
+        del decl, mod
+    assert_no_leaks()
+
+
+def test_non_overloaded_via_shim():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        decl = llvm.intrinsics.trap(mod)
+        assert decl.name == "llvm.trap"
+        del decl, mod
+    assert_no_leaks()
+
+
+def test_unknown_intrinsic_raises():
+    with pytest.raises(AttributeError, match="unknown intrinsic"):
+        llvm.intrinsics.not_a_real_intrinsic_xyz


### PR DESCRIPTION
Binds intrinsic lookup and declaration, plus the `llvm.intrinsics` shim that exposes intrinsics by name.
