### PR TITLE
[eudsl-llvmpy] Support types as nb::is_generic aliases for context-free annotations

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -84,9 +84,14 @@ void populate_types(nb::module_ &m) {
 
   // Parametric type classes carry nb::is_generic() so `IntegerType[32]`,
   // `PointerType[0]`, `FunctionType[ret, [args]]`, etc. produce an unevaluated
-  // types.GenericAlias -- a type annotation that needs no live context. The
-  // matching `.get(...)` classmethod (which the alias forwards to at emit time)
-  // resolves the context via currentOr, so context stays optional here too.
+  // types.GenericAlias -- a type annotation that needs no live context. Each
+  // class also gets a `.get(...)` classmethod that the alias forwards to at
+  // emit time. IntegerType/PointerType/StructType.get resolve the context via
+  // currentOr, so it stays optional there. The element-deriving gets
+  // (ArrayType/VectorType/FunctionType and the concrete vector subtypes) take
+  // their context from the element or return type instead; they still accept
+  // `context` for uniform dispatch and reject it only when it names a different
+  // context.
   nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::IntegerType, llvm::Type)
       .def_static(
@@ -143,9 +148,13 @@ void populate_types(nb::module_ &m) {
       .def_static(
           "get",
           [](llvm::Type *elt, uint64_t n, nb::handle context) -> llvm::ArrayType * {
-            // The element type already pins the context; `context` is accepted
-            // only so the deferred-annotation evaluator can pass it uniformly.
-            (void)context;
+            // The element type already pins the context; a passed `context` is
+            // accepted for uniform dispatch but must not name a different one.
+            if (!context.is_none() &&
+                &elt->getContext() != &eudsl::currentOr(context).get()) {
+              throw nb::value_error(
+                  "element type belongs to a different context");
+            }
             return llvm::ArrayType::get(elt, n);
           },
           "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
@@ -160,7 +169,11 @@ void populate_types(nb::module_ &m) {
           "get",
           [](llvm::Type *elt, unsigned n, bool scalable,
              nb::handle context) -> llvm::VectorType * {
-            (void)context;
+            if (!context.is_none() &&
+                &elt->getContext() != &eudsl::currentOr(context).get()) {
+              throw nb::value_error(
+                  "element type belongs to a different context");
+            }
             return llvm::VectorType::get(elt, n, scalable);
           },
           "element_type"_a, "num_elements"_a, "scalable"_a = false,
@@ -177,12 +190,42 @@ void populate_types(nb::module_ &m) {
       .def_prop_ro("element_type", &llvm::VectorType::getElementType,
                    nb::rv_policy::reference);
 
+  // FixedVectorType/ScalableVectorType inherit VectorType's __class_getitem__,
+  // so they are subscriptable regardless; give each its own `.get` (returning
+  // the concrete subtype) so `FixedVectorType[i32, 4]` resolves correctly
+  // instead of hitting a missing classmethod.
   nb::class_<llvm::FixedVectorType, llvm::VectorType>(m, "FixedVectorType",
                                                       nb::is_generic())
+      .def_static(
+          "get",
+          [](llvm::Type *elt, unsigned n,
+             nb::handle context) -> llvm::FixedVectorType * {
+            if (!context.is_none() &&
+                &elt->getContext() != &eudsl::currentOr(context).get()) {
+              throw nb::value_error(
+                  "element type belongs to a different context");
+            }
+            return llvm::FixedVectorType::get(elt, n);
+          },
+          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("num_elements", &llvm::FixedVectorType::getNumElements);
 
   nb::class_<llvm::ScalableVectorType, llvm::VectorType>(m, "ScalableVectorType",
                                                          nb::is_generic())
+      .def_static(
+          "get",
+          [](llvm::Type *elt, unsigned n,
+             nb::handle context) -> llvm::ScalableVectorType * {
+            if (!context.is_none() &&
+                &elt->getContext() != &eudsl::currentOr(context).get()) {
+              throw nb::value_error(
+                  "element type belongs to a different context");
+            }
+            return llvm::ScalableVectorType::get(elt, n);
+          },
+          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("min_num_elements",
                    &llvm::ScalableVectorType::getMinNumElements);
 
@@ -192,7 +235,19 @@ void populate_types(nb::module_ &m) {
           "get",
           [](llvm::Type *ret, std::vector<llvm::Type *> params, bool varArg,
              nb::handle context) -> llvm::FunctionType * {
-            (void)context;
+            if (!context.is_none()) {
+              llvm::LLVMContext *c = &eudsl::currentOr(context).get();
+              if (&ret->getContext() != c) {
+                throw nb::value_error(
+                    "return type belongs to a different context");
+              }
+              for (llvm::Type *p : params) {
+                if (&p->getContext() != c) {
+                  throw nb::value_error(
+                      "parameter type belongs to a different context");
+                }
+              }
+            }
             return llvm::FunctionType::get(ret, params, varArg);
           },
           "return_type"_a, "params"_a, "var_arg"_a = false,

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -82,16 +82,45 @@ void populate_types(nb::module_ &m) {
   EUDSL_PRIMITIVE_TYPE("f64", getDoubleTy);
 #undef EUDSL_PRIMITIVE_TYPE
 
-  nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType")
+  // Parametric type classes carry nb::is_generic() so `IntegerType[32]`,
+  // `PointerType[0]`, `FunctionType[ret, [args]]`, etc. produce an unevaluated
+  // types.GenericAlias -- a type annotation that needs no live context. The
+  // matching `.get(...)` classmethod (which the alias forwards to at emit time)
+  // resolves the context via currentOr, so context stays optional here too.
+  nb::class_<llvm::IntegerType, llvm::Type>(m, "IntegerType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::IntegerType, llvm::Type)
+      .def_static(
+          "get",
+          [](unsigned bits, nb::handle context) -> llvm::IntegerType * {
+            return llvm::IntegerType::get(eudsl::currentOr(context).get(), bits);
+          },
+          "bits"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+          nb::keep_alive<0, 2>())
       .def_prop_ro("bit_width", &llvm::IntegerType::getBitWidth);
 
-  nb::class_<llvm::PointerType, llvm::Type>(m, "PointerType")
+  nb::class_<llvm::PointerType, llvm::Type>(m, "PointerType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::PointerType, llvm::Type)
+      .def_static(
+          "get",
+          [](unsigned addressSpace, nb::handle context) -> llvm::PointerType * {
+            return llvm::PointerType::get(eudsl::currentOr(context).get(),
+                                          addressSpace);
+          },
+          "address_space"_a = 0, "context"_a = nb::none(),
+          nb::rv_policy::reference, nb::keep_alive<0, 2>())
       .def_prop_ro("address_space", &llvm::PointerType::getAddressSpace);
 
-  nb::class_<llvm::StructType, llvm::Type>(m, "StructType")
+  nb::class_<llvm::StructType, llvm::Type>(m, "StructType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::StructType, llvm::Type)
+      .def_static(
+          "get",
+          [](std::vector<llvm::Type *> elts, bool packed,
+             nb::handle context) -> llvm::StructType * {
+            return llvm::StructType::get(eudsl::currentOr(context).get(), elts,
+                                         packed);
+          },
+          "element_types"_a, "packed"_a = false, "context"_a = nb::none(),
+          nb::rv_policy::reference, nb::keep_alive<0, 3>())
       .def_prop_ro("name",
                    [](llvm::StructType &self) -> std::optional<std::string> {
                      if (!self.hasName())
@@ -109,14 +138,34 @@ void populate_types(nb::module_ &m) {
              bool packed) { self.setBody(elts, packed); },
           "element_types"_a, "packed"_a = false);
 
-  nb::class_<llvm::ArrayType, llvm::Type>(m, "ArrayType")
+  nb::class_<llvm::ArrayType, llvm::Type>(m, "ArrayType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::ArrayType, llvm::Type)
+      .def_static(
+          "get",
+          [](llvm::Type *elt, uint64_t n, nb::handle context) -> llvm::ArrayType * {
+            // The element type already pins the context; `context` is accepted
+            // only so the deferred-annotation evaluator can pass it uniformly.
+            (void)context;
+            return llvm::ArrayType::get(elt, n);
+          },
+          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("num_elements", &llvm::ArrayType::getNumElements)
       .def_prop_ro("element_type", &llvm::ArrayType::getElementType,
                    nb::rv_policy::reference);
 
-  nb::class_<llvm::VectorType, llvm::Type>(m, "VectorType")
+  nb::class_<llvm::VectorType, llvm::Type>(m, "VectorType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::VectorType, llvm::Type)
+      .def_static(
+          "get",
+          [](llvm::Type *elt, unsigned n, bool scalable,
+             nb::handle context) -> llvm::VectorType * {
+            (void)context;
+            return llvm::VectorType::get(elt, n, scalable);
+          },
+          "element_type"_a, "num_elements"_a, "scalable"_a = false,
+          "context"_a = nb::none(), nb::rv_policy::reference,
+          nb::keep_alive<0, 1>())
       .def_prop_ro("min_num_elements",
                    [](llvm::VectorType &self) {
                      return self.getElementCount().getKnownMinValue();
@@ -128,15 +177,27 @@ void populate_types(nb::module_ &m) {
       .def_prop_ro("element_type", &llvm::VectorType::getElementType,
                    nb::rv_policy::reference);
 
-  nb::class_<llvm::FixedVectorType, llvm::VectorType>(m, "FixedVectorType")
+  nb::class_<llvm::FixedVectorType, llvm::VectorType>(m, "FixedVectorType",
+                                                      nb::is_generic())
       .def_prop_ro("num_elements", &llvm::FixedVectorType::getNumElements);
 
-  nb::class_<llvm::ScalableVectorType, llvm::VectorType>(m, "ScalableVectorType")
+  nb::class_<llvm::ScalableVectorType, llvm::VectorType>(m, "ScalableVectorType",
+                                                         nb::is_generic())
       .def_prop_ro("min_num_elements",
                    &llvm::ScalableVectorType::getMinNumElements);
 
-  nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType")
+  nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType", nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::FunctionType, llvm::Type)
+      .def_static(
+          "get",
+          [](llvm::Type *ret, std::vector<llvm::Type *> params, bool varArg,
+             nb::handle context) -> llvm::FunctionType * {
+            (void)context;
+            return llvm::FunctionType::get(ret, params, varArg);
+          },
+          "return_type"_a, "params"_a, "var_arg"_a = false,
+          "context"_a = nb::none(), nb::rv_policy::reference,
+          nb::keep_alive<0, 1>())
       .def_prop_ro("return_type", &llvm::FunctionType::getReturnType,
                    nb::rv_policy::reference)
       .def_prop_ro("num_params", &llvm::FunctionType::getNumParams)

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -31,6 +31,10 @@ def _evaluate_alias_arg(arg, ctx):
         return type(arg)(_evaluate_alias_arg(a, ctx) for a in arg)
     if isinstance(arg, type) and issubclass(arg, Type):
         return arg.get(context=ctx)
+    if callable(arg):
+        # A bare factory (e.g. `llvm.types.i32`) used as a nested subscript arg,
+        # mirroring _resolve's callable branch for top-level annotations.
+        return arg(context=ctx)
     return arg
 
 
@@ -64,6 +68,10 @@ def _resolve(annotation, ctx):
     The GenericAlias and bare-class cases must precede the callable case: both
     are themselves callable and would otherwise hit the wrong branch.
     """
+    if annotation is inspect.Parameter.empty:
+        raise TypeError(
+            "missing type annotation; annotate every parameter and the return type"
+        )
     if isinstance(annotation, Type):
         return annotation
     if type(annotation) is types.GenericAlias:

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -5,23 +5,71 @@
 
 import ast
 import inspect
+import types
+from typing import get_args
 
 from ..eudslllvm_ext.ir import Function, IRBuilder
-from ..eudslllvm_ext.types import Type
+from ..eudslllvm_ext.types import StructType, Type
 from ..eudslllvm_ext.types import function as function_t
 from ..ast.util import get_module_cst
 from .casters import maybe_downcast
 from .context import building, current_builder
 
 
+def _evaluate_alias_arg(arg, ctx):
+    """Recursively turn one subscript argument into a value `.get(...)` accepts.
+
+    A nested alias (`ArrayType[IntegerType[32], 4]`) or bare type class becomes a
+    real Type; a list/tuple is mapped element-wise (e.g. the params list in
+    `FunctionType[ret, [a, b]]`); scalars (ints, bools) pass through unchanged.
+    """
+    if isinstance(arg, Type):
+        return arg
+    if type(arg) is types.GenericAlias:
+        return _evaluate_alias(arg, ctx)
+    if isinstance(arg, (list, tuple)):
+        return type(arg)(_evaluate_alias_arg(a, ctx) for a in arg)
+    if isinstance(arg, type) and issubclass(arg, Type):
+        return arg.get(context=ctx)
+    return arg
+
+
+def _evaluate_alias(alias, ctx):
+    """Evaluate a types.GenericAlias (e.g. `IntegerType[32]`) into an llvm.Type
+    by forwarding its evaluated subscript args to the origin's `.get(...)`.
+
+    `StructType` is variadic in its subscript (`StructType[i32, f64]`), so its
+    element args are collected into the single list `StructType.get` expects;
+    every other origin forwards its args positionally (e.g.
+    `FunctionType[ret, [a, b]]` -> `FunctionType.get(ret, [a, b])`).
+    """
+    origin = alias.__origin__
+    args = [_evaluate_alias_arg(a, ctx) for a in get_args(alias)]
+    if origin is StructType:
+        return origin.get(list(args), context=ctx)
+    return origin.get(*args, context=ctx)
+
+
 def _resolve(annotation, ctx):
     """Resolve a parameter/return annotation to an llvm.Type.
 
-    Accepts a Type instance directly, or a callable `ctx -> Type` (e.g. the
-    `llvm.types.i32` factory used bare as an annotation).
+    Accepts, in order:
+      - a Type instance directly;
+      - a deferred `types.GenericAlias` (`IntegerType[32]`, `PointerType[0]`,
+        `FunctionType[ret, [args]]`, ...) evaluated against `ctx` -- these need
+        no live context to be written as annotations;
+      - a bare parametric type class (`PointerType`) -> `.get(context=ctx)`;
+      - a callable `ctx -> Type` (e.g. the `llvm.types.i32` factory used bare).
+
+    The GenericAlias and bare-class cases must precede the callable case: both
+    are themselves callable and would otherwise hit the wrong branch.
     """
     if isinstance(annotation, Type):
         return annotation
+    if type(annotation) is types.GenericAlias:
+        return _evaluate_alias(annotation, ctx)
+    if isinstance(annotation, type) and issubclass(annotation, Type):
+        return annotation.get(context=ctx)
     if callable(annotation):
         return annotation(context=ctx)
     raise TypeError(f"cannot resolve type annotation {annotation!r}")

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
@@ -6,8 +6,9 @@ import ctypes
 import pytest
 
 import llvm
+from llvm.dsl.func import _resolve
 from llvm.dsl.values import with_element_type
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 from llvm.types import (
     ArrayType,
     FunctionType,
@@ -298,7 +299,9 @@ def test_generic_integer_annotation():
         def f(x: IntegerType[32]) -> IntegerType[32]:
             return x
 
-        assert "define i32 @f(i32" in str(mod)
+        # CHECK: define i32 @f(i32 %[[X:.*]])
+        # CHECK: ret i32 %[[X]]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -311,7 +314,9 @@ def test_generic_pointer_annotation():
         def f(p: PTR) -> PTR:
             return p
 
-        assert "define ptr @f(ptr" in str(mod)
+        # CHECK: define ptr @f(ptr %[[P:.*]])
+        # CHECK: ret ptr %[[P]]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -377,10 +382,10 @@ def test_generic_struct_annotation():
     assert_no_leaks()
 
 
-def test_generic_nested_function_type_via_pointer():
-    # FunctionType[...] itself isn't a valid by-value parameter type, but it is
-    # a first-class deferred type; verify it evaluates and round-trips through a
-    # declared function's own signature.
+def test_generic_multiple_deferred_annotations_in_one_signature():
+    # Two deferred alias params (PTR, I64) plus a deferred return (I32) in a
+    # single signature all evaluate against module.context at emit time. (Real
+    # FunctionType deferral is covered by test_generic_function_type_resolves.)
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
 
@@ -464,11 +469,52 @@ def test_generic_function_type_resolves():
     # FunctionType isn't a valid by-value parameter type, so it can't be a
     # @function annotation; resolve it directly to cover the deferred
     # evaluation of a nested params list (FunctionType[ret, [a, b]]).
-    from llvm.dsl.func import _resolve
-
     with llvm.ir.Context() as ctx:
         t = _resolve(
             FunctionType[IntegerType[32], [PointerType[0], IntegerType[64]]], ctx
         )
         assert str(t) == "i32 (ptr, i64)"
+    assert_no_leaks()
+
+
+def test_generic_nested_bare_factory_arg():
+    # A bare primitive factory (llvm.types.i32) used as a *nested* subscript arg
+    # is evaluated via _evaluate_alias_arg's callable branch, mirroring the
+    # top-level bare-factory path.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(a: ArrayType[llvm.types.i32, 4]) -> I32: ...
+
+        assert "declare i32 @f([4 x i32])" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_bare_integer_annotation_missing_bits_raises():
+    # Bare `IntegerType` as an annotation forwards to IntegerType.get(context=)
+    # with no bits -> a clean TypeError, not a half-built type.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        with pytest.raises(TypeError):
+
+            @llvm.dsl.function(module=mod)
+            def f(x: IntegerType) -> I32: ...
+
+        del mod
+    assert_no_leaks()
+
+
+def test_missing_annotation_raises_clear_typeerror():
+    # An unannotated parameter hits _resolve's empty-sentinel guard and reports
+    # a clear message rather than a cryptic `_empty() takes no arguments`.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        with pytest.raises(TypeError, match="missing type annotation"):
+
+            @llvm.dsl.function(module=mod)
+            def f(x) -> I32: ...
+
+        del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
@@ -8,6 +8,26 @@ import pytest
 import llvm
 from llvm.dsl.values import with_element_type
 from llvm.testing import assert_no_leaks
+from llvm.types import (
+    ArrayType,
+    FunctionType,
+    IntegerType,
+    PointerType,
+    StructType,
+    VectorType,
+)
+
+# Deferred type annotations built at import time, with NO live Context. These
+# are types.GenericAlias objects; they are only evaluated (against the module's
+# context) when the @function decorator emits, so annotating needs no context.
+I32 = IntegerType[32]
+I64 = IntegerType[64]
+PTR = PointerType[0]
+PTR3 = PointerType[3]
+ARR = ArrayType[IntegerType[32], 4]
+VEC = VectorType[IntegerType[32], 4]
+STRUCT = StructType[IntegerType[32], IntegerType[64]]
+NESTED_STRUCT = StructType[StructType[IntegerType[32], IntegerType[64]], IntegerType[32]]
 
 
 def test_declaration_has_no_body():
@@ -262,4 +282,193 @@ def test_name_override():
         assert "define i32 @custom_name" in str(mod)
         assert f.name == "custom_name"
         del mod
+    assert_no_leaks()
+
+
+# --- Deferred generic-type annotations (nb::is_generic), one per new type. ---
+# Each annotation is a types.GenericAlias created at import (no live Context);
+# the decorator evaluates it against module.context when it emits.
+
+
+def test_generic_integer_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(x: IntegerType[32]) -> IntegerType[32]:
+            return x
+
+        assert "define i32 @f(i32" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_pointer_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(p: PTR) -> PTR:
+            return p
+
+        assert "define ptr @f(ptr" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_pointer_addrspace_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(p: PTR3) -> I32: ...
+
+        assert "declare i32 @f(ptr addrspace(3))" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_bare_pointer_annotation():
+    # A bare (non-subscripted) PointerType class annotation -> default addrspace.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(p: PointerType) -> I32: ...
+
+        assert "declare i32 @f(ptr)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_array_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(a: ARR) -> I32: ...
+
+        assert "declare i32 @f([4 x i32])" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_vector_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(v: VEC) -> I32: ...
+
+        assert "declare i32 @f(<4 x i32>)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_struct_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(s: STRUCT) -> I32: ...
+
+        assert "declare i32 @f({ i32, i64 })" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_nested_function_type_via_pointer():
+    # FunctionType[...] itself isn't a valid by-value parameter type, but it is
+    # a first-class deferred type; verify it evaluates and round-trips through a
+    # declared function's own signature.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def callee(p: PTR, n: I64) -> I32: ...
+
+        assert "declare i32 @callee(ptr, i64)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_nested_struct_annotation():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(s: NESTED_STRUCT) -> I32: ...
+
+        assert "declare i32 @f({ { i32, i64 }, i32 })" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_vector_with_concrete_element():
+    # A concrete Type instance (context-bound) may be used as a subscript arg;
+    # _resolve passes it through unchanged before calling .get().
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(v: VectorType[i32, 4]) -> I32: ...
+
+        assert "declare i32 @f(<4 x i32>)" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_struct_with_concrete_elements():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        i64 = llvm.types.i64(ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(s: StructType[i32, i64]) -> I32: ...
+
+        assert "declare i32 @f({ i32, i64 })" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_array_with_concrete_element():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(a: ArrayType[i32, 8]) -> I32: ...
+
+        assert "declare i32 @f([8 x i32])" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_array_of_bare_pointer_annotation():
+    # A bare (non-subscripted) type class used as a *nested* subscript arg is
+    # evaluated via its .get(): ArrayType[PointerType, 4] -> [4 x ptr].
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+
+        @llvm.dsl.function(module=mod)
+        def f(a: ArrayType[PointerType, 4]) -> I32: ...
+
+        assert "declare i32 @f([4 x ptr])" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_generic_function_type_resolves():
+    # FunctionType isn't a valid by-value parameter type, so it can't be a
+    # @function annotation; resolve it directly to cover the deferred
+    # evaluation of a nested params list (FunctionType[ret, [a, b]]).
+    from llvm.dsl.func import _resolve
+
+    with llvm.ir.Context() as ctx:
+        t = _resolve(
+            FunctionType[IntegerType[32], [PointerType[0], IntegerType[64]]], ctx
+        )
+        assert str(t) == "i32 (ptr, i64)"
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/types/test_types_generic.py
+++ b/projects/eudsl-llvmpy/tests/types/test_types_generic.py
@@ -1,0 +1,63 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Types as nb::is_generic GenericAliases: subscript with no live context, and
+.get(...) factories that evaluate against a context."""
+import types
+
+import llvm
+from llvm.testing import assert_no_leaks
+from llvm.types import (
+    ArrayType,
+    FunctionType,
+    IntegerType,
+    PointerType,
+    StructType,
+    VectorType,
+)
+
+# Subscripting a type class needs NO live context: it produces an unevaluated
+# GenericAlias. These are built at import time, before any Context exists.
+I32 = IntegerType[32]
+PTR = PointerType[0]
+FN = FunctionType[IntegerType[32], [PointerType[0], IntegerType[64]]]
+
+
+def test_subscript_yields_generic_alias_without_context():
+    assert type(I32) is types.GenericAlias
+    assert I32.__origin__ is IntegerType
+    assert type(FN) is types.GenericAlias
+    # Nested aliases stay unevaluated too.
+    assert type(FN.__origin__) is type(FunctionType)
+
+
+def test_get_evaluates_against_explicit_context():
+    with llvm.ir.Context() as ctx:
+        assert str(IntegerType.get(32, context=ctx)) == "i32"
+        assert str(PointerType.get(context=ctx)) == "ptr"
+        assert str(PointerType.get(3, context=ctx)) == "ptr addrspace(3)"
+        i32 = llvm.types.i32(ctx)
+        f64 = llvm.types.f64(ctx)
+        assert str(ArrayType.get(i32, 4, context=ctx)) == "[4 x i32]"
+        assert str(VectorType.get(i32, 4, context=ctx)) == "<4 x i32>"
+        assert str(StructType.get([i32, f64], context=ctx)) == "{ i32, double }"
+        assert (
+            str(FunctionType.get(i32, [PointerType.get(context=ctx)], context=ctx))
+            == "i32 (ptr)"
+        )
+    assert_no_leaks()
+
+
+def test_get_uses_current_context_when_omitted():
+    with llvm.ir.Context() as ctx:
+        # No explicit context= -> the current `with Context():` is used.
+        assert IntegerType.get(32) is llvm.types.i32(ctx)
+        assert str(PointerType.get()) == "ptr"
+    assert_no_leaks()
+
+
+def test_get_is_interned_identical_to_primitive_factory():
+    with llvm.ir.Context() as ctx:
+        assert IntegerType.get(32, context=ctx) is llvm.types.i32(ctx)
+        assert PointerType.get(context=ctx) is llvm.types.ptr(context=ctx)
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/types/test_types_generic.py
+++ b/projects/eudsl-llvmpy/tests/types/test_types_generic.py
@@ -4,14 +4,20 @@
 """Types as nb::is_generic GenericAliases: subscript with no live context, and
 .get(...) factories that evaluate against a context."""
 import types
+from typing import get_args
+
+import pytest
 
 import llvm
+from llvm.dsl.func import _resolve
 from llvm.testing import assert_no_leaks
 from llvm.types import (
     ArrayType,
+    FixedVectorType,
     FunctionType,
     IntegerType,
     PointerType,
+    ScalableVectorType,
     StructType,
     VectorType,
 )
@@ -27,8 +33,13 @@ def test_subscript_yields_generic_alias_without_context():
     assert type(I32) is types.GenericAlias
     assert I32.__origin__ is IntegerType
     assert type(FN) is types.GenericAlias
-    # Nested aliases stay unevaluated too.
-    assert type(FN.__origin__) is type(FunctionType)
+    # Nested aliases stay unevaluated: the return-type arg and each element of
+    # the params list are still GenericAliases, not eagerly built Types. (A
+    # tautology like `type(FN.__origin__) is type(FunctionType)` would pass even
+    # if nesting were evaluated eagerly, so inspect the args instead.)
+    ret_arg, params_arg = get_args(FN)
+    assert type(ret_arg) is types.GenericAlias
+    assert [type(p) for p in params_arg] == [types.GenericAlias, types.GenericAlias]
 
 
 def test_get_evaluates_against_explicit_context():
@@ -60,4 +71,128 @@ def test_get_is_interned_identical_to_primitive_factory():
     with llvm.ir.Context() as ctx:
         assert IntegerType.get(32, context=ctx) is llvm.types.i32(ctx)
         assert PointerType.get(context=ctx) is llvm.types.ptr(context=ctx)
+    assert_no_leaks()
+
+
+def test_get_covers_packed_struct_and_var_arg_function():
+    # The optional surfaced flags (StructType packed, FunctionType var_arg) are
+    # otherwise uncovered; pin their printed forms.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32(ctx)
+        assert str(StructType.get([i32], packed=True, context=ctx)) == "<{ i32 }>"
+        assert (
+            str(FunctionType.get(i32, [i32], var_arg=True, context=ctx))
+            == "i32 (i32, ...)"
+        )
+    assert_no_leaks()
+
+
+def test_element_deriving_get_rejects_foreign_context():
+    # ArrayType/VectorType/FunctionType (and the concrete vector subtypes) derive
+    # their context from the element or return type. Passing a *different* context
+    # is a mistake, not a silent no-op: it is rejected rather than quietly
+    # building in the element's context.
+    with llvm.ir.Context() as ctx_a, llvm.ir.Context() as ctx_b:
+        i32_a = llvm.types.i32(ctx_a)
+        i32_b = llvm.types.i32(ctx_b)
+        with pytest.raises(ValueError, match="different context"):
+            ArrayType.get(i32_a, 4, context=ctx_b)
+        with pytest.raises(ValueError, match="different context"):
+            VectorType.get(i32_a, 4, context=ctx_b)
+        with pytest.raises(ValueError, match="different context"):
+            FixedVectorType.get(i32_a, 4, context=ctx_b)
+        with pytest.raises(ValueError, match="different context"):
+            ScalableVectorType.get(i32_a, 4, context=ctx_b)
+        # FunctionType checks both the return type and every parameter.
+        with pytest.raises(ValueError, match="return type belongs"):
+            FunctionType.get(i32_a, [], context=ctx_b)
+        with pytest.raises(ValueError, match="parameter type belongs"):
+            # Return type matches ctx_b, but a parameter is from ctx_a.
+            FunctionType.get(i32_b, [i32_a], context=ctx_b)
+        # Same context is accepted.
+        assert str(ArrayType.get(i32_a, 4, context=ctx_a)) == "[4 x i32]"
+    assert_no_leaks()
+
+
+def test_bare_get_missing_required_args_raises():
+    # Bare `.get()` without its required arguments fails cleanly rather than
+    # producing a half-built type.
+    with llvm.ir.Context():
+        with pytest.raises(TypeError):
+            IntegerType.get()  # missing bits
+        with pytest.raises(TypeError):
+            ArrayType.get()  # missing element_type and count
+    assert_no_leaks()
+
+
+def test_concrete_vector_subtypes_get_returns_right_subtype():
+    # FixedVectorType/ScalableVectorType inherit VectorType's subscript, so each
+    # carries its own .get returning the concrete subtype (not a bare
+    # VectorType). (Foreign-context rejection is covered in
+    # test_element_deriving_get_rejects_foreign_context.)
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32(ctx)
+        fv = llvm.types.FixedVectorType.get(i32, 4, context=ctx)
+        assert type(fv) is llvm.types.FixedVectorType
+        assert str(fv) == "<4 x i32>"
+        sv = llvm.types.ScalableVectorType.get(i32, 4, context=ctx)
+        assert type(sv) is llvm.types.ScalableVectorType
+        assert str(sv) == "<vscale x 4 x i32>"
+    assert_no_leaks()
+
+
+# --- Square-bracket parallels of the .get creation tests above: the same
+# constructions written as Type[...] aliases and evaluated (via the same
+# _resolve the @function decorator uses) against a context. ---
+
+
+def test_subscript_evaluates_against_explicit_context():
+    with llvm.ir.Context() as ctx:
+        assert str(_resolve(IntegerType[32], ctx)) == "i32"
+        assert str(_resolve(PointerType[0], ctx)) == "ptr"
+        assert str(_resolve(PointerType[3], ctx)) == "ptr addrspace(3)"
+        assert str(_resolve(ArrayType[IntegerType[32], 4], ctx)) == "[4 x i32]"
+        assert str(_resolve(VectorType[IntegerType[32], 4], ctx)) == "<4 x i32>"
+        assert (
+            str(_resolve(StructType[IntegerType[32], IntegerType[64]], ctx))
+            == "{ i32, i64 }"
+        )
+        assert (
+            str(_resolve(FunctionType[IntegerType[32], [PointerType[0]]], ctx))
+            == "i32 (ptr)"
+        )
+    assert_no_leaks()
+
+
+def test_subscript_uses_current_context_when_omitted():
+    with llvm.ir.Context() as ctx:
+        # Resolved against the live context; interns to the same type.
+        assert _resolve(IntegerType[32], ctx) is llvm.types.i32(ctx)
+        assert str(_resolve(PointerType[0], ctx)) == "ptr"
+    assert_no_leaks()
+
+
+def test_subscript_is_interned_identical_to_primitive_factory():
+    with llvm.ir.Context() as ctx:
+        assert _resolve(IntegerType[32], ctx) is llvm.types.i32(ctx)
+        assert _resolve(PointerType[0], ctx) is llvm.types.ptr(context=ctx)
+    assert_no_leaks()
+
+
+def test_subscript_concrete_vector_subtypes_return_right_subtype():
+    with llvm.ir.Context() as ctx:
+        fv = _resolve(FixedVectorType[IntegerType[32], 4], ctx)
+        assert type(fv) is FixedVectorType
+        assert str(fv) == "<4 x i32>"
+        sv = _resolve(ScalableVectorType[IntegerType[32], 4], ctx)
+        assert type(sv) is ScalableVectorType
+        assert str(sv) == "<vscale x 4 x i32>"
+    assert_no_leaks()
+
+
+def test_subscript_rejects_foreign_context_element():
+    with llvm.ir.Context() as ctx, llvm.ir.Context() as other:
+        i32_other = llvm.types.i32(other)
+        with pytest.raises(ValueError, match="different context"):
+            _resolve(ArrayType[i32_other, 4], ctx)
     assert_no_leaks()


### PR DESCRIPTION
Port the upstream MLIR mechanism (nanobind is_generic + deferred evaluation)
to eudsl-llvmpy's parametric types so functions can be annotated with types
without a live LLVMContext.

Each parametric type class (IntegerType, PointerType, StructType, ArrayType,
VectorType, FixedVectorType, ScalableVectorType, FunctionType) is now
registered with nb::is_generic(), so `IntegerType[32]`, `PointerType[0]`,
`FunctionType[ret, [args]]`, etc. produce an unevaluated types.GenericAlias --
subscriptable with no context. A matching def_static get(...) constructs the
type, resolving the context via currentOr (so context stays an optional
trailing kwarg). LLVM types are interned per-LLVMContext, so a context-free
annotation must stay a deferred alias; the alias is only turned into a real
type at emit time.

The @function decorator's _resolve now handles a GenericAlias (recursively
evaluating its subscript args, StructType being variadic) and a bare
parametric class, evaluating against module.context. Primitives (i32, void,
...) stay factory functions used bare as annotations via the existing callable
path. Adds tests/types/test_types_generic.py and per-type deferred-annotation
tests (including nested structs and concrete-element subscripts) in
tests/dsl/test_dsl_func.py.