### PR TITLE
[eudsl-llvmpy] Rewrite non-trivial IR-string checks with filecheck_with_comments

### DIFF
--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
@@ -2,7 +2,6 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ctypes
-import re
 
 import pytest
 
@@ -10,7 +9,7 @@ import llvm
 from llvm.dsl.values import with_element_type
 from llvm.ast.canonicalize import canonicalize
 from llvm.dsl.cf import LLVMCanonicalizer
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 
 def test_if_else_produces_phi():
@@ -27,13 +26,17 @@ def test_if_else_produces_phi():
                 r = yield b
             return r
 
-        printed = str(mod)
-        assert "br i1" in printed
-        assert "phi i32" in printed
-        assert "add i32" in printed
-        # Verify the phi has exactly 2 incoming edges [value, %pred].
-        phi_line = [l for l in printed.splitlines() if "phi i32" in l][0]
-        assert len(re.findall(r"\[.*?,\s*%[\w.]+\s*\]", phi_line)) == 2
+        # The if/else with `yield` lowers to a conditional branch and a 2-input
+        # phi that merges the then/else values -- ordered and SSA-bound, which a
+        # substring or edge-count regex cannot express.
+        # CHECK: define i32 @pick(i1 %[[C:.*]], i32 %[[A:.*]], i32 %[[B:.*]])
+        # CHECK: br i1 %[[C]], label %if.then, label %if.else
+        # CHECK: if.then:
+        # CHECK: %[[ADD:.*]] = add i32 %[[A]], 1
+        # CHECK: if.end:
+        # CHECK: %[[PHI:.*]] = phi i32 [ %[[ADD]], %if.then ], [ %[[B]], %if.else ]
+        # CHECK: ret i32 %[[PHI]]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -683,10 +686,10 @@ def test_if_else_phi_has_correct_incomings():
             return r
 
         mod.verify()
-        printed = str(mod)
-        assert printed.count("phi i32") == 1
-        phi_line = [l for l in printed.splitlines() if "phi i32" in l][0]
-        assert len(re.findall(r"\[.*?,\s*%[\w.]+\s*\]", phi_line)) == 2
+        # Exactly one phi, with two incoming edges from the then/else preds.
+        assert str(mod).count("phi i32") == 1
+        # CHECK: %{{.*}} = phi i32 [ {{.*}}, %if.then ], [ {{.*}}, %if.else ]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 def test_while_loop_verifies_cleanly():

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
@@ -7,7 +7,7 @@ import pytest
 import llvm
 from llvm.ast.canonicalize import canonicalize
 from llvm.dsl.cf import LLVMCanonicalizer
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 
 def test_break_raises():
@@ -96,6 +96,8 @@ def test_trailing_return_is_allowed():
                 r = yield b
             return r
 
-        assert "phi i32" in str(mod)
+        # The trailing return produces a merge phi rather than being rejected.
+        # CHECK: %{{.*}} = phi i32 [ {{.*}}, %if.then ], [ {{.*}}, %if.else ]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_coverage.py
@@ -11,7 +11,7 @@ from llvm.dsl import casters as _c
 from llvm.dsl.casters import maybe_downcast, register_value_caster
 from llvm.dsl.context import building, current_builder, current_function
 from llvm.dsl.values import ArithValue, with_element_type, extract
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 
 def _entry(ctx, mod, ret_ty, arg_tys, name="f"):
@@ -89,7 +89,9 @@ def test_float_scalar_coercion():
         bld = llvm.ir.IRBuilder(ctx)
         with bld.at_end_of(bb), building(bld):
             bld.ret(a + 1.5)  # float ArithValue + Python float -> const_fp
-        assert "fadd float" in str(mod)
+        # CHECK: %[[R:.*]] = fadd float %0, 1.500000e+00
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del bld, fn, mod
     assert_no_leaks()
 
@@ -158,7 +160,10 @@ def test_typed_pointer_setitem_with_value_index():
             idx = maybe_downcast(fn.arg(1), fn)
             tp[idx] = llvm.ir.const_int(i32, 9)  # Value index (not int)
             bld.ret(None)
-        assert "getelementptr" in str(mod)
+        # A Value (not python-int) index threads straight into the gep operand.
+        # CHECK: %[[P:.*]] = getelementptr i32, ptr %0, i32 %1
+        # CHECK: store i32 9, ptr %[[P]]
+        filecheck_with_comments(mod)
         del bld, fn, mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
@@ -225,8 +225,10 @@ def test_real_body_is_not_treated_as_empty():
         def f(x: i32) -> i32:
             return x + 1
 
-        assert "define i32 @f" in str(mod)
-        assert "add i32" in str(mod)
+        # CHECK: define i32 @f(i32 %[[X:.*]])
+        # CHECK: %[[R:.*]] = add i32 %[[X]], 1
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -247,9 +249,12 @@ def test_call_declared_extern_from_function_body():
     def caller(x: i32) -> i32:
         return add_one(extern(x))
 
-    printed = str(mod)
-    assert "call i32 @extern" in printed
-    assert "call i32 @add_one" in printed
+    # The nesting add_one(extern(x)) threads extern's result into add_one, in
+    # that order -- an SSA-bound, ordered check a substring cannot express.
+    # CHECK: %[[E:.*]] = call i32 @extern(i32 %0)
+    # CHECK: %[[A:.*]] = call i32 @add_one(i32 %[[E]])
+    # CHECK: ret i32 %[[A]]
+    filecheck_with_comments(mod)
     del mod, ctx, add_one, extern, caller, i32
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_values.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_values.py
@@ -7,7 +7,7 @@ import llvm
 from llvm.dsl.casters import maybe_downcast, register_value_caster
 from llvm.dsl.context import building, current_builder, current_function
 from llvm.dsl.values import ArithValue, extract, with_element_type
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 
 def _entry(ctx, mod, ret_ty, arg_tys, name="f"):
@@ -38,9 +38,10 @@ def test_integer_add_and_mul():
             r = args[0] * args[1] + 1
             assert isinstance(r, ArithValue)  # result stays typed
             b.ret(r)
-        printed = str(mod)
-        assert "mul i32" in printed
-        assert "add i32" in printed
+        # CHECK: %[[M:.*]] = mul i32 %0, %1
+        # CHECK: %[[A:.*]] = add i32 %[[M]], 1
+        # CHECK: ret i32 %[[A]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -53,37 +54,54 @@ def test_float_add_uses_fadd():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] + args[1])
-        assert "fadd float" in str(mod)
+        # CHECK: %[[R:.*]] = fadd float %0, %1
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
 
-def test_float_remaining_arithmetic():
+def test_float_sub_uses_fsub():
     with llvm.ir.Context() as ctx:
-        f32 = llvm.types.f32()
-        
         mod = llvm.ir.Module("m", ctx)
+        f32 = llvm.types.f32()
         fn, bb, args = _entry(ctx, mod, f32, [f32, f32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] - args[1])
-        assert "fsub float" in str(mod)
+        # CHECK: %[[R:.*]] = fsub float %0, %1
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m2", ctx)
+
+def test_float_mul_uses_fmul():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        f32 = llvm.types.f32()
         fn, bb, args = _entry(ctx, mod, f32, [f32, f32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] * args[1])
-        assert "fmul float" in str(mod)
+        # CHECK: %[[R:.*]] = fmul float %0, %1
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m3", ctx)
+
+def test_float_div_uses_fdiv():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        f32 = llvm.types.f32()
         fn, bb, args = _entry(ctx, mod, f32, [f32, f32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] / args[1])
-        assert "fdiv float" in str(mod)
+        # CHECK: %[[R:.*]] = fdiv float %0, %1
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -96,7 +114,9 @@ def test_float_scalar_coercion():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] + 1.5)
-        assert "fadd float %0, 1.500000e+00" in str(mod)
+        # CHECK: %[[R:.*]] = fadd float %0, 1.500000e+00
+        # CHECK: ret float %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -109,12 +129,14 @@ def test_scalar_coercion():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] + 7)
-        assert "add i32 %0, 7" in str(mod)
+        # CHECK: %[[R:.*]] = add i32 %0, 7
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
 
-def test_remaining_arithmetic_dunders():
+def test_integer_sub():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32()
@@ -122,47 +144,84 @@ def test_remaining_arithmetic_dunders():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] - args[1])
-        assert "sub i32" in str(mod)
+        # CHECK: %[[R:.*]] = sub i32 %0, %1
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m2", ctx)
+
+def test_integer_div_uses_sdiv():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, i32, [i32, i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] / args[1])
-        assert "sdiv i32" in str(mod)
+        # CHECK: %[[R:.*]] = sdiv i32 %0, %1
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m3", ctx)
+
+def test_integer_radd():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, i32, [i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(7 + args[0])
-        assert "add i32 %0, 7" in str(mod)
+        # CHECK: %[[R:.*]] = add i32 %0, 7
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m4", ctx)
+
+def test_integer_rmul():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, i32, [i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(7 * args[0])
-        assert "mul i32 %0, 7" in str(mod)
+        # CHECK: %[[R:.*]] = mul i32 %0, 7
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m5", ctx)
+
+def test_integer_rsub():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, i32, [i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(7 - args[0])
-        assert "sub i32 7, %0" in str(mod)
+        # CHECK: %[[R:.*]] = sub i32 7, %0
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m6", ctx)
+
+def test_integer_rdiv():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, i32, [i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(7 / args[0])
-        assert "sdiv i32 7, %0" in str(mod)
+        # CHECK: %[[R:.*]] = sdiv i32 7, %0
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -183,7 +242,7 @@ def test_mismatched_types_raises_typeerror():
     assert_no_leaks()
 
 
-def test_le_ge_ne_comparisons():
+def test_le_uses_sle():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32()
@@ -191,23 +250,39 @@ def test_le_ge_ne_comparisons():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] <= args[1])
-        assert "icmp sle i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp sle i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m2", ctx)
+
+def test_ge_uses_sge():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, llvm.types.i1(), [i32, i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] >= args[1])
-        assert "icmp sge i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp sge i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
+    assert_no_leaks()
 
-        mod = llvm.ir.Module("m3", ctx)
+
+def test_ne_named_method():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32()
         fn, bb, args = _entry(ctx, mod, llvm.types.i1(), [i32, i32])
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0].ne(args[1]))
-        assert "icmp ne i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp ne i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -220,7 +295,9 @@ def test_integer_comparison_signed():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] < args[1])
-        assert "icmp slt i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp slt i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -233,7 +310,9 @@ def test_float_comparison_ordered():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] > args[1])
-        assert "fcmp ogt float" in str(mod)
+        # CHECK: %[[R:.*]] = fcmp ogt float %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -247,7 +326,9 @@ def test_integer_gt_uses_sgt():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] > args[1])
-        assert "icmp sgt i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp sgt i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, bb, args, mod
     assert_no_leaks()
 
@@ -261,23 +342,44 @@ def test_float_lt_uses_olt():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0] < args[1])
-        assert "fcmp olt float" in str(mod)
+        # CHECK: %[[R:.*]] = fcmp olt float %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, bb, args, mod
     assert_no_leaks()
 
 
-def test_double_and_half_are_arithvalue():
-    # The float caster is registered for Half/Double too, not just Float.
+def test_double_is_arithvalue():
+    # The float caster is registered for Double too, not just Float.
     with llvm.ir.Context() as ctx:
-        for ty, want in ((llvm.types.f64(), "fadd double"), (llvm.types.f16(), "fadd half")):
-            mod = llvm.ir.Module("m", ctx)
-            fn, bb, args = _entry(ctx, mod, ty, [ty, ty])
-            b = llvm.ir.IRBuilder(ctx)
-            with b.at_end_of(bb), building(b):
-                assert isinstance(args[0], ArithValue)
-                b.ret(args[0] + args[1])
-            assert want in str(mod)
-            del b, fn, bb, args, mod
+        f64 = llvm.types.f64()
+        mod = llvm.ir.Module("m", ctx)
+        fn, bb, args = _entry(ctx, mod, f64, [f64, f64])
+        b = llvm.ir.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b):
+            assert isinstance(args[0], ArithValue)
+            b.ret(args[0] + args[1])
+        # CHECK: %[[R:.*]] = fadd double %0, %1
+        # CHECK: ret double %[[R]]
+        filecheck_with_comments(mod)
+        del b, fn, bb, args, mod
+    assert_no_leaks()
+
+
+def test_half_is_arithvalue():
+    # The float caster is registered for Half too, not just Float.
+    with llvm.ir.Context() as ctx:
+        f16 = llvm.types.f16()
+        mod = llvm.ir.Module("m", ctx)
+        fn, bb, args = _entry(ctx, mod, f16, [f16, f16])
+        b = llvm.ir.IRBuilder(ctx)
+        with b.at_end_of(bb), building(b):
+            assert isinstance(args[0], ArithValue)
+            b.ret(args[0] + args[1])
+        # CHECK: %[[R:.*]] = fadd half %0, %1
+        # CHECK: ret half %[[R]]
+        filecheck_with_comments(mod)
+        del b, fn, bb, args, mod
     assert_no_leaks()
 
 
@@ -289,7 +391,9 @@ def test_eq_ne_named_methods():
         b = llvm.ir.IRBuilder(ctx)
         with b.at_end_of(bb), building(b):
             b.ret(args[0].eq(args[1]))
-        assert "icmp eq i32" in str(mod)
+        # CHECK: %[[R:.*]] = icmp eq i32 %0, %1
+        # CHECK: ret i1 %[[R]]
+        filecheck_with_comments(mod)
         # __eq__ stays identity so the value is still hashable.
         assert type(args[0] == args[0]) is bool
         assert args[0] == args[0]
@@ -311,10 +415,12 @@ def test_gep_load_store_via_alloca():
             p[0] = llvm.ir.const_int(i32, 5)
             v = p[0]
             b.ret(v)
-        printed = str(mod)
-        assert "getelementptr i32" in printed
-        assert "store i32 5" in printed
-        assert "load i32" in printed
+        # CHECK: %[[P0:.*]] = getelementptr i32, ptr %slot, i64 0
+        # CHECK: store i32 5, ptr %[[P0]]
+        # CHECK: %[[P1:.*]] = getelementptr i32, ptr %slot, i64 0
+        # CHECK: %[[V:.*]] = load i32, ptr %[[P1]]
+        # CHECK: ret i32 %[[V]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -331,9 +437,11 @@ def test_pointer_subscript_returns_arithvalue():
             v = p[2]
             assert isinstance(v, ArithValue)
             b.ret(v + 1)  # typed chaining works off the loaded value
-        printed = str(mod)
-        assert "getelementptr i32" in printed
-        assert "load i32" in printed
+        # CHECK: %[[P:.*]] = getelementptr i32, ptr %0, i64 2
+        # CHECK: %[[V:.*]] = load i32, ptr %[[P]]
+        # CHECK: %[[R:.*]] = add i32 %[[V]], 1
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -353,8 +461,10 @@ def test_pointer_subscript_accepts_value_index():
             v = p[idx]
             assert isinstance(v, ArithValue)
             b.ret(v)
-        printed = str(mod)
-        assert "getelementptr i32" in printed
+        # CHECK: %[[P:.*]] = getelementptr i32, ptr %0, i64 2
+        # CHECK: %[[V:.*]] = load i32, ptr %[[P]]
+        # CHECK: ret i32 %[[V]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -371,7 +481,10 @@ def test_extract_value_from_struct_arg():
             first = extract(fn.arg(0), 0)
             assert isinstance(first, ArithValue)
             b.ret(first + 1)
-        assert "extractvalue { i32, i32 }" in str(mod)
+        # CHECK: %[[E:.*]] = extractvalue { i32, i32 } %0, 0
+        # CHECK: %[[R:.*]] = add i32 %[[E]], 1
+        # CHECK: ret i32 %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 
@@ -389,7 +502,9 @@ def test_insert_value_into_struct():
         with b.at_end_of(bb):
             updated = b.insert_value(fn.arg(0), fn.arg(1), 1)
             b.ret(updated)
-        assert "insertvalue { i32, i32 }" in str(mod)
+        # CHECK: %[[R:.*]] = insertvalue { i32, i32 } %0, i32 %1, 1
+        # CHECK: ret { i32, i32 } %[[R]]
+        filecheck_with_comments(mod)
         del b, fn, mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/ir/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_delegating_accessors.py
@@ -19,7 +19,7 @@ file exercises those bindings and checks their results.
 from textwrap import dedent
 
 import llvm
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 _SRC = dedent(
     """\
@@ -69,8 +69,9 @@ def test_replace_all_uses_with():
         zero = llvm.ir.const_int(llvm.types.i32(ctx), 0)
         add.replace_all_uses_with(zero)
         # The ret now returns the constant; the (dead) add is untouched.
-        assert "ret i32 0" in str(mod)
-        assert "%sum = add" in str(mod)
+        # CHECK: %sum = add i32 %x, %y
+        # CHECK: ret i32 0
+        filecheck_with_comments(mod)
         del f, add, zero, mod
     assert_no_leaks()
 
@@ -254,7 +255,8 @@ def test_value_name_setter_and_instruction_props():
         assert add.parent == entry  # Instruction.parent
         add.name = "renamed"  # Value.name setter
         assert add.name == "renamed"
-        assert "%renamed = add" in str(mod)
+        # CHECK: %renamed = add i32 %x, %y
+        filecheck_with_comments(mod)
         del f, entry, add, ret, mod
     assert_no_leaks()
 
@@ -286,6 +288,8 @@ def test_instruction_set_successor():
         c_block = next(b for b in f.basic_blocks if b.name == "c")
         br.set_successor(0, c_block)  # redirect the true edge from a to c
         assert br.successor(0).name == "c"
-        assert "br i1 %cond, label %c, label %b" in str(mod)
+        # The true edge now targets %c; the false edge is unchanged.
+        # CHECK: br i1 %cond, label %c, label %b
+        filecheck_with_comments(mod)
         del f, br, c_block, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/passmanager/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_passes.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import pytest
 
 import llvm
-from llvm.testing import assert_no_leaks
+from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 _SRC = dedent(
     """\
@@ -24,9 +24,10 @@ def test_instcombine_removes_add_zero():
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         assert "add i32 %x, 0" in str(mod)
         llvm.passmanager.run_passes(mod, "instcombine")
-        printed = str(mod)
-        assert "add i32 %x, 0" not in printed
-        assert "ret i32 %x" in printed
+        # instcombine folds `add %x, 0` away -> the function returns %x directly.
+        # CHECK-NOT: add i32 %x, 0
+        # CHECK: ret i32 %x
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -63,9 +64,9 @@ def test_default_pipeline_o2():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         llvm.passmanager.run_default_pipeline(mod, llvm.passmanager.OptLevel.O2)
-        printed = str(mod)
-        assert "add i32 %x, 0" not in printed
-        assert "ret i32 %x" in printed
+        # CHECK-NOT: add i32 %x, 0
+        # CHECK: ret i32 %x
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -86,9 +87,9 @@ def test_default_pipeline_with_tuning():
         pto.loop_vectorization = False
         pto.slp_vectorization = False
         llvm.passmanager.run_default_pipeline(mod, llvm.passmanager.OptLevel.O2, tuning=pto)
-        printed = str(mod)
-        assert "add i32 %x, 0" not in printed
-        assert "ret i32 %x" in printed
+        # CHECK-NOT: add i32 %x, 0
+        # CHECK: ret i32 %x
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -106,7 +107,8 @@ def test_run_passes_with_debug(capsys):
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         llvm.passmanager.run_passes(mod, "instcombine", debug=True)
-        assert "add i32 %x, 0" not in str(mod)
+        # CHECK-NOT: add i32 %x, 0
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 
@@ -115,7 +117,8 @@ def test_run_passes_with_verify_each():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         llvm.passmanager.run_passes(mod, "instcombine", verify_each=True)
-        assert "ret i32 %x" in str(mod)
+        # CHECK: ret i32 %x
+        filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
 


### PR DESCRIPTION
Ports the printed-IR assertions that verify **structure** — multi-line, ordered, SSA-operand-threaded, branch/phi, or regex — from substring `in` / `re` checks to ordered, SSA-bound `filecheck_with_comments` (the real LLVM FileCheck), which fails on a mismatch and binds def-use edges a substring cannot.

**Left as plain asserts** (per scope): single-line `declare`/`define` signature lines, bare markers (`ret void`, `target datalayout`), name/attribute equality, metadata/module-header content, and error-message matches.

### Converted
- **test_dsl_values.py** — arithmetic / compare / gep / extract / insert checks become `op → operands → result` CHECK chains. The multi-module functions (float & integer remaining arithmetic, le/ge/ne, double/half) are split into one module per test so each has its own check-file.
- **test_dsl_func.py** — the real-body and nested-call `add_one(extern(x))` tests get SSA-bound, order-preserving checks.
- **test_dsl_cf.py / test_dsl_cf_reject.py** — the if/else phi edge-count regex becomes a full phi-line check binding both incoming `[value, %pred]` edges; drops the now-unused `re` import.
- **test_dsl_coverage.py** — fadd / gep checks bind operands.
- **test_passes.py** — pass effects become `CHECK-NOT` (add-zero removed) / `CHECK` (`ret %x`) on the post-pass module.
- **test_delegating_accessors.py** — RAUW, rename, and `set_successor` checks become SSA / branch-structural checks.

Test-only; no C++ changes. Full suite green (370 passed, Python coverage 99.53%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)