### PR TITLE
[eudsl-llvmpy] Drop the eudsl-tblgen coexistence test

### DIFF
--- a/.github/workflows/build_test_release_eudsl.yml
+++ b/.github/workflows/build_test_release_eudsl.yml
@@ -395,7 +395,7 @@ jobs:
         run: |
 
           python -m pip install pytest pytest-cov
-          python -m pip install eudsl-llvmpy eudsl-tblgen -f wheelhouse
+          python -m pip install eudsl-llvmpy -f wheelhouse
           # mlir-native-tools installs the FileCheck binary into sys.prefix/bin,
           # which llvm.testing.filecheck_with_comments locates.
           python -m pip install mlir-native-tools \
@@ -477,11 +477,10 @@ jobs:
         run: |
 
           # Build deps for the --no-build-isolation instrumented build, plus the
-          # eudsl-tblgen build dependency and the test runner.
+          # test runner.
           $python3_command -m pip install \
             "nanobind==2.12.0" ninja "scikit-build-core==0.10.7" \
             typing_extensions numpy pytest pytest-cov
-          $python3_command -m pip install eudsl-tblgen -f wheelhouse
           # mlir-native-tools installs the FileCheck binary into sys.prefix/bin,
           # which llvm.testing.filecheck_with_comments locates. Needed here too
           # (not just the Test job) since this job's pytest run exercises the

--- a/projects/eudsl-llvmpy/tests/ir/test_bindings.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_bindings.py
@@ -3,17 +3,8 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from textwrap import dedent
 
-import eudsl_tblgen  # noqa: F401
-
 import llvm
 from llvm.testing import assert_no_leaks
-
-
-def test_symbol_collision():
-    # eudsl-tblgen is a separate extension in a different nanobind domain;
-    # importing both (done at module scope above) must not clash.
-    assert eudsl_tblgen is not None
-    assert llvm is not None
 
 
 def test_smoke():


### PR DESCRIPTION
`tests/ir/test_bindings.py::test_symbol_collision` imported `eudsl_tblgen` at **module scope** solely to assert that eudsl-tblgen and llvm (two separate nanobind extensions in different domains) can be imported together without clashing.

Because the import was module-level, pytest **collection of the entire llvmpy test suite** hard-required `eudsl_tblgen` — so every llvmpy test and C++-coverage CI job had to `pip install eudsl-tblgen`, coupling the suite to a sibling package for one coexistence smoke test.

Remove the test and its import so the llvmpy suite stands alone. (`test_smoke` and the rest of the file are unchanged and still pass.)