### PR TITLE
[eudsl-llvmpy] Fix lazy-view use-after-free by pinning the owning module

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -117,6 +117,8 @@ void populate_context(nb::module_ &m) {
               std::advance(it, i);
               return &*it;
             };
+            // Pin the module itself: it owns the functions' storage.
+            seq.owner = nb::find(self);
             return seq;
           },
           nb::keep_alive<0, 1>())

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -141,7 +141,7 @@ void populate_context(nb::module_ &m) {
           [](eudsl::Module &self) {
             return nb::make_iterator<nb::rv_policy::reference>(
                 nb::type<eudsl::Module>(), "FunctionIterator",
-                self.get().begin(), self.get().end());
+                self.get().begin(), self.get().end(), nb::keep_alive<0, 1>());
           },
           nb::keep_alive<0, 1>())
       .def(
@@ -149,13 +149,13 @@ void populate_context(nb::module_ &m) {
           [](eudsl::Module &self, const std::string &name) {
             return self.get().getFunction(name);
           },
-          "name"_a, nb::rv_policy::reference)
+          "name"_a, nb::rv_policy::reference_internal)
       .def(
           "get_global_variable",
           [](eudsl::Module &self, const std::string &name) {
             return self.get().getNamedGlobal(name);
           },
-          "name"_a, nb::rv_policy::reference)
+          "name"_a, nb::rv_policy::reference_internal)
       .def(
           "add_named_metadata",
           [](eudsl::Module &self, const std::string &name, llvm::MDNode *node) {

--- a/projects/eudsl-llvmpy/src/IR/Ownership.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.cpp
@@ -5,12 +5,27 @@
 #include "IR/Ownership.h"
 
 #include <stdexcept>
+#include <unordered_map>
 #include <vector>
 
 namespace eudsl {
 
 static int64_t gLiveContexts = 0;
 static int64_t gLiveModules = 0;
+
+/// Maps each live llvm::Module to its owning eudsl::Module wrapper, so a view
+/// built from a bare llvm::Value can find the wrapper (and pin its Python
+/// object) via moduleWrapperFor.
+static std::unordered_map<const llvm::Module *, Module *> &liveModuleMap() {
+  static std::unordered_map<const llvm::Module *, Module *> map;
+  return map;
+}
+
+Module *moduleWrapperFor(const llvm::Module *m) {
+  auto &map = liveModuleMap();
+  auto it = map.find(m);
+  return it == map.end() ? nullptr : it->second;
+}
 
 Context::Context() : ctx(std::make_shared<llvm::LLVMContext>()) {
   ++gLiveContexts;
@@ -49,15 +64,23 @@ llvm::LLVMContext &Context::get() const {
 Module::Module(const std::string &name, Context &ctx)
     : ctxKeepAlive(ctx.shared()),
       mod(std::make_unique<llvm::Module>(name, ctx.get())), owner(&ctx) {
+  keyMod = mod.get();
+  liveModuleMap()[keyMod] = this;
   ++gLiveModules;
 }
 
 Module::Module(std::unique_ptr<llvm::Module> m, Context &ctx)
     : ctxKeepAlive(ctx.shared()), mod(std::move(m)), owner(&ctx) {
+  keyMod = mod.get();
+  liveModuleMap()[keyMod] = this;
   ++gLiveModules;
 }
 
-Module::~Module() { --gLiveModules; }
+Module::~Module() {
+  if (keyMod)
+    liveModuleMap().erase(keyMod);
+  --gLiveModules;
+}
 
 int64_t Module::liveCount() { return gLiveModules; }
 

--- a/projects/eudsl-llvmpy/src/IR/Ownership.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.cpp
@@ -13,9 +13,19 @@ namespace eudsl {
 static int64_t gLiveContexts = 0;
 static int64_t gLiveModules = 0;
 
-/// Maps each live llvm::Module to its owning eudsl::Module wrapper, so a view
-/// built from a bare llvm::Value can find the wrapper (and pin its Python
-/// object) via moduleWrapperFor.
+/// Maps an llvm::Module pointer to the eudsl::Module wrapper that was
+/// constructed around it, so a view built from a bare llvm::Value can find the
+/// wrapper (and pin its Python object) via moduleWrapperFor. The key is the
+/// llvm::Module pointer captured at construction; the entry is inserted by the
+/// ctors and removed by the dtor, so it tracks *wrapper* lifetime. take() does
+/// not update it: after a module is consumed the wrapper stays registered under
+/// its (now-dangling) former key until the wrapper is destroyed -- moduleWrapperFor
+/// only hashes/compares the pointer and never dereferences it, so a stale key is
+/// not itself unsafe (see the guarded erase in ~Module).
+///
+/// Not synchronized: like the gLiveContexts/gLiveModules counters below, this
+/// map assumes the GIL and is not safe under free-threading (the module is built
+/// Py_MOD_GIL_NOT_USED but thread-safety is not verified).
 static std::unordered_map<const llvm::Module *, Module *> &liveModuleMap() {
   static std::unordered_map<const llvm::Module *, Module *> map;
   return map;
@@ -77,8 +87,17 @@ Module::Module(std::unique_ptr<llvm::Module> m, Context &ctx)
 }
 
 Module::~Module() {
-  if (keyMod)
-    liveModuleMap().erase(keyMod);
+  // Guard the erase: only remove the entry if it still maps to *this*. After
+  // take() frees the llvm::Module and a new one is allocated at the same address
+  // and wrapped by a different Module, the map key collides; an unconditional
+  // erase(keyMod) would clobber the newer wrapper's entry (ABA), unpinning its
+  // views back into a use-after-free.
+  if (keyMod) {
+    auto &map = liveModuleMap();
+    auto it = map.find(keyMod);
+    if (it != map.end() && it->second == this)
+      map.erase(it);
+  }
   --gLiveModules;
 }
 

--- a/projects/eudsl-llvmpy/src/IR/Ownership.h
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.h
@@ -75,6 +75,12 @@ private:
   std::shared_ptr<llvm::LLVMContext> ctxKeepAlive;
   std::unique_ptr<llvm::Module> mod;
   Context *owner;
+  const llvm::Module *keyMod = nullptr; // registry key; see moduleWrapperFor
 };
+
+/// The live eudsl::Module wrapping `m`, or null. Lets a sub-object view resolve
+/// the owning module from a bare llvm::Value and pin its Python wrapper alive,
+/// so a held view never outlives the module that owns its storage.
+Module *moduleWrapperFor(const llvm::Module *m);
 
 } // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Ownership.h
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.h
@@ -78,9 +78,13 @@ private:
   const llvm::Module *keyMod = nullptr; // registry key; see moduleWrapperFor
 };
 
-/// The live eudsl::Module wrapping `m`, or null. Lets a sub-object view resolve
-/// the owning module from a bare llvm::Value and pin its Python wrapper alive,
-/// so a held view never outlives the module that owns its storage.
+/// The eudsl::Module wrapper registered for `m`, or null. Keyed by the
+/// llvm::Module pointer captured when the wrapper was constructed and tracks the
+/// wrapper's lifetime (not the llvm::Module's): after take() consumes the module
+/// the wrapper stays registered under its former key until destroyed. Lets a
+/// sub-object view resolve the owning module from a bare llvm::Value and pin its
+/// Python wrapper alive, so a held view never outlives the module that owns its
+/// storage.
 Module *moduleWrapperFor(const llvm::Module *m);
 
 } // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Sequence.h
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.h
@@ -13,8 +13,11 @@ namespace eudsl {
 
 /// A lazy, sliceable sequence view over an LLVM container. It holds closures
 /// that compute the length and the i-th element on demand, so iterating or
-/// indexing does not materialize a list. The accessor that returns a Sequence
-/// must keep_alive<0,1> it to the parent, whose storage owns the elements.
+/// indexing does not materialize a list. The accessor sets `owner` to a strong
+/// reference to the Python object that owns the elements' storage (the Module),
+/// so a held view -- and every element it yields -- keeps that storage alive
+/// and never dangles past it. `owner` may be none for context-owned values
+/// (e.g. constants) that have no owning module.
 ///
 /// __len__ and integer __getitem__ (negative-aware, IndexError past the ends)
 /// are lazy; a slice materializes just the requested window into a list.
@@ -22,6 +25,7 @@ namespace eudsl {
 template <typename T> struct Sequence {
   std::function<std::size_t()> length;
   std::function<T *(std::size_t)> at;
+  nb::object owner;
 };
 
 template <typename T> void bindSequence(nb::module_ &m, const char *name) {
@@ -31,6 +35,14 @@ template <typename T> void bindSequence(nb::module_ &m, const char *name) {
              return static_cast<Py_ssize_t>(self.length());
            })
       .def("__getitem__", [](Sequence<T> &self, nb::handle index) -> nb::object {
+        // Pin each yielded element to the storage owner so it survives even if
+        // the view itself is dropped -- mirroring MLIR's owner-reference chain.
+        auto element = [&](std::size_t k) -> nb::object {
+          nb::object obj = nb::cast(self.at(k), nb::rv_policy::reference);
+          if (self.owner.is_valid() && !self.owner.is_none())
+            nb::detail::keep_alive(obj.ptr(), self.owner.ptr());
+          return obj;
+        };
         Py_ssize_t n = static_cast<Py_ssize_t>(self.length());
         if (nb::isinstance<nb::slice>(index)) {
           auto [start, stop, step, count] =
@@ -38,8 +50,7 @@ template <typename T> void bindSequence(nb::module_ &m, const char *name) {
           nb::list out;
           Py_ssize_t idx = start;
           for (size_t k = 0; k < count; ++k) {
-            out.append(nb::cast(self.at(static_cast<std::size_t>(idx)),
-                                nb::rv_policy::reference));
+            out.append(element(static_cast<std::size_t>(idx)));
             idx += step;
           }
           return out;
@@ -51,8 +62,7 @@ template <typename T> void bindSequence(nb::module_ &m, const char *name) {
           i += n;
         if (i < 0 || i >= n)
           throw nb::index_error("index out of range");
-        return nb::cast(self.at(static_cast<std::size_t>(i)),
-                        nb::rv_policy::reference);
+        return element(static_cast<std::size_t>(i));
       });
 }
 

--- a/projects/eudsl-llvmpy/src/IR/Sequence.h
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.h
@@ -13,11 +13,19 @@ namespace eudsl {
 
 /// A lazy, sliceable sequence view over an LLVM container. It holds closures
 /// that compute the length and the i-th element on demand, so iterating or
-/// indexing does not materialize a list. The accessor sets `owner` to a strong
-/// reference to the Python object that owns the elements' storage (the Module),
-/// so a held view -- and every element it yields -- keeps that storage alive
-/// and never dangles past it. `owner` may be none for context-owned values
-/// (e.g. constants) that have no owning module.
+/// indexing does not materialize a list.
+///
+/// Lifetime: two independent anchors keep storage alive. (1) The accessor sets
+/// `owner` to a strong reference to the Python object that owns the *container's*
+/// storage (usually the Module); holding the view -- which holds `owner` -- keeps
+/// that storage alive, and `owner` is also pinned onto every yielded element.
+/// (2) `ownerOf`, when set, resolves an *individual element's* own storage owner,
+/// which is pinned onto that element too -- so a module-owned element yielded by
+/// a none-owner container (e.g. a GlobalVariable via `ConstantExpr.operands`,
+/// whose ConstantExpr has no module) is anchored to its own module rather than
+/// left dangling. Either may resolve to none (a context-owned constant, or no
+/// live module wrapper); the accessors additionally `keep_alive<0,1>` the view to
+/// its immediate parent.
 ///
 /// __len__ and integer __getitem__ (negative-aware, IndexError past the ends)
 /// are lazy; a slice materializes just the requested window into a list.
@@ -26,6 +34,7 @@ template <typename T> struct Sequence {
   std::function<std::size_t()> length;
   std::function<T *(std::size_t)> at;
   nb::object owner;
+  std::function<nb::object(T *)> ownerOf;
 };
 
 template <typename T> void bindSequence(nb::module_ &m, const char *name) {
@@ -35,12 +44,24 @@ template <typename T> void bindSequence(nb::module_ &m, const char *name) {
              return static_cast<Py_ssize_t>(self.length());
            })
       .def("__getitem__", [](Sequence<T> &self, nb::handle index) -> nb::object {
-        // Pin each yielded element to the storage owner so it survives even if
-        // the view itself is dropped -- mirroring MLIR's owner-reference chain.
+        // Pin each yielded element to its storage owner(s) so it survives even
+        // if the view itself is dropped -- mirroring MLIR's owner-reference
+        // chain. Pin to both the container's owner and (when known) the
+        // element's own owner: the latter anchors a module-owned element yielded
+        // by a none-owner container to its own module.
         auto element = [&](std::size_t k) -> nb::object {
-          nb::object obj = nb::cast(self.at(k), nb::rv_policy::reference);
-          if (self.owner.is_valid() && !self.owner.is_none())
-            nb::detail::keep_alive(obj.ptr(), self.owner.ptr());
+          T *ptr = self.at(k);
+          nb::object obj = nb::cast(ptr, nb::rv_policy::reference);
+          auto pin = [&](const nb::object &o) {
+            // nb::detail::keep_alive is the dynamic (runtime nurse/patient) form
+            // behind rv_policy::reference_internal; it is NB_CORE-exported and
+            // has no public wrapper, so the detail:: reach-in is intentional.
+            if (o.is_valid() && !o.is_none())
+              nb::detail::keep_alive(obj.ptr(), o.ptr());
+          };
+          pin(self.owner);
+          if (self.ownerOf)
+            pin(self.ownerOf(ptr));
           return obj;
         };
         Py_ssize_t n = static_cast<Py_ssize_t>(self.length());

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -27,9 +27,10 @@
 #include <algorithm>
 #include <vector>
 
-/// The Python wrapper of the module that owns `v`'s storage (or none for a
-/// context-owned value with no module, e.g. a constant). A sub-object view
-/// stores this so holding the view keeps the owning module alive.
+/// The Python wrapper of the module that owns `v`'s storage, or none when `v`
+/// has no owning module (a context-owned value such as a constant) or its
+/// module has no live wrapper. A sub-object view stores this so holding the
+/// view keeps the owning module alive.
 static nb::object ownerObjectFor(const llvm::Value *v) {
   const llvm::Module *m = nullptr;
   if (auto *inst = llvm::dyn_cast<llvm::Instruction>(v))
@@ -40,12 +41,10 @@ static nb::object ownerObjectFor(const llvm::Value *v) {
     m = gv->getParent();
   else if (auto *bb = llvm::dyn_cast<llvm::BasicBlock>(v))
     m = bb->getModule();
-  if (!m)
-    return nb::none();
+  // moduleWrapperFor(nullptr) is null, so a value with no module folds to a
+  // none owner without a separate branch.
   eudsl::Module *wrapper = eudsl::moduleWrapperFor(m);
-  if (!wrapper)
-    return nb::none();
-  nb::object obj = nb::find(*wrapper);
+  nb::object obj = wrapper ? nb::find(*wrapper) : nb::none();
   return obj.is_valid() ? obj : nb::none();
 }
 

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -28,9 +28,10 @@
 #include <vector>
 
 /// The Python wrapper of the module that owns `v`'s storage, or none when `v`
-/// has no owning module (a context-owned value such as a constant) or its
-/// module has no live wrapper. A sub-object view stores this so holding the
-/// view keeps the owning module alive.
+/// has no owning module (a context-owned value such as a constant) or when no
+/// live wrapper for that module can be resolved. A sub-object view stores this
+/// so holding the view -- or an element it yields -- keeps the owning module
+/// alive.
 static nb::object ownerObjectFor(const llvm::Value *v) {
   const llvm::Module *m = nullptr;
   if (auto *inst = llvm::dyn_cast<llvm::Instruction>(v))
@@ -77,6 +78,7 @@ void populate_values(nb::module_ &m) {
               return *it;
             };
             seq.owner = ownerObjectFor(v);
+            seq.ownerOf = [](llvm::User *e) { return ownerObjectFor(e); };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -94,6 +96,11 @@ void populate_values(nb::module_ &m) {
               return &*it;
             };
             seq.owner = ownerObjectFor(v);
+            // A Use lives in its User's operand list, so it is owned by the
+            // User's module.
+            seq.ownerOf = [](llvm::Use *e) {
+              return ownerObjectFor(e->getUser());
+            };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -143,6 +150,7 @@ void populate_values(nb::module_ &m) {
               return u->getOperand(static_cast<unsigned>(i));
             };
             seq.owner = ownerObjectFor(u);
+            seq.ownerOf = [](llvm::Value *e) { return ownerObjectFor(e); };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -232,6 +240,7 @@ void populate_values(nb::module_ &m) {
               return &*it;
             };
             seq.owner = ownerObjectFor(b);
+            seq.ownerOf = [](llvm::Instruction *e) { return ownerObjectFor(e); };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -288,6 +297,7 @@ void populate_values(nb::module_ &m) {
               return f->getArg(static_cast<unsigned>(i));
             };
             seq.owner = ownerObjectFor(f);
+            seq.ownerOf = [](llvm::Argument *e) { return ownerObjectFor(e); };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -303,6 +313,7 @@ void populate_values(nb::module_ &m) {
               return &*it;
             };
             seq.owner = ownerObjectFor(f);
+            seq.ownerOf = [](llvm::BasicBlock *e) { return ownerObjectFor(e); };
             return seq;
           },
           nb::keep_alive<0, 1>())

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -27,6 +27,28 @@
 #include <algorithm>
 #include <vector>
 
+/// The Python wrapper of the module that owns `v`'s storage (or none for a
+/// context-owned value with no module, e.g. a constant). A sub-object view
+/// stores this so holding the view keeps the owning module alive.
+static nb::object ownerObjectFor(const llvm::Value *v) {
+  const llvm::Module *m = nullptr;
+  if (auto *inst = llvm::dyn_cast<llvm::Instruction>(v))
+    m = inst->getModule();
+  else if (auto *arg = llvm::dyn_cast<llvm::Argument>(v))
+    m = arg->getParent() ? arg->getParent()->getParent() : nullptr;
+  else if (auto *gv = llvm::dyn_cast<llvm::GlobalValue>(v))
+    m = gv->getParent();
+  else if (auto *bb = llvm::dyn_cast<llvm::BasicBlock>(v))
+    m = bb->getModule();
+  if (!m)
+    return nb::none();
+  eudsl::Module *wrapper = eudsl::moduleWrapperFor(m);
+  if (!wrapper)
+    return nb::none();
+  nb::object obj = nb::find(*wrapper);
+  return obj.is_valid() ? obj : nb::none();
+}
+
 void populate_values(nb::module_ &m) {
   // A def-use edge: which User uses a value, and at which operand index.
   nb::class_<llvm::Use>(m, "Use")
@@ -55,6 +77,7 @@ void populate_values(nb::module_ &m) {
               std::advance(it, i);
               return *it;
             };
+            seq.owner = ownerObjectFor(v);
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -71,6 +94,7 @@ void populate_values(nb::module_ &m) {
               std::advance(it, i);
               return &*it;
             };
+            seq.owner = ownerObjectFor(v);
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -119,6 +143,7 @@ void populate_values(nb::module_ &m) {
             seq.at = [u](std::size_t i) {
               return u->getOperand(static_cast<unsigned>(i));
             };
+            seq.owner = ownerObjectFor(u);
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -206,6 +231,7 @@ void populate_values(nb::module_ &m) {
               std::advance(it, i);
               return &*it;
             };
+            seq.owner = ownerObjectFor(b);
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -261,6 +287,7 @@ void populate_values(nb::module_ &m) {
             seq.at = [f](std::size_t i) {
               return f->getArg(static_cast<unsigned>(i));
             };
+            seq.owner = ownerObjectFor(f);
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -275,6 +302,7 @@ void populate_values(nb::module_ &m) {
               std::advance(it, i);
               return &*it;
             };
+            seq.owner = ownerObjectFor(f);
             return seq;
           },
           nb::keep_alive<0, 1>())

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -167,7 +167,8 @@ void populate_values(nb::module_ &m) {
           [](llvm::User &self) {
             return nb::make_iterator<nb::rv_policy::reference>(
                 nb::type<llvm::User>(), "OperandIterator",
-                self.value_op_begin(), self.value_op_end());
+                self.value_op_begin(), self.value_op_end(),
+                nb::keep_alive<0, 1>());
           },
           nb::keep_alive<0, 1>());
 
@@ -253,7 +254,7 @@ void populate_values(nb::module_ &m) {
           [](llvm::BasicBlock &self) {
             return nb::make_iterator<nb::rv_policy::reference>(
                 nb::type<llvm::BasicBlock>(), "InstructionIterator",
-                self.begin(), self.end());
+                self.begin(), self.end(), nb::keep_alive<0, 1>());
           },
           nb::keep_alive<0, 1>());
 
@@ -324,7 +325,7 @@ void populate_values(nb::module_ &m) {
           [](llvm::Function &self) {
             return nb::make_iterator<nb::rv_policy::reference>(
                 nb::type<llvm::Function>(), "BasicBlockIterator", self.begin(),
-                self.end());
+                self.end(), nb::keep_alive<0, 1>());
           },
           nb::keep_alive<0, 1>())
       .def_prop_ro(
@@ -348,7 +349,8 @@ void populate_values(nb::module_ &m) {
             // the LLVM analogue of MLIR's op.walk() over a single region.
             return nb::make_iterator<nb::rv_policy::reference>(
                 nb::type<llvm::Function>(), "WalkIterator",
-                llvm::inst_begin(self), llvm::inst_end(self));
+                llvm::inst_begin(self), llvm::inst_end(self),
+                nb::keep_alive<0, 1>());
           },
           nb::keep_alive<0, 1>())
       .def_prop_rw("linkage", &llvm::Function::getLinkage,

--- a/projects/eudsl-llvmpy/tests/ir/test_lazy_views.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_lazy_views.py
@@ -127,3 +127,26 @@ def test_container_view_keeps_module_alive():
         gc.collect()
         assert llvm.ir.Context._get_live_module_count() == 0
     assert_no_leaks()
+
+
+def test_nested_view_outlives_module():
+    # A sub-object view (operands) and an element taken from it each pin the
+    # owning module alive, so touching them after every other handle is dropped
+    # is safe -- previously a use-after-free / segfault.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        add = mod.get_function("f").entry_block.instructions[0]
+        ops = add.operands
+        op0 = ops[0]  # element extracted from the view
+        del add, mod  # only the view and its element still reference the module
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 1
+        assert len(ops) == 2  # view still valid
+        assert type(op0).__name__ == "Argument"  # element still valid, not freed
+        del ops
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 1  # element still pins it
+        del op0
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 0
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
@@ -2,12 +2,14 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Lifetime safety: a wrapper returned by any traversal accessor keeps the
-owning module alive, so holding it after the module handle is dropped is never a
-use-after-free. Each case holds ONLY the accessor result, drops the module, and
-asserts the module is still live (== 1) before touching the result, then asserts
-dropping the result releases the module (== 0). The count assertion runs before
-any dereference, so an accessor that fails to pin fails cleanly rather than
-segfaulting."""
+owning module alive *while that module is live*, so dropping the Python module
+handle (but not consuming it) never dangles a held wrapper. Each case holds ONLY
+the accessor result, drops the module, and asserts the module is still live
+(== 1) before touching the result, then asserts dropping the result releases the
+module (== 0). The count assertion runs before any dereference, so an accessor
+that fails to pin fails cleanly rather than segfaulting. (Consuming the module
+via take()/_take() hands its storage to the JIT and is outside this guarantee;
+see test_take_consumes_module_and_is_outside_pinning_guarantee.)"""
 import gc
 
 import pytest
@@ -21,6 +23,7 @@ _SRC = """\
 @fp = ifunc i32 (), ptr @res
 @al = alias i32, ptr @g
 @ba = global ptr blockaddress(@f, %b)
+@ce = global i64 ptrtoint (ptr @g to i64)
 
 define i32 @f(i32 %x, i32 %y) {
 entry:
@@ -52,35 +55,43 @@ def _load_ptr(m, name):
     raise AssertionError(name)
 
 
-# (id, make(mod) -> wrapper held as the sole reference, touch(wrapper) -> uses it)
+# (id, make(mod) -> wrapper held as the sole reference, touch(wrapper) -> asserts
+# concrete content while storage is valid). The touch confirms downcast/identity;
+# it is NOT the safety signal (freed LLVM storage reads back plausible garbage,
+# e.g. name -> ""), which is the `== 1` count assertion that precedes it.
 CASES = [
     ("get_function", lambda m: m.get_function("f"), lambda v: v.name == "f"),
     ("get_global_variable", lambda m: m.get_global_variable("g"), lambda v: v.name == "g"),
-    ("module_getitem", lambda m: m[0], lambda v: bool(v.name)),
-    ("module_functions_view", lambda m: m.functions[0], lambda v: bool(v.name)),
+    ("module_getitem", lambda m: m[0], lambda v: v.name == "f"),
+    ("module_functions_view", lambda m: m.functions[0], lambda v: v.name == "f"),
     ("function_arg", lambda m: m.get_function("f").arg(0), lambda v: v.arg_no == 0),
     ("function_args_view", lambda m: m.get_function("f").args[0], lambda v: v.arg_no == 0),
-    ("function_entry_block", lambda m: m.get_function("f").entry_block, lambda v: bool(v.name)),
-    ("function_bbs_view", lambda m: m.get_function("f").basic_blocks[0], lambda v: bool(v.name)),
-    ("function_getitem", lambda m: m.get_function("f")[0], lambda v: bool(v.name)),
+    ("function_entry_block", lambda m: m.get_function("f").entry_block, lambda v: v.name == "entry"),
+    ("function_bbs_view", lambda m: m.get_function("f").basic_blocks[0], lambda v: v.name == "entry"),
+    ("function_getitem", lambda m: m.get_function("f")[0], lambda v: v.name == "entry"),
     ("bb_parent", lambda m: m.get_function("f").entry_block.parent, lambda v: v.name == "f"),
     ("bb_terminator", lambda m: m.get_function("f").entry_block.terminator, lambda v: v.is_terminator),
-    ("bb_instructions_view", lambda m: m.get_function("f").entry_block.instructions[0], lambda v: bool(str(v))),
-    ("bb_getitem", lambda m: m.get_function("f").entry_block[0], lambda v: bool(str(v))),
-    ("inst_parent", lambda m: _add(m).parent, lambda v: bool(v.name)),
-    ("inst_operand", lambda m: _add(m).operand(0), lambda v: bool(str(v))),
-    ("inst_operands_view", lambda m: _add(m).operands[0], lambda v: bool(str(v))),
-    ("user_getitem", lambda m: _add(m)[0], lambda v: bool(str(v))),
+    ("bb_instructions_view", lambda m: m.get_function("f").entry_block.instructions[0], lambda v: v.name == "gv"),
+    ("bb_getitem", lambda m: m.get_function("f").entry_block[0], lambda v: v.name == "gv"),
+    ("inst_parent", lambda m: _add(m).parent, lambda v: v.name == "entry"),
+    ("inst_operand", lambda m: _add(m).operand(0), lambda v: v.name == "x"),
+    ("inst_operands_view", lambda m: _add(m).operands[0], lambda v: v.name == "x"),
+    ("user_getitem", lambda m: _add(m)[0], lambda v: v.name == "x"),
     ("arg_parent", lambda m: m.get_function("f").arg(0).parent, lambda v: v.name == "f"),
-    ("arg_users_view", lambda m: m.get_function("f").arg(0).users[0], lambda v: bool(str(v))),
+    ("arg_users_view", lambda m: m.get_function("f").arg(0).users[0], lambda v: v.name == "s"),
     ("arg_uses_view", lambda m: m.get_function("f").arg(0).uses[0], lambda v: v.operand_number == 0),
-    ("use_user", lambda m: m.get_function("f").arg(0).uses[0].user, lambda v: bool(str(v))),
-    ("gvar_initializer", lambda m: m.get_global_variable("g").initializer, lambda v: bool(str(v))),
+    ("use_user", lambda m: m.get_function("f").arg(0).uses[0].user, lambda v: v.name == "s"),
+    ("gvar_initializer", lambda m: m.get_global_variable("g").initializer, lambda v: str(v) == "i32 7"),
     ("load_pointer_operand", lambda m: _load_ptr(m, "g"), lambda v: v.name == "g"),
     ("global_alias_aliasee", lambda m: _load_ptr(m, "al").aliasee, lambda v: v.name == "g"),
     ("global_ifunc_resolver", lambda m: _load_ptr(m, "fp").resolver, lambda v: v.name == "res"),
     ("block_address_function", lambda m: _load_ptr(m, "ba").initializer.function, lambda v: v.name == "f"),
     ("block_address_block", lambda m: _load_ptr(m, "ba").initializer.basic_block, lambda v: v.name == "b"),
+    # A none-owner container (the ConstantExpr `ptrtoint (ptr @g to i64)`, which
+    # has no module) yielding a module-owned element (@g): the element must pin
+    # its OWN module, not the container's. Before the per-element owner fix this
+    # failed cleanly at count 0.
+    ("const_expr_operand_module_owned", lambda m: m.get_global_variable("ce").initializer.operands[0], lambda v: v.name == "g"),
 ]
 
 
@@ -101,27 +112,57 @@ def test_accessor_result_pins_module(make, touch):
     assert_no_leaks()
 
 
+_ITER_CASES = [
+    ("module_iter", lambda m: next(iter(m)), lambda v: v.name == "f"),  # -> Function
+    ("function_iter", lambda m: next(iter(m.get_function("f"))), lambda v: v.name == "entry"),  # -> BasicBlock
+    ("bb_iter", lambda m: next(iter(m.get_function("f").entry_block)), lambda v: v.name == "gv"),  # -> Instruction
+    ("user_iter", lambda m: next(iter(_add(m))), lambda v: v.name == "x"),  # -> operand Value
+]
+
+
 @pytest.mark.parametrize(
-    "make",
-    [
-        lambda m: next(iter(m)),  # Module.__iter__ -> Function
-        lambda m: next(iter(m.get_function("f"))),  # Function.__iter__ -> BasicBlock
-        lambda m: next(iter(m.get_function("f").entry_block)),  # BB.__iter__ -> Instruction
-        lambda m: next(iter(_add(m))),  # User.__iter__ -> operand Value
-    ],
-    ids=["module_iter", "function_iter", "bb_iter", "user_iter"],
+    "make,check",
+    [(c[1], c[2]) for c in _ITER_CASES],
+    ids=[c[0] for c in _ITER_CASES],
 )
-def test_iterator_element_pins_module(make):
+def test_iterator_element_pins_module(make, check):
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         held = make(mod)  # element from an iterator; the iterator is not retained
         del mod
         gc.collect()
         assert llvm.ir.Context._get_live_module_count() == 1
-        assert str(held) is not None
+        # Concrete content, not `str(held) is not None` (always true): confirms
+        # the yielded element is the expected wrapper while its storage is valid.
+        assert check(held)
         del held
         gc.collect()
         assert llvm.ir.Context._get_live_module_count() == 0
+    assert_no_leaks()
+
+
+def test_missing_lookup_returns_none():
+    # get_function/get_global_variable return a null llvm pointer for a missing
+    # name; reference_internal on null yields None (keep_alive no-ops on None).
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        assert mod.get_function("missing") is None
+        assert mod.get_global_variable("missing") is None
+        del mod
+    assert_no_leaks()
+
+
+def test_take_consumes_module_and_is_outside_pinning_guarantee():
+    # take()/_take() hand the llvm::Module to the JIT (here, drop it), which then
+    # owns its storage. The pinning guarantee covers a *live* module; a wrapper
+    # obtained before the module is consumed is not covered. Document that the
+    # wrapper is consumed and further module access raises cleanly (rather than
+    # dereferencing a held pre-take value, which is now freed).
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        mod._take()
+        with pytest.raises(RuntimeError, match="consumed"):
+            mod.get_function("f")
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
@@ -1,0 +1,125 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Lifetime safety: a wrapper returned by any traversal accessor keeps the
+owning module alive, so holding it after the module handle is dropped is never a
+use-after-free. Each case holds ONLY the accessor result, drops the module, and
+asserts the module is still live (== 1) before touching the result, then asserts
+dropping the result releases the module (== 0). The count assertion runs before
+any dereference, so an accessor that fails to pin fails cleanly rather than
+segfaulting."""
+import gc
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = """\
+@g = global i32 7
+@res = global ptr null
+@fp = ifunc i32 (), ptr @res
+@al = alias i32, ptr @g
+@ba = global ptr blockaddress(@f, %b)
+
+define i32 @f(i32 %x, i32 %y) {
+entry:
+  %gv = load i32, ptr @g
+  %a = load i32, ptr @al
+  %i = load ptr, ptr @fp
+  %bp = load ptr, ptr @ba
+  %s = add i32 %x, %y
+  br label %b
+b:
+  ret i32 %s
+}
+"""
+
+
+def _add(m):
+    # The `add` instruction (a User with two operands) in @f's entry block.
+    for inst in m.get_function("f").entry_block.instructions:
+        if isinstance(inst, llvm.ir.BinaryOperator):
+            return inst
+    raise AssertionError("add")
+
+
+def _load_ptr(m, name):
+    # pointer_operand of the load whose pointer is the named global/alias/ifunc.
+    for inst in m.get_function("f").entry_block.instructions:
+        if isinstance(inst, llvm.ir.LoadInst) and inst.pointer_operand.name == name:
+            return inst.pointer_operand
+    raise AssertionError(name)
+
+
+# (id, make(mod) -> wrapper held as the sole reference, touch(wrapper) -> uses it)
+CASES = [
+    ("get_function", lambda m: m.get_function("f"), lambda v: v.name == "f"),
+    ("get_global_variable", lambda m: m.get_global_variable("g"), lambda v: v.name == "g"),
+    ("module_getitem", lambda m: m[0], lambda v: bool(v.name)),
+    ("module_functions_view", lambda m: m.functions[0], lambda v: bool(v.name)),
+    ("function_arg", lambda m: m.get_function("f").arg(0), lambda v: v.arg_no == 0),
+    ("function_args_view", lambda m: m.get_function("f").args[0], lambda v: v.arg_no == 0),
+    ("function_entry_block", lambda m: m.get_function("f").entry_block, lambda v: bool(v.name)),
+    ("function_bbs_view", lambda m: m.get_function("f").basic_blocks[0], lambda v: bool(v.name)),
+    ("function_getitem", lambda m: m.get_function("f")[0], lambda v: bool(v.name)),
+    ("bb_parent", lambda m: m.get_function("f").entry_block.parent, lambda v: v.name == "f"),
+    ("bb_terminator", lambda m: m.get_function("f").entry_block.terminator, lambda v: v.is_terminator),
+    ("bb_instructions_view", lambda m: m.get_function("f").entry_block.instructions[0], lambda v: bool(str(v))),
+    ("bb_getitem", lambda m: m.get_function("f").entry_block[0], lambda v: bool(str(v))),
+    ("inst_parent", lambda m: _add(m).parent, lambda v: bool(v.name)),
+    ("inst_operand", lambda m: _add(m).operand(0), lambda v: bool(str(v))),
+    ("inst_operands_view", lambda m: _add(m).operands[0], lambda v: bool(str(v))),
+    ("user_getitem", lambda m: _add(m)[0], lambda v: bool(str(v))),
+    ("arg_parent", lambda m: m.get_function("f").arg(0).parent, lambda v: v.name == "f"),
+    ("arg_users_view", lambda m: m.get_function("f").arg(0).users[0], lambda v: bool(str(v))),
+    ("arg_uses_view", lambda m: m.get_function("f").arg(0).uses[0], lambda v: v.operand_number == 0),
+    ("use_user", lambda m: m.get_function("f").arg(0).uses[0].user, lambda v: bool(str(v))),
+    ("gvar_initializer", lambda m: m.get_global_variable("g").initializer, lambda v: bool(str(v))),
+    ("load_pointer_operand", lambda m: _load_ptr(m, "g"), lambda v: v.name == "g"),
+    ("global_alias_aliasee", lambda m: _load_ptr(m, "al").aliasee, lambda v: v.name == "g"),
+    ("global_ifunc_resolver", lambda m: _load_ptr(m, "fp").resolver, lambda v: v.name == "res"),
+    ("block_address_function", lambda m: _load_ptr(m, "ba").initializer.function, lambda v: v.name == "f"),
+    ("block_address_block", lambda m: _load_ptr(m, "ba").initializer.basic_block, lambda v: v.name == "b"),
+]
+
+
+@pytest.mark.parametrize("make,touch", [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+def test_accessor_result_pins_module(make, touch):
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        held = make(mod)
+        del mod  # the accessor result is now the only reference to the module
+        gc.collect()
+        # Assert BEFORE touching: a non-pinning accessor fails here (count 0),
+        # so we never dereference freed storage.
+        assert llvm.ir.Context._get_live_module_count() == 1
+        assert touch(held)
+        del held
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 0
+    assert_no_leaks()
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda m: next(iter(m)),  # Module.__iter__ -> Function
+        lambda m: next(iter(m.get_function("f"))),  # Function.__iter__ -> BasicBlock
+        lambda m: next(iter(m.get_function("f").entry_block)),  # BB.__iter__ -> Instruction
+        lambda m: next(iter(_add(m))),  # User.__iter__ -> operand Value
+    ],
+    ids=["module_iter", "function_iter", "bb_iter", "user_iter"],
+)
+def test_iterator_element_pins_module(make):
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        held = make(mod)  # element from an iterator; the iterator is not retained
+        del mod
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 1
+        assert str(held) is not None
+        del held
+        gc.collect()
+        assert llvm.ir.Context._get_live_module_count() == 0
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
@@ -123,3 +123,15 @@ def test_iterator_element_pins_module(make):
         gc.collect()
         assert llvm.ir.Context._get_live_module_count() == 0
     assert_no_leaks()
+
+
+def test_no_module_owner_view_is_safe():
+    # A context-owned value (a constant) has no owning module, so its views get
+    # a none owner (nothing to pin). Accessing them must not crash; it simply
+    # isn't module-pinned. Exercises ownerObjectFor's no-module fold.
+    with llvm.ir.Context() as ctx:
+        c = llvm.ir.const_int(llvm.types.i32(ctx), 5)
+        assert len(c.users) == 0
+        assert len(c.uses) == 0
+        del c
+    assert_no_leaks()


### PR DESCRIPTION
Fixes the use-after-free where a Python wrapper returned by a traversal accessor could outlive the `Module` that owns its storage (dropping the module while holding the wrapper freed the storage → segfault / silent UAF). Follows MLIR's owner-reference model (`PyObjectRef` chain rooted at the storage owner, `mlir/lib/Bindings/Python/IRCore.cpp`).

**Commit 1 — Sequence views.** Each `Sequence<T>` view (`operands`/`users`/`uses`/`instructions`/`args`/`basic_blocks`/`functions`) stores a strong `nb::object` reference to the owning `Module`, and every element yielded by `__getitem__` is `keep_alive`'d to that owner. Resolving the owner from a bare `llvm::Value` uses a new `llvm::Module* → eudsl::Module*` registry (populated in the `Module` ctors, erased in the dtor) + `nb::find`.

**Commit 2 — all other accessors + iterators (general fix).**
- `get_function`/`get_global_variable` were `rv_policy::reference` (pinned nothing), breaking the `reference_internal` chain every downstream scalar accessor (`arg`, `entry_block`, `operand`, `.parent`, `.terminator`, `initializer`, `aliasee`, `resolver`, `block_address`, `use.user`, …) relies on. Made them `reference_internal` so the whole scalar graph roots at the owning `Module`.
- `make_iterator` yielded elements with no keep-alive; passing `nb::keep_alive<0,1>` to each `make_iterator` pins element→iterator, which combined with the existing keep-alive on the `__iter__` def (iterator→container) roots iterated elements at the module too.

Values with no owning module (e.g. constants) get a `none` owner and are unchanged; their lifetime rides the `reference_internal` chain to whatever module-owned parent produced them.

**Tests.** `test_lazy_views.py::test_nested_view_outlives_module` (previously a segfault) plus `test_value_lifetimes.py` — for **every** Value-returning accessor and **every** iterator, hold only the result, drop the module, assert the module stays live (`== 1`) *before* touching the result, then that dropping it releases the module (`== 0`). The count assertion precedes any dereference, so a non-pinning accessor fails cleanly rather than segfaulting. Full suite: 340 passed, leak gate green.

Split out of #564 (this is an ownership fix, unrelated to the `nb::is_generic` types port).