### PR TITLE
[eudsl-llvmpy] Test hardening: honesty fixes, method-pointer + downcast tests, function-coverage enforcement

### DIFF
--- a/projects/eudsl-llvmpy/scripts/check_coverage.py
+++ b/projects/eudsl-llvmpy/scripts/check_coverage.py
@@ -56,6 +56,72 @@ def parse_lcov(lcov_text):
     return file_hits
 
 
+def parse_lcov_functions(lcov_text):
+    """Parse LCOV FN/FNDA records into per-file, per-function data.
+
+    Line coverage alone misses an accessor lambda whose body shares a source
+    line with the enclosing `.def(...)` registration call: the registration
+    runs at import, so the line is marked covered even though the lambda body
+    never executes. Each lambda is its own FUNCTION in the coverage data, so
+    function coverage (FNDA execution counts) catches these. The X-macro
+    dispatch (e.g. valueTypeInfo) stays a single function, so this does not
+    penalize its many unreachable case regions.
+
+    Returns {filepath: {name: {"line": lineno, "count": hits}, ...}, ...}
+    """
+    file_fns = {}
+    current_file = None
+
+    for line in lcov_text.splitlines():
+        if line.startswith("SF:"):
+            current_file = line[3:]
+            file_fns.setdefault(current_file, {})
+        elif line.startswith("FN:"):
+            if current_file is None:
+                continue
+            # FN:<line>,<name>  (llvm-cov) or FN:<start>,<end>,<name>
+            rest = line[3:]
+            head, _, name = rest.rpartition(",")
+            first = head.split(",", 1)[0]
+            try:
+                lineno = int(first)
+            except ValueError:
+                continue
+            entry = file_fns[current_file].setdefault(name, {"line": None, "count": 0})
+            entry["line"] = lineno
+        elif line.startswith("FNDA:"):
+            if current_file is None:
+                continue
+            count_str, _, name = line[5:].partition(",")
+            try:
+                count = int(count_str)
+            except ValueError:
+                continue
+            entry = file_fns[current_file].setdefault(name, {"line": None, "count": 0})
+            entry["count"] = count
+        elif line == "end_of_record":
+            current_file = None
+
+    return file_fns
+
+
+def demangle(names):
+    """Best-effort demangling for nicer reporting. Returns {name: pretty}."""
+    stripped = [n.split(":", 1)[-1] for n in names]  # drop any "file:" prefix
+    for tool in ("llvm-cxxfilt", "c++filt"):
+        try:
+            out = subprocess.run(
+                [tool], input="\n".join(stripped), capture_output=True, text=True
+            )
+            if out.returncode == 0:
+                pretty = out.stdout.splitlines()
+                if len(pretty) == len(names):
+                    return dict(zip(names, pretty))
+        except (OSError, FileNotFoundError):
+            continue
+    return {n: s for n, s in zip(names, stripped)}
+
+
 def get_excluded_lines(filepath):
     """Read a source file and return the set of line numbers excluded by
     LCOV_EXCL_LINE, LCOV_EXCL_START, and LCOV_EXCL_STOP markers.
@@ -130,6 +196,15 @@ def main():
         help="Minimum required line coverage percentage (default: 97)",
     )
     parser.add_argument(
+        "--function-threshold",
+        type=float,
+        default=None,
+        help="Minimum required function coverage percentage "
+        "(default: same as --threshold). Function coverage catches accessor "
+        "lambdas whose body never runs even though their registration line is "
+        "covered.",
+    )
+    parser.add_argument(
         "--ignore-filename-regex",
         default=None,
         help="Skip files matching this regex",
@@ -147,6 +222,7 @@ def main():
     ignore_re = re.compile(args.ignore_filename_regex) if args.ignore_filename_regex else None
 
     file_hits = parse_lcov(lcov_text)
+    file_fns = parse_lcov_functions(lcov_text)
 
     file_stats = {}
     for filepath, line_counts in file_hits.items():
@@ -170,19 +246,63 @@ def main():
             else:
                 missed.append(lineno)
 
-        file_stats[filepath] = {"total": total, "covered": covered, "missed": missed}
+        # Function coverage: a function whose definition line is excluded
+        # (e.g. an LCOV_EXCL_START/STOP block like the fatal handler) is
+        # dropped, mirroring the line-coverage exclusion.
+        f_total = 0
+        f_covered = 0
+        f_missed = []
+        for name, info in file_fns.get(filepath, {}).items():
+            ln = info["line"]
+            if ln is not None and ln in excluded:
+                continue
+            f_total += 1
+            if info["count"] > 0:
+                f_covered += 1
+            else:
+                f_missed.append((ln if ln is not None else 0, name))
+
+        file_stats[filepath] = {
+            "total": total,
+            "covered": covered,
+            "missed": missed,
+            "f_total": f_total,
+            "f_covered": f_covered,
+            "f_missed": f_missed,
+        }
 
     total_lines = sum(s["total"] for s in file_stats.values())
     covered_lines = sum(s["covered"] for s in file_stats.values())
     percent = (covered_lines / total_lines * 100.0) if total_lines > 0 else 0.0
 
+    total_fns = sum(s["f_total"] for s in file_stats.values())
+    covered_fns = sum(s["f_covered"] for s in file_stats.values())
+    fn_percent = (covered_fns / total_fns * 100.0) if total_fns > 0 else 100.0
+
+    fn_threshold = (
+        args.function_threshold
+        if args.function_threshold is not None
+        else args.threshold
+    )
+
     print(f"eudsl-llvmpy C++ coverage: {covered_lines}/{total_lines} lines ({percent:.2f}%)")
+    print(f"eudsl-llvmpy C++ coverage: {covered_fns}/{total_fns} functions ({fn_percent:.2f}%)")
+
+    # Demangle any missed function names for readable reporting.
+    all_missed = [name for s in file_stats.values() for _, name in s["f_missed"]]
+    pretty = demangle(all_missed) if all_missed else {}
 
     for filename, stats in sorted(file_stats.items()):
         f_total = stats["total"]
         f_covered = stats["covered"]
         f_percent = (f_covered / f_total * 100.0) if f_total > 0 else 0.0
-        print(f"  {filename}: {f_covered}/{f_total} ({f_percent:.2f}%)")
+        fn_t = stats["f_total"]
+        fn_c = stats["f_covered"]
+        fn_p = (fn_c / fn_t * 100.0) if fn_t > 0 else 100.0
+        print(
+            f"  {filename}: {f_covered}/{f_total} lines ({f_percent:.2f}%), "
+            f"{fn_c}/{fn_t} functions ({fn_p:.2f}%)"
+        )
         if stats["missed"]:
             sorted_lines = sorted(stats["missed"])
             ranges = []
@@ -195,12 +315,26 @@ def main():
                     start = prev = l
             ranges.append(f"{start}-{prev}" if prev > start else str(start))
             print(f"    missed lines: {', '.join(ranges)}")
+        for ln, name in sorted(stats["f_missed"]):
+            print(f"    missed function (line {ln}): {pretty.get(name, name)}")
 
-    if percent < args.threshold:
-        print(f"\nFAILED: coverage {percent:.2f}% < threshold {args.threshold:.2f}%")
+    line_ok = percent >= args.threshold
+    fn_ok = fn_percent >= fn_threshold
+    if not line_ok or not fn_ok:
+        if not line_ok:
+            print(f"\nFAILED: line coverage {percent:.2f}% < threshold {args.threshold:.2f}%")
+        if not fn_ok:
+            print(
+                f"\nFAILED: function coverage {fn_percent:.2f}% < threshold "
+                f"{fn_threshold:.2f}% (an accessor/binding runs at registration "
+                f"but its body is never called by a test)"
+            )
         return 1
 
-    print(f"\nPASSED: coverage {percent:.2f}% >= threshold {args.threshold:.2f}%")
+    print(
+        f"\nPASSED: line coverage {percent:.2f}% >= {args.threshold:.2f}%, "
+        f"function coverage {fn_percent:.2f}% >= {fn_threshold:.2f}%"
+    )
     return 0
 
 

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -36,7 +36,8 @@ void populate_context(nb::module_ &m) {
           },
           nb::arg("exc_type").none(), nb::arg("exc_value").none(),
           nb::arg("traceback").none())
-      .def_static("_get_live_count", &eudsl::Context::liveCount);
+      .def_static("_get_live_count", &eudsl::Context::liveCount)
+      .def_static("_get_live_module_count", &eudsl::Module::liveCount);
 
   nb::class_<eudsl::Module>(m, "Module")
       .def(nb::init<const std::string &, eudsl::Context &>(), "name"_a,

--- a/projects/eudsl-llvmpy/src/IR/Ownership.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.cpp
@@ -9,6 +9,7 @@
 namespace eudsl {
 
 static int64_t gLiveContexts = 0;
+static int64_t gLiveModules = 0;
 
 Context::Context() : ctx(std::make_shared<llvm::LLVMContext>()) {
   ++gLiveContexts;
@@ -33,10 +34,18 @@ llvm::LLVMContext &Context::get() const {
 
 Module::Module(const std::string &name, Context &ctx)
     : ctxKeepAlive(ctx.shared()),
-      mod(std::make_unique<llvm::Module>(name, ctx.get())), owner(&ctx) {}
+      mod(std::make_unique<llvm::Module>(name, ctx.get())), owner(&ctx) {
+  ++gLiveModules;
+}
 
 Module::Module(std::unique_ptr<llvm::Module> m, Context &ctx)
-    : ctxKeepAlive(ctx.shared()), mod(std::move(m)), owner(&ctx) {}
+    : ctxKeepAlive(ctx.shared()), mod(std::move(m)), owner(&ctx) {
+  ++gLiveModules;
+}
+
+Module::~Module() { --gLiveModules; }
+
+int64_t Module::liveCount() { return gLiveModules; }
 
 llvm::Module &Module::get() const {
   if (!mod) {

--- a/projects/eudsl-llvmpy/src/IR/Ownership.h
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.h
@@ -47,6 +47,9 @@ class Module {
 public:
   Module(const std::string &name, Context &ctx);
   Module(std::unique_ptr<llvm::Module> mod, Context &ctx);
+  ~Module();
+  Module(const Module &) = delete;
+  Module &operator=(const Module &) = delete;
 
   llvm::Module &get() const;
   /// Relinquish ownership. Every later get() throws.
@@ -54,6 +57,12 @@ public:
   bool isConsumed() const { return mod == nullptr; }
 
   Context &context() const { return *owner; }
+
+  /// Number of live Module wrappers. Unlike Context::liveCount (which drops on
+  /// release()/__exit__), this is tied to actual object destruction, so a
+  /// leaked Module — including one keeping its LLVMContext alive past the
+  /// context manager — is observable. Mirrors mlir's _get_live_module_count.
+  static int64_t liveCount();
 
 private:
   std::shared_ptr<llvm::LLVMContext> ctxKeepAlive;

--- a/projects/eudsl-llvmpy/src/llvm/testing.py
+++ b/projects/eudsl-llvmpy/src/llvm/testing.py
@@ -9,10 +9,14 @@ from . import Context
 
 
 def assert_no_leaks():
-    """Assert every Context has been destroyed.
+    """Assert every Context has been released at this point.
 
-    Mirrors the convention in llvm-project/mlir/test/python/ir/*.py: a test
-    that constructs IR must leave no live context behind.
+    This is a cheap in-body check: `Context.__exit__` calls release(), so after
+    a `with` block the context count is back to zero. It does NOT prove the
+    underlying objects were destroyed — a Module (and the LLVMContext it keeps
+    alive) can still be referenced by a live local. The authoritative leak gate
+    is the autouse fixture in tests/conftest.py, which checks both the context
+    and module counts after the test frame (and its locals) is gone.
     """
     gc.collect()
     live = Context._get_live_count()

--- a/projects/eudsl-llvmpy/tests/conftest.py
+++ b/projects/eudsl-llvmpy/tests/conftest.py
@@ -1,0 +1,28 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Authoritative leak gate for the whole suite.
+
+Every test runs inside this fixture. The checks fire in teardown, after the
+test function has returned and its frame (and every local it held) is gone, so
+a nonzero count means an object outlived all its Python references -- a real
+ownership/keep_alive bug, not just a value still bound to a local. This catches
+the case a context-only, in-body check cannot: `Context.__exit__` drops the
+context count to zero even while a leaked Module keeps its LLVMContext alive,
+so the Module count (tied to actual destruction) is what makes a leak visible.
+"""
+import gc
+
+import pytest
+
+from llvm import Context
+
+
+@pytest.fixture(autouse=True)
+def _assert_no_leaks():
+    yield
+    gc.collect()
+    live_ctx = Context._get_live_count()
+    live_mod = Context._get_live_module_count()
+    assert live_ctx == 0, f"{live_ctx} Context object(s) leaked past the test"
+    assert live_mod == 0, f"{live_mod} Module object(s) leaked past the test"

--- a/projects/eudsl-llvmpy/tests/test_context.py
+++ b/projects/eudsl-llvmpy/tests/test_context.py
@@ -9,6 +9,39 @@ import llvm
 from llvm.testing import assert_no_leaks
 
 
+def test_module_is_counted():
+    # The module count is tied to actual destruction, so it detects a leak the
+    # context count cannot: __exit__ zeroes the context count even while a
+    # Module still keeps the LLVMContext alive.
+    assert llvm.Context._get_live_module_count() == 0
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        assert llvm.Context._get_live_module_count() == 1
+        second = llvm.Module("m2", ctx)
+        assert llvm.Context._get_live_module_count() == 2
+        del second
+        gc.collect()
+        assert llvm.Context._get_live_module_count() == 1
+        del mod
+    gc.collect()
+    assert llvm.Context._get_live_module_count() == 0
+    assert_no_leaks()
+
+
+def test_leaked_module_is_detected_by_module_count():
+    # A module held past the context's release is invisible to the context count
+    # (release() dropped it to 0) but visible to the module count.
+    ctx = llvm.Context()
+    leaked = llvm.Module("leak", ctx)
+    ctx.__exit__(None, None, None)  # as if leaving a `with` block
+    gc.collect()
+    assert llvm.Context._get_live_count() == 0  # released
+    assert llvm.Context._get_live_module_count() == 1  # but the module lives
+    del leaked, ctx
+    gc.collect()
+    assert_no_leaks()
+
+
 def test_context_is_counted():
     assert llvm.Context._get_live_count() == 0
     ctx = llvm.Context()

--- a/projects/eudsl-llvmpy/tests/test_context.py
+++ b/projects/eudsl-llvmpy/tests/test_context.py
@@ -38,7 +38,6 @@ def test_leaked_module_is_detected_by_module_count():
     assert llvm.Context._get_live_count() == 0  # released
     assert llvm.Context._get_live_module_count() == 1  # but the module lives
     del leaked, ctx
-    gc.collect()
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/test_cpp_coverage.py
+++ b/projects/eudsl-llvmpy/tests/test_cpp_coverage.py
@@ -86,7 +86,7 @@ def test_use_of_released_context_raises():
 
 
 def test_target_machine_bad_triple_raises():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="No available targets"):
         llvm.TargetMachine("nonsense-not-a-triple")
 
 
@@ -128,7 +128,7 @@ def test_builder_fcmp_gep_call():
         assert "fcmp olt" in printed and "getelementptr" in printed
         assert "icmp eq" in printed
         assert "call i32 @callee" in printed
-        del b, fn, callee, mod
+        del b, bb, fn, callee, mod
     assert_no_leaks()
 
 
@@ -157,7 +157,7 @@ def test_constant_int_zext_and_global_initializer():
         g = loads[0].pointer_operand
         e = loads[1].pointer_operand
         assert type(g).__name__ == "GlobalVariable"
-        assert g.initializer is not None  # @g has an initializer
+        assert g.initializer.value == 5  # @g's initializer is the constant i32 5
         assert e.initializer is None  # @e is external, no initializer
         del loads, g, e, mod
     assert_no_leaks()
@@ -216,7 +216,7 @@ def test_jit_lookup_missing_symbol_raises():
     )
     jit = llvm.LLJIT()
     jit.add_module(mod)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Symbols not found"):
         jit.lookup("absent")
     del jit, mod, ctx
 

--- a/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
@@ -1,14 +1,20 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Behavioral tests for bindings that delegate straight to an LLVM method.
+"""Behavioral tests for bindings that line coverage cannot force.
 
-These are bound as method pointers (`.def("x", &llvm::T::x)`), so their
-implementation lives in the LLVM libraries, not in src/IR. The only line in
-src/IR is the registration, which runs at `import llvm` and is therefore
-"covered" by any test. Line coverage can't force these to be exercised, so a
-regression (wrong method bound, wrong signature, wrong result) would not show
-up as a coverage drop. This file exercises each one and checks its result.
+Two kinds of binding are invisible to the line-coverage gate:
+
+1. Method pointers (`.def("x", &llvm::T::x)`): the implementation is in the
+   LLVM libraries, not src/IR, so the only src/IR line is the registration.
+2. Accessor/op LAMBDAS (`.def("x", [](...){ ... })`): the lambda body often
+   shares a source line with the enclosing `.def(...)` call, which runs at
+   import. Line coverage marks that line covered even though the lambda body
+   never executes.
+
+The C++ coverage gate now also enforces FUNCTION coverage (each lambda is its
+own function), so a binding whose body is never called fails the gate. This
+file exercises those bindings and checks their results.
 """
 from textwrap import dedent
 
@@ -156,4 +162,98 @@ def test_global_variable_is_constant():
         assert loads[0].pointer_operand.is_constant  # @c
         assert not loads[1].pointer_operand.is_constant  # @v
         del f, loads, mod
+    assert_no_leaks()
+
+
+def test_builder_binary_ops_and_insert_point():
+    with llvm.Context() as ctx:
+        mod = llvm.Module("m", ctx)
+        i32 = llvm.i32(ctx)
+        f32 = llvm.f32(ctx)
+        fn = llvm.Function.create(
+            llvm.function_t(i32, [i32, i32, f32, f32]), "f", mod
+        )
+        bb = fn.append_basic_block("entry")
+        b = llvm.IRBuilder(ctx)
+        b.set_insert_point(bb)  # set_insert_point
+        assert b.insert_block == bb  # insert_block property
+        ia, ib, fa, fb = fn.arg(0), fn.arg(1), fn.arg(2), fn.arg(3)
+        b.add(ia, ib)
+        b.sub(ia, ib)
+        b.mul(ia, ib)
+        b.sdiv(ia, ib)
+        b.udiv(ia, ib)
+        b.fadd(fa, fb)
+        b.fsub(fa, fb)
+        b.fmul(fa, fb)
+        b.fdiv(fa, fb)
+        b.ret(ia)
+        printed = str(mod)
+        for op in ("add i32", "sub i32", "mul i32", "sdiv i32", "udiv i32",
+                   "fadd float", "fsub float", "fmul float", "fdiv float"):
+            assert op in printed, op
+        del b, bb, fn, ia, ib, fa, fb, mod
+    assert_no_leaks()
+
+
+def test_instruction_accessors():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                declare i32 @g(i32)
+                define i32 @f(i1 %c, ptr %p) {
+                entry:
+                  %s = alloca i32
+                  store i32 7, ptr %s
+                  %v = load i32, ptr %s
+                  %r = call i32 @g(i32 %v)
+                  br i1 %c, label %a, label %b
+                a:
+                  br label %b
+                b:
+                  ret i32 %r
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        insts = f.entry_block.instructions
+
+        def first(kind):
+            return next(i for i in insts if type(i).__name__ == kind)
+
+        alloca = first("AllocaInst")
+        store = first("StoreInst")
+        call = first("CallInst")
+        condbr = f.entry_block.terminator
+        assert str(alloca.allocated_type) == "i32"  # AllocaInst.allocated_type
+        assert store.pointer_operand == alloca  # StoreInst.pointer_operand
+        assert call.called_operand.name == "g"  # CallBase.called_operand
+        assert condbr.is_conditional  # CondBrInst.is_conditional
+        assert condbr.condition == f.arg(0)  # CondBrInst.condition (== %c)
+        a_block = next(b for b in f.basic_blocks if b.name == "a")
+        assert not a_block.terminator.is_conditional  # UncondBrInst.is_conditional
+        b_block = next(b for b in f.basic_blocks if b.name == "b")
+        assert b_block.terminator.return_value == call  # ReturnInst.return_value
+        del f, insts, alloca, store, call, condbr, a_block, b_block, mod
+    assert_no_leaks()
+
+
+def test_value_name_setter_and_instruction_props():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        entry = f.entry_block
+        add = entry.instructions[0]
+        ret = entry.terminator
+        assert add.is_terminator is False  # Instruction.is_terminator
+        assert ret.is_terminator is True
+        assert add.parent == entry  # Instruction.parent
+        add.name = "renamed"  # Value.name setter
+        assert add.name == "renamed"
+        assert "%renamed = add" in str(mod)
+        del f, entry, add, ret, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
@@ -1,0 +1,159 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Behavioral tests for bindings that delegate straight to an LLVM method.
+
+These are bound as method pointers (`.def("x", &llvm::T::x)`), so their
+implementation lives in the LLVM libraries, not in src/IR. The only line in
+src/IR is the registration, which runs at `import llvm` and is therefore
+"covered" by any test. Line coverage can't force these to be exercised, so a
+regression (wrong method bound, wrong signature, wrong result) would not show
+up as a coverage drop. This file exercises each one and checks its result.
+"""
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent(
+    """\
+    define i32 @f(i32 %x, i32 %y) {
+    entry:
+      %sum = add i32 %x, %y
+      ret i32 %sum
+    }
+    """
+)
+
+
+def test_type_is_pointer_and_is_label():
+    with llvm.Context() as ctx:
+        assert llvm.ptr_t(ctx).is_pointer
+        assert not llvm.i32(ctx).is_pointer
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        # A basic block is a Value; its type is the label type.
+        assert f.entry_block.type.is_label
+        assert not f.arg(0).type.is_label
+        del f, mod
+    assert_no_leaks()
+
+
+def test_vector_type_element_type():
+    with llvm.Context() as ctx:
+        assert llvm.vector_t(llvm.f32(ctx), 8).element_type == llvm.f32(ctx)
+    assert_no_leaks()
+
+
+def test_value_type_accessor():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        assert f.arg(0).type == llvm.i32(ctx)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_replace_all_uses_with():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(_SRC, ctx, "m")
+        f = mod.get_function("f")
+        add = f.arg(0).users[0]  # %sum = add, used by the ret
+        assert "ret i32 %sum" in str(mod)
+        zero = llvm.const_int(llvm.i32(ctx), 0)
+        add.replace_all_uses_with(zero)
+        # The ret now returns the constant; the (dead) add is untouched.
+        assert "ret i32 0" in str(mod)
+        assert "%sum = add" in str(mod)
+        del f, add, zero, mod
+    assert_no_leaks()
+
+
+def test_instruction_successor():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                define void @f(i1 %c) {
+                entry:
+                  br i1 %c, label %a, label %b
+                a:
+                  ret void
+                b:
+                  ret void
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        br = f.entry_block.terminator
+        assert br.successor(0).name == "a"
+        assert br.successor(1).name == "b"
+        del f, br, mod
+    assert_no_leaks()
+
+
+def test_function_type_and_var_arg():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                declare i32 @printf(ptr, ...)
+                define i32 @f(i32 %x) {
+                  ret i32 %x
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        assert str(f.function_type) == "i32 (i32)"
+        assert not f.is_var_arg
+        assert mod.get_function("printf").is_var_arg
+        del f, mod
+    assert_no_leaks()
+
+
+def test_function_visibility_roundtrip():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly("define void @f() {\n ret void\n}\n", ctx, "m")
+        f = mod.get_function("f")
+        assert f.visibility == llvm.Visibility.DEFAULT
+        f.visibility = llvm.Visibility.HIDDEN
+        assert f.visibility == llvm.Visibility.HIDDEN
+        assert "hidden" in str(mod)
+        del f, mod
+    assert_no_leaks()
+
+
+def test_global_variable_is_constant():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(
+            dedent(
+                """\
+                @c = constant i32 5
+                @v = global i32 0
+                define i32 @f() {
+                entry:
+                  %a = load i32, ptr @c
+                  %b = load i32, ptr @v
+                  ret i32 %a
+                }
+                """
+            ),
+            ctx,
+            "m",
+        )
+        f = mod.get_function("f")
+        loads = [
+            i
+            for i in f.entry_block.instructions
+            if type(i).__name__ == "LoadInst"
+        ]
+        assert loads[0].pointer_operand.is_constant  # @c
+        assert not loads[1].pointer_operand.is_constant  # @v
+        del f, loads, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/test_delegating_accessors.py
@@ -34,8 +34,8 @@ _SRC = dedent(
 
 def test_type_is_pointer_and_is_label():
     with llvm.Context() as ctx:
-        assert llvm.ptr_t(ctx).is_pointer
-        assert not llvm.i32(ctx).is_pointer
+        assert llvm.types.ptr(ctx).is_pointer
+        assert not llvm.types.i32(ctx).is_pointer
         mod = llvm.parse_assembly(_SRC, ctx, "m")
         f = mod.get_function("f")
         # A basic block is a Value; its type is the label type.
@@ -47,7 +47,7 @@ def test_type_is_pointer_and_is_label():
 
 def test_vector_type_element_type():
     with llvm.Context() as ctx:
-        assert llvm.vector_t(llvm.f32(ctx), 8).element_type == llvm.f32(ctx)
+        assert llvm.types.vector(llvm.types.f32(ctx), 8).element_type == llvm.types.f32(ctx)
     assert_no_leaks()
 
 
@@ -55,7 +55,7 @@ def test_value_type_accessor():
     with llvm.Context() as ctx:
         mod = llvm.parse_assembly(_SRC, ctx, "m")
         f = mod.get_function("f")
-        assert f.arg(0).type == llvm.i32(ctx)
+        assert f.arg(0).type == llvm.types.i32(ctx)
         del f, mod
     assert_no_leaks()
 
@@ -66,7 +66,7 @@ def test_replace_all_uses_with():
         f = mod.get_function("f")
         add = f.arg(0).users[0]  # %sum = add, used by the ret
         assert "ret i32 %sum" in str(mod)
-        zero = llvm.const_int(llvm.i32(ctx), 0)
+        zero = llvm.const_int(llvm.types.i32(ctx), 0)
         add.replace_all_uses_with(zero)
         # The ret now returns the constant; the (dead) add is untouched.
         assert "ret i32 0" in str(mod)
@@ -168,10 +168,10 @@ def test_global_variable_is_constant():
 def test_builder_binary_ops_and_insert_point():
     with llvm.Context() as ctx:
         mod = llvm.Module("m", ctx)
-        i32 = llvm.i32(ctx)
-        f32 = llvm.f32(ctx)
+        i32 = llvm.types.i32(ctx)
+        f32 = llvm.types.f32(ctx)
         fn = llvm.Function.create(
-            llvm.function_t(i32, [i32, i32, f32, f32]), "f", mod
+            llvm.types.function(i32, [i32, i32, f32, f32]), "f", mod
         )
         bb = fn.append_basic_block("entry")
         b = llvm.IRBuilder(ctx)

--- a/projects/eudsl-llvmpy/tests/test_downcast_kinds.py
+++ b/projects/eudsl-llvmpy/tests/test_downcast_kinds.py
@@ -1,0 +1,226 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Every bound Value subclass is reached and downcast to the right Python class.
+
+The `type_hook` (Kinds.cpp `valueTypeInfo`) maps an llvm::Value* to its concrete
+bound class. Most instruction/constant classes are registered with a bare
+`nb::class_<...>` and no methods, so they add no coverage region -- neither line
+nor function coverage forces a test to ever obtain one. A wrong entry in the
+dispatch (or a missing registration) would go unnoticed. These tests construct
+IR of each kind and assert the downcast produces the expected concrete class.
+"""
+from textwrap import dedent
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+
+def _instruction_kinds(mod):
+    kinds = set()
+    for f in mod.functions:
+        for bb in f.basic_blocks:
+            for inst in bb.instructions:
+                kinds.add(type(inst).__name__)
+    return kinds
+
+
+# Each source contributes one or more instruction kinds not covered by the
+# opcode sweep in test_cpp_coverage.py.
+_SOURCES = {
+    "casts": """\
+        define void @f(i8 %a, float %b, double %c, ptr %p) {
+          %1 = sext i8 %a to i32
+          %2 = fptoui float %b to i32
+          %3 = uitofp i32 %2 to float
+          %4 = fptrunc double %c to float
+          %5 = fpext float %b to double
+          %6 = addrspacecast ptr %p to ptr addrspace(1)
+          %7 = ptrtoaddr ptr %p to i64
+          %8 = fneg float %b
+          %9 = freeze i32 %2
+          ret void
+        }
+    """,
+    "vector_aggregate": """\
+        define void @f(<4 x i32> %v, <4 x i32> %w, i32 %x, {i32, i32} %s) {
+          %1 = extractelement <4 x i32> %v, i32 0
+          %2 = insertelement <4 x i32> %v, i32 %x, i32 1
+          %3 = shufflevector <4 x i32> %v, <4 x i32> %w, <4 x i32> <i32 0, i32 1, i32 4, i32 5>
+          %4 = extractvalue {i32, i32} %s, 0
+          %5 = insertvalue {i32, i32} %s, i32 %x, 1
+          ret void
+        }
+    """,
+    "terminators": """\
+        define void @f(i32 %x, ptr %p) {
+        entry:
+          switch i32 %x, label %d [i32 0, label %a]
+        a:
+          %v = va_arg ptr %p, i32
+          indirectbr ptr %p, [label %d]
+        d:
+          unreachable
+        }
+    """,
+    "callbr": """\
+        define void @f() {
+        entry:
+          callbr void asm "", ""() to label %n []
+        n:
+          ret void
+        }
+    """,
+    "atomics": """\
+        define void @f(ptr %p) {
+          %1 = atomicrmw add ptr %p, i32 1 seq_cst
+          %2 = cmpxchg ptr %p, i32 0, i32 1 seq_cst seq_cst
+          fence seq_cst
+          ret void
+        }
+    """,
+    "itanium_eh": """\
+        declare void @g()
+        declare i32 @__gxx_personality_v0(...)
+        define void @f() personality ptr @__gxx_personality_v0 {
+        entry:
+          invoke void @g() to label %ok unwind label %lp
+        ok:
+          ret void
+        lp:
+          %e = landingpad {ptr, i32} cleanup
+          resume {ptr, i32} %e
+        }
+    """,
+    "windows_catch": """\
+        declare void @g()
+        declare i32 @__CxxFrameHandler3(...)
+        define void @f() personality ptr @__CxxFrameHandler3 {
+        entry:
+          invoke void @g() to label %ok unwind label %cs
+        ok:
+          ret void
+        cs:
+          %c = catchswitch within none [label %h] unwind to caller
+        h:
+          %p = catchpad within %c [ptr null, i32 64, ptr null]
+          catchret from %p to label %ok
+        }
+    """,
+    "windows_cleanup": """\
+        declare void @g()
+        declare i32 @__CxxFrameHandler3(...)
+        define void @f() personality ptr @__CxxFrameHandler3 {
+        entry:
+          invoke void @g() to label %ok unwind label %cp
+        ok:
+          ret void
+        cp:
+          %p = cleanuppad within none []
+          cleanupret from %p unwind to caller
+        }
+    """,
+}
+
+_EXPECTED_INSTRUCTIONS = {
+    "SExtInst", "FPToUIInst", "UIToFPInst", "FPTruncInst", "FPExtInst",
+    "AddrSpaceCastInst", "PtrToAddrInst", "FPUnaryOperator", "FreezeInst",
+    "ExtractElementInst", "InsertElementInst", "ShuffleVectorInst",
+    "ExtractValueInst", "InsertValueInst",
+    "SwitchInst", "IndirectBrInst", "UnreachableInst", "VAArgInst",
+    "CallBrInst",
+    "AtomicRMWInst", "AtomicCmpXchgInst", "FenceInst",
+    "InvokeInst", "LandingPadInst", "ResumeInst",
+    "CatchSwitchInst", "CatchPadInst", "CatchReturnInst",
+    "CleanupPadInst", "CleanupReturnInst",
+}
+
+
+def test_instruction_kinds_downcast():
+    seen = set()
+    with llvm.Context() as ctx:
+        for name, src in _SOURCES.items():
+            mod = llvm.parse_assembly(dedent(src), ctx, name)
+            seen |= _instruction_kinds(mod)
+            del mod
+    missing = _EXPECTED_INSTRUCTIONS - seen
+    assert not missing, f"instruction kinds not downcast: {sorted(missing)}"
+    assert_no_leaks()
+
+
+_CONSTANTS_SRC = """\
+    @g = global i32 0
+    @parr = global [2 x ptr] [ptr @g, ptr null]
+    @st   = global {i32, i32} {i32 1, i32 2}
+    @darr = global [4 x i8] c"abcd"
+    @zi   = global [4 x i32] zeroinitializer
+    @pvec = global <2 x ptr> <ptr @g, ptr null>
+    @dvec = global <4 x i32> <i32 1, i32 2, i32 3, i32 4>
+    @ce   = global i64 ptrtoint (ptr @g to i64)
+    @ba   = global ptr blockaddress(@f, %b)
+    @al   = alias i32, ptr @g
+    @res  = global ptr null
+    @if   = ifunc i32 (), ptr @res
+
+    declare void @noop()
+    declare i32 @__CxxFrameHandler3(...)
+    define i32 @f() personality ptr @__CxxFrameHandler3 {
+    entry:
+      br label %b
+    b:
+      %parr = load ptr, ptr @parr
+      %st   = load i32, ptr @st
+      %darr = load i8,  ptr @darr
+      %zi   = load i32, ptr @zi
+      %pvec = load <2 x ptr>, ptr @pvec
+      %dvec = load <4 x i32>, ptr @dvec
+      %ce   = load i64, ptr @ce
+      %ba   = load ptr, ptr @ba
+      %al   = load i32, ptr @al
+      %if   = load ptr, ptr @if
+      invoke void @noop() to label %ok unwind label %cp
+    ok:
+      ret i32 0
+    cp:
+      %pad = cleanuppad within none []
+      cleanupret from %pad unwind to caller
+    }
+"""
+
+
+def test_constant_and_global_kinds_downcast():
+    with llvm.Context() as ctx:
+        mod = llvm.parse_assembly(dedent(_CONSTANTS_SRC), ctx, "m")
+        f = mod.get_function("f")
+        # Map each load's pointed-at global name -> (global class, init class).
+        by_name = {}
+        for bb in f.basic_blocks:
+            for inst in bb.instructions:
+                if type(inst).__name__ == "LoadInst":
+                    g = inst.pointer_operand
+                    init = getattr(g, "initializer", None)
+                    by_name[g.name] = (
+                        type(g).__name__,
+                        type(init).__name__ if init is not None else None,
+                    )
+        # Global kinds obtained directly.
+        assert by_name["al"][0] == "GlobalAlias"
+        assert by_name["if"][0] == "GlobalIFunc"
+        # Constant kinds obtained as initializers.
+        inits = {v[1] for v in by_name.values()}
+        expected = {
+            "ConstantArray", "ConstantStruct", "ConstantDataArray",
+            "ConstantAggregateZero", "ConstantVector", "ConstantDataVector",
+            "ConstantExpr", "BlockAddress",
+        }
+        assert expected <= inits, f"missing: {sorted(expected - inits)}"
+        # ConstantTokenNone is the `within none` operand of the cleanup pad.
+        pad = next(
+            i
+            for bb in f.basic_blocks
+            for i in bb.instructions
+            if type(i).__name__ == "CleanupPadInst"
+        )
+        assert type(pad.operand(0)).__name__ == "ConstantTokenNone"
+        del f, mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_downcast_kinds.py
+++ b/projects/eudsl-llvmpy/tests/test_downcast_kinds.py
@@ -122,28 +122,49 @@ _SOURCES = {
     """,
 }
 
-_EXPECTED_INSTRUCTIONS = {
-    "SExtInst", "FPToUIInst", "UIToFPInst", "FPTruncInst", "FPExtInst",
-    "AddrSpaceCastInst", "PtrToAddrInst", "FPUnaryOperator", "FreezeInst",
-    "ExtractElementInst", "InsertElementInst", "ShuffleVectorInst",
-    "ExtractValueInst", "InsertValueInst",
-    "SwitchInst", "IndirectBrInst", "UnreachableInst", "VAArgInst",
-    "CallBrInst",
-    "AtomicRMWInst", "AtomicCmpXchgInst", "FenceInst",
-    "InvokeInst", "LandingPadInst", "ResumeInst",
-    "CatchSwitchInst", "CatchPadInst", "CatchReturnInst",
-    "CleanupPadInst", "CleanupReturnInst",
-}
+def _leaf_instruction_classes():
+    """Derive the set of leaf Instruction subclasses from the bindings."""
+    instr = llvm.Instruction
+    all_sub = set()
+    for name in dir(llvm):
+        obj = getattr(llvm, name)
+        if isinstance(obj, type) and issubclass(obj, instr) and obj is not instr:
+            all_sub.add(obj)
+    leaves = set()
+    for cls in all_sub:
+        is_parent = any(
+            issubclass(other, cls) and other is not cls for other in all_sub
+        )
+        if not is_parent:
+            leaves.add(cls.__name__)
+    # BinaryOperator is not a leaf (FPBinaryOperator subclasses it) but the
+    # type_hook returns it for integer binops, so include it.
+    if hasattr(llvm, "BinaryOperator"):
+        leaves.add("BinaryOperator")
+    return leaves
 
 
 def test_instruction_kinds_downcast():
+    expected = _leaf_instruction_classes()
     seen = set()
     with llvm.Context() as ctx:
         for name, src in _SOURCES.items():
             mod = llvm.parse_assembly(dedent(src), ctx, name)
             seen |= _instruction_kinds(mod)
             del mod
-    missing = _EXPECTED_INSTRUCTIONS - seen
+    # This test covers the "hard" kinds (EH, atomics, vector, etc.) that the
+    # per-instruction test in test_cpp_coverage.py doesn't exercise. Together
+    # the two files must cover every leaf. Anything missing here means a new
+    # source snippet is needed.
+    covered_by_opcode_sweep = {
+        "BinaryOperator", "FPBinaryOperator",
+        "TruncInst", "ZExtInst", "SIToFPInst", "FPToSIInst",
+        "BitCastInst", "PtrToIntInst", "IntToPtrInst",
+        "ICmpInst", "FCmpInst", "SelectInst",
+        "AllocaInst", "StoreInst", "LoadInst", "GetElementPtrInst",
+        "CallInst", "UncondBrInst", "CondBrInst", "PHINode", "ReturnInst",
+    }
+    missing = expected - seen - covered_by_opcode_sweep
     assert not missing, f"instruction kinds not downcast: {sorted(missing)}"
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_metadata.py
+++ b/projects/eudsl-llvmpy/tests/test_metadata.py
@@ -16,20 +16,6 @@ def test_named_metadata_round_trips():
         assert '!0 = !{!"hello"}' in printed
         got = mod.named_metadata("my.meta")
         assert len(got) == 1
-        # The accessor returns the node we added, not just some node.
-        assert got[0].num_operands == 1
-        assert got[0].operand(0).string == "hello"
-        del mod
-    assert_no_leaks()
-
-
-def test_metadata_accessors():
-    with llvm.Context() as ctx:
-        mod = llvm.Module("m", ctx)
-        s = llvm.md_string(ctx, "hello")
-        node = llvm.md_node(ctx, [s])
-        mod.add_named_metadata("my.meta", node)
-        got = mod.named_metadata("my.meta")
         retrieved = got[0]
         assert isinstance(retrieved, llvm.MDNode)
         assert retrieved.num_operands == 1
@@ -37,4 +23,13 @@ def test_metadata_accessors():
         assert isinstance(op, llvm.MDString)
         assert op.string == "hello"
         del mod
+    assert_no_leaks()
+
+
+def test_metadata_str():
+    with llvm.Context() as ctx:
+        s = llvm.md_string(ctx, "hi")
+        node = llvm.md_node(ctx, [s])
+        assert "hi" in str(s)
+        assert "hi" in str(node)
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_metadata.py
+++ b/projects/eudsl-llvmpy/tests/test_metadata.py
@@ -16,6 +16,9 @@ def test_named_metadata_round_trips():
         assert '!0 = !{!"hello"}' in printed
         got = mod.named_metadata("my.meta")
         assert len(got) == 1
+        # The accessor returns the node we added, not just some node.
+        assert got[0].num_operands == 1
+        assert got[0].operand(0).string == "hello"
         del mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/test_target.py
+++ b/projects/eudsl-llvmpy/tests/test_target.py
@@ -20,6 +20,17 @@ _SRC = dedent(
     """
 )
 
+# Same symbol name @add, different body, so any difference in emitted assembly
+# comes from codegen of the body rather than the symbol/label text.
+_SRC_CONST = dedent(
+    """\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      ret i32 12345
+    }
+    """
+)
+
 
 def test_host_triple_is_nonempty():
     assert isinstance(llvm.host_triple(), str)
@@ -60,6 +71,7 @@ def test_emit_assembly_and_object():
         mod = llvm.parse_assembly(_SRC, ctx, "m")
         tm = llvm.TargetMachine()
         mod.set_data_layout_from(tm)
+<<<<<<< HEAD
         asm_out = tm.emit_assembly(mod)
         assert "%s = add" not in asm_out
         assert "ret" in asm_out.lower() or "bx" in asm_out.lower() or "blr" in asm_out.lower()
@@ -71,4 +83,20 @@ def test_emit_assembly_and_object():
         elif sys.platform == "linux":
             assert obj[:4] == b"\x7fELF"
         del tm, mod
+=======
+        asm = tm.emit_assembly(mod)
+        # "add" alone is vacuous: the symbol @add puts it in the output no matter
+        # what the body compiles to. Prove emit reflects the body by emitting a
+        # same-named function with a different body and asserting they differ,
+        # and that the constant-returning body shows its immediate.
+        const_mod = llvm.parse_assembly(_SRC_CONST, ctx, "m2")
+        const_mod.set_data_layout_from(tm)
+        const_asm = tm.emit_assembly(const_mod)
+        assert asm != const_asm
+        assert "12345" in const_asm and "12345" not in asm
+        obj = tm.emit_object(mod)
+        assert isinstance(obj, bytes)
+        assert len(obj) > 0
+        del tm, mod, const_mod
+>>>>>>> 1b08a8e5 ([eudsl-llvmpy] Address test-honesty review findings)
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_target.py
+++ b/projects/eudsl-llvmpy/tests/test_target.py
@@ -71,24 +71,7 @@ def test_emit_assembly_and_object():
         mod = llvm.parse_assembly(_SRC, ctx, "m")
         tm = llvm.TargetMachine()
         mod.set_data_layout_from(tm)
-<<<<<<< HEAD
-        asm_out = tm.emit_assembly(mod)
-        assert "%s = add" not in asm_out
-        assert "ret" in asm_out.lower() or "bx" in asm_out.lower() or "blr" in asm_out.lower()
-        obj = tm.emit_object(mod)
-        assert isinstance(obj, bytes)
-        assert len(obj) > 4
-        if sys.platform == "darwin":
-            assert obj[:4] == b"\xcf\xfa\xed\xfe" or obj[:4] == b"\xfe\xed\xfa\xcf"
-        elif sys.platform == "linux":
-            assert obj[:4] == b"\x7fELF"
-        del tm, mod
-=======
         asm = tm.emit_assembly(mod)
-        # "add" alone is vacuous: the symbol @add puts it in the output no matter
-        # what the body compiles to. Prove emit reflects the body by emitting a
-        # same-named function with a different body and asserting they differ,
-        # and that the constant-returning body shows its immediate.
         const_mod = llvm.parse_assembly(_SRC_CONST, ctx, "m2")
         const_mod.set_data_layout_from(tm)
         const_asm = tm.emit_assembly(const_mod)
@@ -96,7 +79,10 @@ def test_emit_assembly_and_object():
         assert "12345" in const_asm and "12345" not in asm
         obj = tm.emit_object(mod)
         assert isinstance(obj, bytes)
-        assert len(obj) > 0
+        assert len(obj) > 4
+        if sys.platform == "darwin":
+            assert obj[:4] == b"\xcf\xfa\xed\xfe" or obj[:4] == b"\xfe\xed\xfa\xcf"
+        elif sys.platform == "linux":
+            assert obj[:4] == b"\x7fELF"
         del tm, mod, const_mod
->>>>>>> 1b08a8e5 ([eudsl-llvmpy] Address test-honesty review findings)
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/test_types.py
+++ b/projects/eudsl-llvmpy/tests/test_types.py
@@ -8,6 +8,7 @@ from llvm.testing import assert_no_leaks
 def test_primitive_types_print():
     with llvm.Context() as ctx:
         assert str(llvm.types.void(ctx)) == "void"
+        assert str(llvm.types.label(ctx)) == "label"
         assert str(llvm.types.i1(ctx)) == "i1"
         assert str(llvm.types.i8(ctx)) == "i8"
         assert str(llvm.types.i16(ctx)) == "i16"


### PR DESCRIPTION
Hardens the test suite behind the coverage gate.

- Addresses test-honesty review findings where an assertion passed without exercising the bound behavior.
- Behaviorally tests the method-pointer-delegating bindings such as `replace_all_uses_with`, which have no llvmpy-side implementation and so are not otherwise forced by coverage.
- Extends `check_coverage.py` to enforce function coverage alongside line coverage, closing gaps where a single-line lambda shares a source line with its `.def` registration.
- Tests downcasting to every bound Value subclass.
