### PR TITLE
[eudsl-llvmpy] Add llvm.instructions + extend IRBuilder to the full instruction set

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -6,8 +6,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # eudsl-llvmpy
 
-Python bindings for LLVM IR, plus a small DSL for authoring IR from Python. Both
-ship in the top-level `llvm` package.
+Python bindings for LLVM IR, plus a small DSL for authoring IR from Python.
 
 There are two layers. The lower one is a hand-written [nanobind](https://github.com/wjakob/nanobind)
 wrapper over the LLVM **C++** API, so the Python class hierarchy mirrors
@@ -18,56 +17,68 @@ whose control flow is lowered to basic blocks and phi nodes.
 
 The DSL sits on top of the bindings. You can use the bindings alone.
 
+## Package layout
+
+The API is organized into submodules, MLIR-style; nothing is re-exported at the
+package top level:
+
+- `llvm.ir` — `Context`, `Module`, `Function`, `BasicBlock`, `IRBuilder`,
+  `InsertPoint`, the `Value` hierarchy, constants (`const_int`, `const_fp`,
+  `const_bool`), `parse_assembly`, metadata, and the `CmpPredicate` /
+  `AtomicOrdering` / `AtomicRMWBinOp` enums.
+- `llvm.types` — the `Type` factories (`i1`…`i64`, `f16`/`f32`/`f64`, `ptr`,
+  `void`, `function`, `struct`, `array`, `vector`) and `TypeID`.
+- `llvm.instructions` — free-function instruction emitters.
+- `llvm.passmanager` — `run_passes`, `run_default_pipeline`.
+- `llvm.jit` — `LLJIT`, `TargetMachine`, `link_into`, `host_triple`,
+  `registered_targets`.
+- `llvm.intrinsics` — intrinsic declarations by name.
+- `llvm.dsl` — the `@function` decorator, `range_`, and the control-flow
+  machinery.
+
 ## Object layer
 
 Comparable in reach to `llvmlite`, with its own API rather than a compatible
 shim. Bound surface:
 
-- **Context and Module** with real ownership. A `Context` is a context manager;
-  leaving the block frees the underlying `LLVMContext`, and touching anything
-  that outlived it raises instead of segfaulting. `Context._get_live_count()`
-  reports live objects for leak checks.
-- **The `Type` hierarchy**: integers, floats, pointers, structs (named and
-  literal), arrays, vectors, functions. Values downcast to their concrete
-  Python class automatically.
+- **Context and Module** with real ownership. A `llvm.ir.Context` is a context
+  manager; leaving the block frees the underlying `LLVMContext`, and touching
+  anything that outlived it raises instead of segfaulting.
+  `Context._get_live_count()` reports live objects for leak checks.
+- **The `Type` hierarchy** (`llvm.types`): integers, floats, pointers, structs
+  (named and literal), arrays, vectors, functions. Values downcast to their
+  concrete Python class automatically.
 - **The `Value` hierarchy** down to the instruction classes worth traversing:
   `PHINode`, `CallInst`, `GetElementPtrInst`, `AllocaInst`, `LoadInst`,
-  `StoreInst`, and the branch and compare instructions. `Argument`,
-  `BasicBlock`, `Function`, `GlobalVariable`, and the `Constant` subclasses are
-  all here too.
-- **`IRBuilder`** with a `with builder.at_end_of(block):` insertion-point
-  context manager.
+  `StoreInst`, the atomics, and the branch and compare instructions.
+  `Argument`, `BasicBlock`, `Function`, `GlobalVariable`, and the `Constant`
+  subclasses are all here too.
+- **`IRBuilder`** with an MLIR-style insertion-point model (see below).
 - **Attributes, linkage, visibility, calling convention.**
 - **Metadata**: `MDString`, `MDNode`, named module metadata.
 - **Errors as exceptions.** A bad parse raises `ParseError`, a failed
   `verify()` raises `VerifyError`, and any `llvm::Expected`/`llvm::Error`
   failure raises `RuntimeError` carrying the LLVM message.
 - **Verify, and bitcode read/write.**
-- **Optimization** through `llvm.run_passes(module, "instcombine,gvn")`, which
-  runs a new-pass-manager pipeline parsed from the string and raises on an
+- **Optimization** through `llvm.passmanager.run_passes(module, "instcombine,gvn")`,
+  which runs a new-pass-manager pipeline parsed from the string and raises on an
   unknown pass.
-- **`Target`, `TargetMachine`, `DataLayout`**, with assembly and object
-  emission.
-- **Module linking** through `llvm.link_into(dest, src)`, which raises on
+- **`TargetMachine`** (`llvm.jit`), with assembly and object emission;
+  `host_triple()` and `registered_targets()`.
+- **Module linking** through `llvm.jit.link_into(dest, src)`, which raises on
   conflicting symbols.
 - **ORC `LLJIT`**: add a module, look up a symbol, get an address you can call
   through `ctypes`.
-- **Intrinsics** by name. Import `llvm.intrinsics`, then
-  `llvm.intrinsics.sqrt(module, [f64])` resolves the intrinsic ID, uses the
-  given overload types, and inserts the declaration, all against LLVM's own
-  tables. The primitives `lookup_intrinsic_id`, `intrinsic_is_overloaded`, and
-  `get_intrinsic_declaration` are there too.
-
-Because `llvm::Value` and `llvm::Type` have no vtables, nanobind's RTTI-based
-downcasting can't apply. The bindings use `nanobind::detail::type_hook` keyed on
-`Value.def`/`Instruction.def` and `Type::TypeID` to pick the right Python class
-for a returned pointer.
+- **Intrinsics** by name. `llvm.intrinsics.sqrt(module, [f64])` resolves the
+  intrinsic ID, uses the given overload types, and inserts the declaration, all
+  against LLVM's own tables. The primitives `lookup_intrinsic_id`,
+  `intrinsic_is_overloaded`, and `get_intrinsic_declaration` are there too.
 
 ```python
 import llvm
 
-with llvm.Context() as ctx:
-    mod = llvm.parse_assembly(
+with llvm.ir.Context() as ctx:
+    mod = llvm.ir.parse_assembly(
         "define i32 @f(i32 %x) {\n"
         "entry:\n"
         "  %s = add i32 %x, 1\n"
@@ -80,57 +91,97 @@ with llvm.Context() as ctx:
     print(type(add).__name__)  # BinaryOperator
 ```
 
+### Building IR: insertion points and instruction emitters
+
+An `IRBuilder` carries an insertion point. `with InsertPoint(...):` positions it
+and restores the previous point on exit, mirroring MLIR's `ir.InsertionPoint`:
+`InsertPoint(block)` appends at the end of a block, `InsertPoint(instruction)`
+inserts before an instruction, and there are `InsertPoint.at_block_begin`,
+`at_block_terminator`, and `after` factories. Entering `with builder:` (or
+passing `builder=` to `InsertPoint`) makes a builder the *contextual* builder,
+so `current_builder()` and `current_function()` resolve without threading the
+builder through every call.
+
+`llvm.instructions` provides a free function for every `IRBuilder` emitter
+(`add`, `load`, `gep`, `icmp`, `select`, `switch_`, `atomic_rmw`, `call`, …).
+Each takes an optional keyword-only `builder`; when omitted it uses the
+contextual builder. Plain Python numbers are materialized into constants of the
+inferred type (a sibling operand's type, the function's return type for `ret`,
+or the callee's parameter type for `call`), so you can write `add(x, 1)` or
+`ret(0)` directly.
+
+```python
+import llvm
+from llvm import ir, types
+from llvm import instructions as I
+
+with ir.Context() as ctx:
+    i32 = types.i32()
+    mod = ir.Module("m", ctx)
+    fn = ir.Function.create(types.function(i32, [i32]), "inc", mod)
+    b = ir.IRBuilder(ctx)
+    with ir.InsertPoint(fn.append_basic_block("entry"), builder=b):
+        I.ret(I.add(fn.arg(0), 1, "s"))   # `1` becomes an i32 constant
+    print(str(mod))
+```
+
 ## DSL layer
 
-Decorate a function with `@llvm.function`. Type annotations are LLVM types.
-Arithmetic and comparison operators emit the matching instruction, dispatched on
-the operand type: `+` becomes `add` for integers and `fadd` for floats, `<`
-becomes `icmp slt` or `fcmp olt`. A Python `int` or `float` operand coerces to a
-constant of the other side's type. This matches `ArithValue` in
+Decorate a function with `@llvm.dsl.function(module=...)`. Type annotations are
+LLVM types. Arithmetic and comparison operators emit the matching instruction,
+dispatched on the operand type: `+` becomes `add` for integers and `fadd` for
+floats, `<` becomes `icmp slt` or `fcmp olt`. A Python `int` or `float` operand
+coerces to a constant of the other side's type. This matches `ArithValue` in
 `eudsl-python-extras` so moving between the MLIR DSL and this one costs nothing.
 
 ```python
 import ctypes
 import llvm
-from llvm.dsl.cf import range_
+from llvm import ir, types, jit
+from llvm.dsl import function, range_
+from llvm.ast.canonicalize import canonicalize
+from llvm.dsl.cf import LLVMCanonicalizer
 
-ctx = llvm.Context()
-mod = llvm.Module("m", ctx)
-i32 = llvm.i32(ctx)
+ctx = ir.Context()
+mod = ir.Module("m", ctx)
+i32 = types.i32(ctx)
 
-@llvm.function(module=mod)
+@function(module=mod)
 def inc(x: i32) -> i32:
     return x + 1
 
-@llvm.function(module=mod)
+@function(module=mod)
+@canonicalize(using=LLVMCanonicalizer())
 def total(n: i32) -> i32:
-    acc = llvm.const_int(i32, 0)
+    acc = ir.const_int(i32, 0)
     for i in range_(0, n):
         acc = acc + i
         yield acc          # loop-carried value -> phi at the header
     return acc
 
-jit = llvm.LLJIT()
-jit.add_module(mod)
-f = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
+j = jit.LLJIT()
+j.add_module(mod)
+f = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(j.lookup("total"))
 assert f(5) == 0 + 1 + 2 + 3 + 4
 ```
 
 Control flow uses a `yield` protocol borrowed from `eudsl-python-extras`' `scf`
-dialect. An AST canonicalizer rewrites `if`/`elif`/`else`/`while`/`for` into
-basic blocks, and any value you `yield` out of a region becomes a phi node at
-the join or loop header. `if` produces a branch and a join-block phi. `while`
-and `for` produce a header/body/exit structure with loop-carried phis for
-whatever the body yields. `for i in range_(lo, hi, step)` gives you an induction
-variable.
+dialect. Functions that use `if`/`elif`/`else`/`while`/`for` add
+`@canonicalize(using=LLVMCanonicalizer())` beneath `@function`; the canonicalizer
+rewrites those statements into basic blocks, and any value you `yield` out of a
+region becomes a phi node at the join or loop header. `if` produces a branch and
+a join-block phi. `while` and `for` produce a header/body/exit structure with
+loop-carried phis for whatever the body yields. `for i in range_(lo, hi, step)`
+gives you an induction variable.
 
-`@llvm.function` also covers declarations (an empty `...` body), definitions,
-calls between decorated functions (via `__call__`), multiple return values,
-function attributes, linkage, calling convention, and varargs.
+`@function` also covers declarations (an empty `...` body), definitions, calls
+between decorated functions (via `__call__`), multiple return values, function
+attributes, linkage, calling convention, and varargs.
 
 ```python
-@llvm.function(module=mod)
-def pick(c: llvm.i1, a: i32, b: i32) -> i32:
+@function(module=mod)
+@canonicalize(using=LLVMCanonicalizer())
+def pick(c: types.i1(ctx), a: i32, b: i32) -> i32:
     if c:
         r = yield a + 1
     else:
@@ -142,31 +193,26 @@ def pick(c: llvm.i1, a: i32, b: i32) -> i32:
 
 Like MLIR's `register_value_caster`, you can register a Python subclass to wrap
 values of a given type kind. The DSL uses this to make integer and float values
-come back as `ArithValue` (the class carrying the operator overloads). The
-registry lives in Python (`llvm.dsl.casters`), so nothing holds Python
-references at interpreter shutdown; C++ exposes only a stateless
-`_wrap_value_as` primitive.
+come back as `ArithValue` (the class carrying the operator overloads).
 
 ```python
+from llvm import ir
+from llvm.types import TypeID
 from llvm.dsl.casters import register_value_caster
-from llvm.eudslllvm_ext import TypeID
 
 @register_value_caster(TypeID.Integer)
-class MyInt(llvm.Value):
+class MyInt(ir.Value):
     ...
 ```
 
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not
-  supported.** The loop transforms lift a body into a nested function that the
-  `if`/`else` transformer does not revisit, so a bare `break` or `return` there
-  would emit wrong IR silently. The transformer detects these and raises
-  `NotImplementedError` with a message rather than miscompiling.
-- **Control flow nested inside a loop body is rejected** for the same reason.
-  An `if` at the top level of a function works; an `if` inside a `while` or
-  `for` body raises `NotImplementedError`. This is the piece most worth
-  revisiting.
+  supported**, and neither is **control flow nested inside a loop body** (an
+  `if` at the top level of a function works; an `if` inside a `while` or `for`
+  body does not). The canonicalizer detects these and raises
+  `NotImplementedError` rather than emitting wrong IR. Nested control flow is
+  the piece most worth revisiting.
 - **The fatal-error path is best-effort.** LLVM's fatal error handler cannot
   return, so where a bad argument would trip it, the bindings validate up front
   and raise. A genuine LLVM fatal error still aborts the process after a warning.
@@ -175,8 +221,8 @@ class MyInt(llvm.Value):
 - **Scope of the binding.** `llvm/IR` is not bound exhaustively. The rule is:
   what the DSL needs, what `llvmlite.binding` exposes, and everything reachable
   by traversal from a `Module`. Out of scope for now: DIBuilder/DebugInfo,
-  remarks, the disassembler, object-file inspection, and ORC customization
-  points that need Python callbacks.
+  remarks, the disassembler, object-file inspection, funclet-based exception
+  handling, and ORC customization points that need Python callbacks.
 - **Targets.** The build links host targets only by default (AArch64 and X86).
   AMDGPU and NVPTX stay reachable through the `EUDSL_LLVMPY_TARGETS` CMake
   option. Emitting AMDGCN assembly never needed an AMD device; only running it

--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -7,6 +7,8 @@
 
 #include <llvm/IR/Function.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
 
 #include <iterator>
 #include <vector>
@@ -125,8 +127,57 @@ void populate_builder(nb::module_ &m) {
       EUDSL_BIN("sdiv", CreateSDiv)
       EUDSL_BIN("udiv", CreateUDiv)
       EUDSL_BIN("fdiv", CreateFDiv)
+      EUDSL_BIN("srem", CreateSRem)
+      EUDSL_BIN("urem", CreateURem)
+      EUDSL_BIN("frem", CreateFRem)
+      EUDSL_BIN("shl", CreateShl)
+      EUDSL_BIN("lshr", CreateLShr)
+      EUDSL_BIN("ashr", CreateAShr)
+      EUDSL_BIN("and_", CreateAnd)
+      EUDSL_BIN("or_", CreateOr)
+      EUDSL_BIN("xor", CreateXor)
       // clang-format on
 #undef EUDSL_BIN
+      // Unary ops: (value, name) -> value.
+#define EUDSL_UNARY(pyName, method)                                            \
+  .def(                                                                        \
+      pyName,                                                                  \
+      [](B &self, llvm::Value *v, const std::string &name) -> llvm::Value * {  \
+        return self.method(v, name);                                           \
+      },                                                                       \
+      "value"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      // clang-format off
+      EUDSL_UNARY("neg", CreateNeg)
+      EUDSL_UNARY("fneg", CreateFNeg)
+      EUDSL_UNARY("not_", CreateNot)
+      EUDSL_UNARY("ptrtoaddr", CreatePtrToAddr)
+      // clang-format on
+#undef EUDSL_UNARY
+      // Casts: (value, dest_type, name) -> value.
+#define EUDSL_CAST(pyName, method)                                             \
+  .def(                                                                        \
+      pyName,                                                                  \
+      [](B &self, llvm::Value *v, llvm::Type *ty,                              \
+         const std::string &name) -> llvm::Value * {                          \
+        return self.method(v, ty, name);                                       \
+      },                                                                       \
+      "value"_a, "dest_type"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      // clang-format off
+      EUDSL_CAST("trunc", CreateTrunc)
+      EUDSL_CAST("zext", CreateZExt)
+      EUDSL_CAST("sext", CreateSExt)
+      EUDSL_CAST("fptoui", CreateFPToUI)
+      EUDSL_CAST("fptosi", CreateFPToSI)
+      EUDSL_CAST("uitofp", CreateUIToFP)
+      EUDSL_CAST("sitofp", CreateSIToFP)
+      EUDSL_CAST("fptrunc", CreateFPTrunc)
+      EUDSL_CAST("fpext", CreateFPExt)
+      EUDSL_CAST("ptrtoint", CreatePtrToInt)
+      EUDSL_CAST("inttoptr", CreateIntToPtr)
+      EUDSL_CAST("bitcast", CreateBitCast)
+      EUDSL_CAST("addrspacecast", CreateAddrSpaceCast)
+      // clang-format on
+#undef EUDSL_CAST
       .def(
           "icmp",
           [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l, llvm::Value *r,
@@ -207,6 +258,149 @@ void populate_builder(nb::module_ &m) {
             return self.CreateInsertValue(agg, val, {idx}, name);
           },
           "aggregate"_a, "value"_a, "index"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "select",
+          [](B &self, llvm::Value *cond, llvm::Value *t, llvm::Value *f,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateSelect(cond, t, f, name);
+          },
+          "cond"_a, "true_value"_a, "false_value"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "freeze",
+          [](B &self, llvm::Value *v, const std::string &name) -> llvm::Value * {
+            return self.CreateFreeze(v, name);
+          },
+          "value"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "extract_element",
+          [](B &self, llvm::Value *vec, llvm::Value *idx,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateExtractElement(vec, idx, name);
+          },
+          "vector"_a, "index"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "insert_element",
+          [](B &self, llvm::Value *vec, llvm::Value *elt, llvm::Value *idx,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateInsertElement(vec, elt, idx, name);
+          },
+          "vector"_a, "element"_a, "index"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "shuffle_vector",
+          [](B &self, llvm::Value *v1, llvm::Value *v2, std::vector<int> mask,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateShuffleVector(v1, v2, mask, name);
+          },
+          "v1"_a, "v2"_a, "mask"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "va_arg",
+          [](B &self, llvm::Value *list, llvm::Type *ty,
+             const std::string &name) -> llvm::Value * {
+            return self.CreateVAArg(list, ty, name);
+          },
+          "arg_list"_a, "type"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "unreachable",
+          [](B &self) -> llvm::Value * { return self.CreateUnreachable(); },
+          nb::rv_policy::reference_internal)
+      .def(
+          "switch_",
+          [](B &self, llvm::Value *v, llvm::BasicBlock *dest,
+             unsigned num_cases) -> llvm::SwitchInst * {
+            return self.CreateSwitch(v, dest, num_cases);
+          },
+          "value"_a, "default_dest"_a, "num_cases"_a = 10,
+          nb::rv_policy::reference_internal)
+      .def(
+          "indirect_br",
+          [](B &self, llvm::Value *addr,
+             unsigned num_dests) -> llvm::IndirectBrInst * {
+            return self.CreateIndirectBr(addr, num_dests);
+          },
+          "address"_a, "num_dests"_a = 10, nb::rv_policy::reference_internal)
+      .def(
+          "resume",
+          [](B &self, llvm::Value *exn) -> llvm::Value * {
+            return self.CreateResume(exn);
+          },
+          "exn"_a, nb::rv_policy::reference_internal)
+      .def(
+          "fence",
+          [](B &self, llvm::AtomicOrdering ordering,
+             bool single_thread) -> llvm::Value * {
+            // FenceInst is void-typed, so (unlike the neighboring atomic
+            // emitters, which produce a named value) there is no result to name.
+            llvm::SyncScope::ID ssid = single_thread
+                                           ? llvm::SyncScope::SingleThread
+                                           : llvm::SyncScope::System;
+            return self.CreateFence(ordering, ssid);
+          },
+          "ordering"_a, "single_thread"_a = false,
+          nb::rv_policy::reference_internal)
+      .def(
+          "atomic_rmw",
+          [](B &self, llvm::AtomicRMWInst::BinOp op, llvm::Value *ptr,
+             llvm::Value *val, llvm::AtomicOrdering ordering, bool single_thread,
+             const std::string &name) -> llvm::Value * {
+            llvm::SyncScope::ID ssid = single_thread
+                                           ? llvm::SyncScope::SingleThread
+                                           : llvm::SyncScope::System;
+            // MaybeAlign() -> IRBuilder derives the natural alignment.
+            llvm::Value *v = self.CreateAtomicRMW(op, ptr, val,
+                                                  llvm::MaybeAlign(), ordering,
+                                                  ssid);
+            if (!name.empty())
+              v->setName(name);
+            return v;
+          },
+          "op"_a, "ptr"_a, "value"_a, "ordering"_a, "single_thread"_a = false,
+          "name"_a = "", nb::rv_policy::reference_internal)
+      .def(
+          "atomic_cmpxchg",
+          [](B &self, llvm::Value *ptr, llvm::Value *cmp, llvm::Value *new_value,
+             llvm::AtomicOrdering success, llvm::AtomicOrdering failure,
+             bool single_thread, const std::string &name) -> llvm::Value * {
+            // The AtomicCmpXchgInst ctor asserts these; check first so a bad
+            // ordering raises a catchable Python error instead of aborting.
+            if (!llvm::AtomicCmpXchgInst::isValidSuccessOrdering(success)) {
+              throw nb::value_error(
+                  "invalid cmpxchg success ordering (must not be NotAtomic or "
+                  "Unordered)");
+            }
+            if (!llvm::AtomicCmpXchgInst::isValidFailureOrdering(failure)) {
+              throw nb::value_error(
+                  "invalid cmpxchg failure ordering (must not be NotAtomic, "
+                  "Unordered, Release, or AcquireRelease)");
+            }
+            llvm::SyncScope::ID ssid = single_thread
+                                           ? llvm::SyncScope::SingleThread
+                                           : llvm::SyncScope::System;
+            llvm::Value *v = self.CreateAtomicCmpXchg(
+                ptr, cmp, new_value, llvm::MaybeAlign(), success, failure, ssid);
+            if (!name.empty())
+              v->setName(name);
+            return v;
+          },
+          "ptr"_a, "cmp"_a, "new_value"_a, "success_ordering"_a,
+          "failure_ordering"_a, "single_thread"_a = false, "name"_a = "",
+          nb::rv_policy::reference_internal)
+      .def(
+          "call_intrinsic",
+          [](B &self, unsigned intrinsic_id, std::vector<llvm::Type *> types,
+             std::vector<llvm::Value *> args,
+             const std::string &name) -> llvm::Value * {
+            llvm::Value *v = self.CreateIntrinsic(
+                static_cast<llvm::Intrinsic::ID>(intrinsic_id), types, args);
+            if (!name.empty())
+              v->setName(name);
+            return v;
+          },
+          "intrinsic_id"_a, "overload_types"_a, "args"_a, "name"_a = "",
           nb::rv_policy::reference_internal);
 
   // --- DSL current-builder/function state + MLIR-style InsertPoint ---

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -88,6 +88,12 @@ void populate_constants(nb::module_ &m) {
         return std::string(self.getOpcodeName());
       });
   nb::class_<llvm::BlockAddress, llvm::Constant>(m, "BlockAddress")
+      .def_static(
+          "get",
+          [](llvm::Function *f, llvm::BasicBlock *bb) -> llvm::Constant * {
+            return llvm::BlockAddress::get(f, bb);
+          },
+          "function"_a, "basic_block"_a, nb::rv_policy::reference)
       .def_prop_ro(
           "function",
           [](llvm::BlockAddress &self) { return self.getFunction(); },

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -4,6 +4,7 @@
 
 #include "IR/Common.h"
 
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instructions.h>
 
@@ -32,6 +33,42 @@ void populate_instructions(nb::module_ &m) {
       .value("UNE", llvm::CmpInst::FCMP_UNE);
   m.attr("ICmpPredicate") = m.attr("CmpPredicate");
   m.attr("FCmpPredicate") = m.attr("CmpPredicate");
+
+  // Memory-ordering + atomicrmw operation enums, used by the IRBuilder
+  // fence/atomic_rmw/atomic_cmpxchg emitters.
+  nb::enum_<llvm::AtomicOrdering>(m, "AtomicOrdering")
+      .value("NotAtomic", llvm::AtomicOrdering::NotAtomic)
+      .value("Unordered", llvm::AtomicOrdering::Unordered)
+      .value("Monotonic", llvm::AtomicOrdering::Monotonic)
+      .value("Acquire", llvm::AtomicOrdering::Acquire)
+      .value("Release", llvm::AtomicOrdering::Release)
+      .value("AcquireRelease", llvm::AtomicOrdering::AcquireRelease)
+      .value("SequentiallyConsistent",
+             llvm::AtomicOrdering::SequentiallyConsistent);
+  nb::enum_<llvm::AtomicRMWInst::BinOp>(m, "AtomicRMWBinOp")
+      .value("Xchg", llvm::AtomicRMWInst::Xchg)
+      .value("Add", llvm::AtomicRMWInst::Add)
+      .value("Sub", llvm::AtomicRMWInst::Sub)
+      .value("And", llvm::AtomicRMWInst::And)
+      .value("Nand", llvm::AtomicRMWInst::Nand)
+      .value("Or", llvm::AtomicRMWInst::Or)
+      .value("Xor", llvm::AtomicRMWInst::Xor)
+      .value("Max", llvm::AtomicRMWInst::Max)
+      .value("Min", llvm::AtomicRMWInst::Min)
+      .value("UMax", llvm::AtomicRMWInst::UMax)
+      .value("UMin", llvm::AtomicRMWInst::UMin)
+      .value("FAdd", llvm::AtomicRMWInst::FAdd)
+      .value("FSub", llvm::AtomicRMWInst::FSub)
+      .value("FMax", llvm::AtomicRMWInst::FMax)
+      .value("FMin", llvm::AtomicRMWInst::FMin)
+      .value("FMaximum", llvm::AtomicRMWInst::FMaximum)
+      .value("FMinimum", llvm::AtomicRMWInst::FMinimum)
+      .value("FMaximumNum", llvm::AtomicRMWInst::FMaximumNum)
+      .value("FMinimumNum", llvm::AtomicRMWInst::FMinimumNum)
+      .value("UIncWrap", llvm::AtomicRMWInst::UIncWrap)
+      .value("UDecWrap", llvm::AtomicRMWInst::UDecWrap)
+      .value("USubCond", llvm::AtomicRMWInst::USubCond)
+      .value("USubSat", llvm::AtomicRMWInst::USubSat);
 
   // Intermediate bases (the Value type_hook never names these, but leaf classes
   // need them registered as their nanobind base).
@@ -131,8 +168,10 @@ void populate_instructions(nb::module_ &m) {
           "condition",
           [](llvm::CondBrInst &self) { return self.getCondition(); },
           nb::rv_policy::reference_internal);
-  nb::class_<llvm::SwitchInst, llvm::Instruction>(m, "SwitchInst");
-  nb::class_<llvm::IndirectBrInst, llvm::Instruction>(m, "IndirectBrInst");
+  nb::class_<llvm::SwitchInst, llvm::Instruction>(m, "SwitchInst")
+      .def("add_case", &llvm::SwitchInst::addCase, "on_value"_a, "dest"_a);
+  nb::class_<llvm::IndirectBrInst, llvm::Instruction>(m, "IndirectBrInst")
+      .def("add_destination", &llvm::IndirectBrInst::addDestination, "dest"_a);
   nb::class_<llvm::ResumeInst, llvm::Instruction>(m, "ResumeInst");
   nb::class_<llvm::UnreachableInst, llvm::Instruction>(m, "UnreachableInst");
   nb::class_<llvm::SelectInst, llvm::Instruction>(m, "SelectInst");

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -5,8 +5,9 @@
 
 # MLIR-style submodule layout: nothing is re-exported at the package top level.
 # Use llvm.ir.Context, llvm.types.i32, llvm.passmanager.run_passes,
-# llvm.jit.LLJIT, llvm.intrinsics.sqrt, llvm.dsl.function, etc.
-from . import ir, types, passmanager, jit, intrinsics, dsl  # noqa: F401
+# llvm.jit.LLJIT, llvm.intrinsics.sqrt, llvm.instructions.load, llvm.dsl.function,
+# etc.
+from . import ir, types, passmanager, jit, intrinsics, instructions, dsl  # noqa: F401
 
 from .dsl.values import install_value_casters as _install_value_casters
 

--- a/projects/eudsl-llvmpy/src/llvm/instructions.py
+++ b/projects/eudsl-llvmpy/src/llvm/instructions.py
@@ -1,0 +1,440 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Free-function forms of the IRBuilder instruction emitters.
+
+Each function mirrors the matching ``IRBuilder`` method and takes an optional
+keyword-only ``builder``; when omitted, the contextual builder is used (the one
+made current by ``with builder:`` or ``with InsertPoint(...):``, via
+``current_builder()``). So inside such a context you can write ``load(i32, p)``
+instead of ``b.load(i32, p)``.
+
+Operands that are plain Python numbers are materialized into LLVM constants
+before the instruction is emitted, so ``add(x, 1)``, ``ret(0)``, or
+``call(f, [5])`` work without spelling out ``i32_const``. The constant's type is
+inferred from the surrounding operand: a sibling SSA operand for binary
+ops/comparisons/select, the enclosing function's return type for ``ret``, and
+the callee's parameter type for ``call``. Integer indices to ``gep``,
+``extract_element`` and ``insert_element`` become ``i32`` constants. Where no
+type can be inferred (e.g. both operands are numbers), a ``TypeError`` is
+raised; pass an explicit constant in that case.
+"""
+from .ir import const_fp, const_int, current_builder
+
+__all__ = [
+    # terminators
+    "ret", "br", "cond_br", "unreachable", "switch_", "indirect_br", "resume",
+    # integer / float binary
+    "add", "fadd", "sub", "fsub", "mul", "fmul", "sdiv", "udiv", "fdiv",
+    "srem", "urem", "frem", "shl", "lshr", "ashr", "and_", "or_", "xor",
+    # unary
+    "neg", "fneg", "not_",
+    # comparisons
+    "icmp", "fcmp",
+    # casts
+    "trunc", "zext", "sext", "fptoui", "fptosi", "uitofp", "sitofp",
+    "fptrunc", "fpext", "ptrtoint", "inttoptr", "bitcast", "addrspacecast",
+    "ptrtoaddr",
+    # memory / atomics
+    "alloca", "load", "store", "gep", "fence", "atomic_rmw", "atomic_cmpxchg",
+    # calls, phis, constants
+    "call", "call_intrinsic", "phi", "i64_const", "i32_const",
+    # aggregates / vectors
+    "extract_value", "insert_value", "extract_element", "insert_element",
+    "shuffle_vector",
+    # misc
+    "select", "freeze", "va_arg",
+]
+
+
+def _builder(builder):
+    return current_builder() if builder is None else builder
+
+
+def _is_number(x):
+    # bool is a subclass of int; both are handled by _const_of.
+    return isinstance(x, (int, float))
+
+
+def _const_of(value, ref_type):
+    """Materialize a Python number as an LLVM constant of ``ref_type``.
+
+    ``ref_type`` (the operand/return/parameter type the constant is matched to)
+    must be a scalar integer or floating-point type; anything else (e.g. a
+    vector) raises, since there is no unambiguous constant to build. A float is
+    rejected for an integer type rather than silently truncated."""
+    if ref_type.is_integer:
+        if isinstance(value, float):
+            raise TypeError(
+                f"cannot use float {value!r} as an integer constant of "
+                f"{ref_type}"
+            )
+        # Interpret negatives as signed and non-negatives as unsigned so the
+        # full [-2**(w-1), 2**w) range is accepted (e.g. the mask 0xFF into i8).
+        return const_int(ref_type, int(value), signed=value < 0)
+    if ref_type.is_floating_point:
+        return const_fp(ref_type, float(value))
+    raise TypeError(
+        f"cannot build a constant of type {ref_type} from {value!r}; "
+        "pass an explicit value"
+    )
+
+
+def _coerce_pair(lhs, rhs):
+    """Coerce whichever of ``lhs``/``rhs`` is a Python number to a constant of
+    the other's type. Both being numbers leaves no type to infer."""
+    lhs_num, rhs_num = _is_number(lhs), _is_number(rhs)
+    if lhs_num and rhs_num:
+        raise TypeError(
+            "at least one operand must be an SSA value so the constant's type "
+            "can be inferred; pass an explicit value"
+        )
+    if lhs_num:
+        lhs = _const_of(lhs, rhs.type)
+    elif rhs_num:
+        rhs = _const_of(rhs, lhs.type)
+    return lhs, rhs
+
+
+# --- Terminators --------------------------------------------------------------
+
+
+def ret(value=None, *, builder=None):
+    b = _builder(builder)
+    if _is_number(value):
+        value = _const_of(value, b.insert_block.parent.return_type)
+    return b.ret(value)
+
+
+def br(dest, *, builder=None):
+    return _builder(builder).br(dest)
+
+
+def cond_br(cond, true_dest, false_dest, *, builder=None):
+    return _builder(builder).cond_br(cond, true_dest, false_dest)
+
+
+def unreachable(*, builder=None):
+    return _builder(builder).unreachable()
+
+
+def switch_(value, default_dest, num_cases=10, *, builder=None):
+    return _builder(builder).switch_(value, default_dest, num_cases)
+
+
+def indirect_br(address, num_dests=10, *, builder=None):
+    return _builder(builder).indirect_br(address, num_dests)
+
+
+def resume(exn, *, builder=None):
+    return _builder(builder).resume(exn)
+
+
+# --- Binary arithmetic / bitwise ----------------------------------------------
+
+
+def add(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).add(lhs, rhs, name)
+
+
+def fadd(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).fadd(lhs, rhs, name)
+
+
+def sub(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).sub(lhs, rhs, name)
+
+
+def fsub(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).fsub(lhs, rhs, name)
+
+
+def mul(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).mul(lhs, rhs, name)
+
+
+def fmul(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).fmul(lhs, rhs, name)
+
+
+def sdiv(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).sdiv(lhs, rhs, name)
+
+
+def udiv(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).udiv(lhs, rhs, name)
+
+
+def fdiv(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).fdiv(lhs, rhs, name)
+
+
+def srem(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).srem(lhs, rhs, name)
+
+
+def urem(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).urem(lhs, rhs, name)
+
+
+def frem(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).frem(lhs, rhs, name)
+
+
+def shl(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).shl(lhs, rhs, name)
+
+
+def lshr(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).lshr(lhs, rhs, name)
+
+
+def ashr(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).ashr(lhs, rhs, name)
+
+
+def and_(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).and_(lhs, rhs, name)
+
+
+def or_(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).or_(lhs, rhs, name)
+
+
+def xor(lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).xor(lhs, rhs, name)
+
+
+# --- Unary --------------------------------------------------------------------
+
+
+def neg(value, name="", *, builder=None):
+    return _builder(builder).neg(value, name)
+
+
+def fneg(value, name="", *, builder=None):
+    return _builder(builder).fneg(value, name)
+
+
+def not_(value, name="", *, builder=None):
+    return _builder(builder).not_(value, name)
+
+
+# --- Comparisons --------------------------------------------------------------
+
+
+def icmp(predicate, lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).icmp(predicate, lhs, rhs, name)
+
+
+def fcmp(predicate, lhs, rhs, name="", *, builder=None):
+    lhs, rhs = _coerce_pair(lhs, rhs)
+    return _builder(builder).fcmp(predicate, lhs, rhs, name)
+
+
+# --- Casts --------------------------------------------------------------------
+
+
+def trunc(value, dest_type, name="", *, builder=None):
+    return _builder(builder).trunc(value, dest_type, name)
+
+
+def zext(value, dest_type, name="", *, builder=None):
+    return _builder(builder).zext(value, dest_type, name)
+
+
+def sext(value, dest_type, name="", *, builder=None):
+    return _builder(builder).sext(value, dest_type, name)
+
+
+def fptoui(value, dest_type, name="", *, builder=None):
+    return _builder(builder).fptoui(value, dest_type, name)
+
+
+def fptosi(value, dest_type, name="", *, builder=None):
+    return _builder(builder).fptosi(value, dest_type, name)
+
+
+def uitofp(value, dest_type, name="", *, builder=None):
+    return _builder(builder).uitofp(value, dest_type, name)
+
+
+def sitofp(value, dest_type, name="", *, builder=None):
+    return _builder(builder).sitofp(value, dest_type, name)
+
+
+def fptrunc(value, dest_type, name="", *, builder=None):
+    return _builder(builder).fptrunc(value, dest_type, name)
+
+
+def fpext(value, dest_type, name="", *, builder=None):
+    return _builder(builder).fpext(value, dest_type, name)
+
+
+def ptrtoint(value, dest_type, name="", *, builder=None):
+    return _builder(builder).ptrtoint(value, dest_type, name)
+
+
+def inttoptr(value, dest_type, name="", *, builder=None):
+    return _builder(builder).inttoptr(value, dest_type, name)
+
+
+def bitcast(value, dest_type, name="", *, builder=None):
+    return _builder(builder).bitcast(value, dest_type, name)
+
+
+def addrspacecast(value, dest_type, name="", *, builder=None):
+    return _builder(builder).addrspacecast(value, dest_type, name)
+
+
+def ptrtoaddr(value, name="", *, builder=None):
+    return _builder(builder).ptrtoaddr(value, name)
+
+
+# --- Memory / atomics ---------------------------------------------------------
+
+
+def alloca(type, name="", *, builder=None):
+    return _builder(builder).alloca(type, name)
+
+
+def load(type, ptr, name="", *, builder=None):
+    return _builder(builder).load(type, ptr, name)
+
+
+def store(value, ptr, *, builder=None):
+    return _builder(builder).store(value, ptr)
+
+
+def gep(type, ptr, indices, name="", *, builder=None):
+    b = _builder(builder)
+    # i32 is valid for both array/pointer and (mandatory for) struct indices.
+    indices = [b.i32_const(i) if isinstance(i, int) else i for i in indices]
+    return b.gep(type, ptr, indices, name)
+
+
+def fence(ordering, single_thread=False, *, builder=None):
+    return _builder(builder).fence(ordering, single_thread)
+
+
+def atomic_rmw(op, ptr, value, ordering, single_thread=False, name="", *, builder=None):
+    return _builder(builder).atomic_rmw(op, ptr, value, ordering, single_thread, name)
+
+
+def atomic_cmpxchg(
+    ptr,
+    cmp,
+    new_value,
+    success_ordering,
+    failure_ordering,
+    single_thread=False,
+    name="",
+    *,
+    builder=None,
+):
+    return _builder(builder).atomic_cmpxchg(
+        ptr, cmp, new_value, success_ordering, failure_ordering, single_thread, name
+    )
+
+
+# --- Calls, phis, constants ---------------------------------------------------
+
+
+def call(fn, args, name="", *, builder=None):
+    # A number arg is coerced to its declared parameter type. Args beyond a
+    # varargs callee's fixed params have no declared type, so a number there is
+    # rejected (pass an explicit constant) rather than handed to the binding raw.
+    fty = fn.function_type
+    n = fty.num_params
+    coerced = []
+    for i, a in enumerate(args):
+        if _is_number(a):
+            if i >= n:
+                raise TypeError(
+                    f"cannot infer a type for number argument {a!r} at "
+                    f"position {i}, beyond the callee's {n} fixed parameter(s); "
+                    "pass an explicit constant"
+                )
+            a = _const_of(a, fty.param_type(i))
+        coerced.append(a)
+    return _builder(builder).call(fn, coerced, name)
+
+
+def call_intrinsic(intrinsic_id, overload_types, args, name="", *, builder=None):
+    return _builder(builder).call_intrinsic(intrinsic_id, overload_types, args, name)
+
+
+def phi(type, name="", *, builder=None):
+    return _builder(builder).phi(type, name)
+
+
+def i64_const(value, *, builder=None):
+    return _builder(builder).i64_const(value)
+
+
+def i32_const(value, *, builder=None):
+    return _builder(builder).i32_const(value)
+
+
+# --- Aggregates / vectors -----------------------------------------------------
+
+
+def extract_value(aggregate, index, name="", *, builder=None):
+    return _builder(builder).extract_value(aggregate, index, name)
+
+
+def insert_value(aggregate, value, index, name="", *, builder=None):
+    return _builder(builder).insert_value(aggregate, value, index, name)
+
+
+def extract_element(vector, index, name="", *, builder=None):
+    b = _builder(builder)
+    if isinstance(index, int):
+        index = b.i32_const(index)
+    return b.extract_element(vector, index, name)
+
+
+def insert_element(vector, element, index, name="", *, builder=None):
+    b = _builder(builder)
+    if isinstance(index, int):
+        index = b.i32_const(index)
+    return b.insert_element(vector, element, index, name)
+
+
+def shuffle_vector(v1, v2, mask, name="", *, builder=None):
+    return _builder(builder).shuffle_vector(v1, v2, mask, name)
+
+
+# --- Misc ---------------------------------------------------------------------
+
+
+def select(cond, true_value, false_value, name="", *, builder=None):
+    true_value, false_value = _coerce_pair(true_value, false_value)
+    return _builder(builder).select(cond, true_value, false_value, name)
+
+
+def freeze(value, name="", *, builder=None):
+    return _builder(builder).freeze(value, name)
+
+
+def va_arg(arg_list, type, name="", *, builder=None):
+    return _builder(builder).va_arg(arg_list, type, name)

--- a/projects/eudsl-llvmpy/tests/ir/test_instruction_functions.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_instruction_functions.py
@@ -1,0 +1,767 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Free-function instruction emitters (llvm.instructions): they delegate to the
+contextual builder (`with builder:` / `with InsertPoint(...):`) when no `builder`
+is passed, or to an explicit `builder=`."""
+import pytest
+
+import llvm
+from llvm import instructions as I
+from llvm.ir import InsertPoint, IRBuilder
+from llvm.testing import assert_no_leaks, filecheck_with_comments
+
+
+def _fn(ctx, ret, args, name="f"):
+    mod = llvm.ir.Module("m", ctx)
+    fn = llvm.ir.Function.create(llvm.types.function(ret, args), name, mod)
+    return mod, fn
+
+
+def test_int_arithmetic_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            s = I.add(x, y, "s")
+            I.sub(x, y, "d")
+            I.mul(x, y, "m")
+            I.sdiv(x, y, "q")
+            I.udiv(x, y, "uq")
+            I.ret(s)
+        p = str(mod)
+        assert "%s = add i32 %0, %1" in p
+        assert "%d = sub i32 %0, %1" in p
+        assert "%m = mul i32 %0, %1" in p
+        assert "%q = sdiv i32 %0, %1" in p
+        assert "%uq = udiv i32 %0, %1" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_float_arithmetic_and_fcmp_free_functions():
+    with llvm.ir.Context() as ctx:
+        f32 = llvm.types.f32()
+        mod, fn = _fn(ctx, f32, [f32, f32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            I.fsub(x, y, "d")
+            I.fmul(x, y, "m")
+            I.fdiv(x, y, "q")
+            I.fcmp(llvm.ir.CmpPredicate.OGT, x, y, "c")
+            I.ret(I.fadd(x, y, "s"))
+        p = str(mod)
+        assert "%s = fadd float %0, %1" in p
+        assert "%d = fsub float %0, %1" in p
+        assert "%m = fmul float %0, %1" in p
+        assert "%q = fdiv float %0, %1" in p
+        assert "%c = fcmp ogt float %0, %1" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_icmp_free_function():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, llvm.types.i1(), [i32, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.ret(I.icmp(llvm.ir.CmpPredicate.SLT, fn.arg(0), fn.arg(1), "c"))
+        assert "%c = icmp slt i32 %0, %1" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_memory_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [llvm.types.ptr()])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            slot = I.alloca(i32, "slot")
+            I.store(I.i32_const(5), slot)
+            I.gep(i32, fn.arg(0), [I.i64_const(2)], "g")
+            I.ret(I.load(i32, slot, "ld"))
+        # CHECK: %slot = alloca i32
+        # CHECK: store i32 5, ptr %slot
+        # CHECK: %g = getelementptr i32, ptr %0, i64 2
+        # CHECK: %ld = load i32, ptr %slot
+        # CHECK: ret i32 %ld
+        filecheck_with_comments(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_call_and_aggregate_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        st = llvm.types.struct([i32, i32])
+        mod = llvm.ir.Module("m", ctx)
+        callee = llvm.ir.Function.create(llvm.types.function(i32, [i32]), "callee", mod)
+        fn = llvm.ir.Function.create(llvm.types.function(i32, [st, i32]), "f", mod)
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            upd = I.insert_value(fn.arg(0), fn.arg(1), 1, "upd")
+            first = I.extract_value(upd, 0, "first")
+            I.ret(I.call(callee, [first], "c"))
+        p = str(mod)
+        assert "%upd = insertvalue { i32, i32 } %0, i32 %1, 1" in p
+        assert "%first = extractvalue { i32, i32 } %upd, 0" in p
+        assert "%c = call i32 @callee(i32 %first)" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_terminators_and_phi_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [llvm.types.i1()])
+        entry = fn.append_basic_block("entry")
+        a = fn.append_basic_block("a")
+        bb = fn.append_basic_block("b")
+        join = fn.append_basic_block("join")
+        b = IRBuilder(ctx)
+        with InsertPoint(entry, builder=b):
+            I.cond_br(fn.arg(0), a, bb)
+        with InsertPoint(a, builder=b):
+            I.br(join)
+        with InsertPoint(bb, builder=b):
+            I.br(join)
+        with InsertPoint(join, builder=b):
+            ph = I.phi(i32, "p")
+            ph.add_incoming(I.i32_const(1), a)
+            ph.add_incoming(I.i32_const(2), bb)
+            I.ret(ph)
+        p = str(mod)
+        assert "br i1 %0, label %a, label %b" in p
+        assert "%p = phi i32 [ 1, %a ], [ 2, %b ]" in p
+        assert "ret i32 %p" in p
+        del b, fn, entry, a, bb, join, ph, mod
+    assert_no_leaks()
+
+
+def test_free_function_via_with_builder():
+    # The contextual builder can also come from a bare `with builder:`.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        entry = fn.append_basic_block("entry")
+        b = IRBuilder(ctx)
+        with b:
+            b.set_insert_point(entry)
+            I.ret(I.add(fn.arg(0), I.i32_const(1), "s"))
+        assert "%s = add i32 %0, 1" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_explicit_builder_without_any_context():
+    # No `with builder:` / InsertPoint: pass builder= explicitly.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        entry = fn.append_basic_block("entry")
+        b = IRBuilder(ctx)
+        b.set_insert_point(entry)
+        s = I.add(fn.arg(0), I.i32_const(1, builder=b), "s", builder=b)
+        I.ret(s, builder=b)
+        assert "%s = add i32 %0, 1" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_free_function_without_builder_or_context_raises():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        with pytest.raises(RuntimeError, match="no current IRBuilder"):
+            I.add(fn.arg(0), fn.arg(0), "s")  # no builder=, no context
+        del mod
+    assert_no_leaks()
+
+
+def test_int_bitwise_rem_and_unary_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            I.srem(x, y, "srem")
+            I.urem(x, y, "urem")
+            I.shl(x, y, "shl")
+            I.lshr(x, y, "lshr")
+            I.ashr(x, y, "ashr")
+            I.and_(x, y, "andv")
+            I.or_(x, y, "orv")
+            I.xor(x, y, "xorv")
+            I.neg(x, "neg")
+            I.not_(x, "notv")
+            I.ret(x)
+        p = str(mod)
+        assert "%srem = srem i32 %0, %1" in p
+        assert "%urem = urem i32 %0, %1" in p
+        assert "%shl = shl i32 %0, %1" in p
+        assert "%lshr = lshr i32 %0, %1" in p
+        assert "%ashr = ashr i32 %0, %1" in p
+        assert "%andv = and i32 %0, %1" in p
+        assert "%orv = or i32 %0, %1" in p
+        assert "%xorv = xor i32 %0, %1" in p
+        assert "%neg = sub i32 0, %0" in p
+        assert "%notv = xor i32 %0, -1" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_float_rem_and_fneg_free_functions():
+    with llvm.ir.Context() as ctx:
+        f32 = llvm.types.f32()
+        mod, fn = _fn(ctx, f32, [f32, f32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            I.frem(x, y, "frem")
+            I.fneg(x, "fneg")
+            I.ret(x)
+        p = str(mod)
+        assert "%frem = frem float %0, %1" in p
+        assert "%fneg = fneg float %0" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_integer_and_pointer_cast_free_functions():
+    with llvm.ir.Context() as ctx:
+        i64, i32, ptr, f32 = (
+            llvm.types.i64(), llvm.types.i32(), llvm.types.ptr(), llvm.types.f32()
+        )
+        mod, fn = _fn(ctx, i64, [i64, i32, ptr])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            a, n, p_ = fn.arg(0), fn.arg(1), fn.arg(2)
+            I.trunc(a, i32, "tr")
+            I.zext(n, i64, "ze")
+            I.sext(n, i64, "se")
+            I.ptrtoint(p_, i64, "p2i")
+            I.inttoptr(a, ptr, "i2p")
+            I.bitcast(n, f32, "bc")
+            I.ret(a)
+        p = str(mod)
+        assert "%tr = trunc i64 %0 to i32" in p
+        assert "%ze = zext i32 %1 to i64" in p
+        assert "%se = sext i32 %1 to i64" in p
+        assert "%p2i = ptrtoint ptr %2 to i64" in p
+        assert "%i2p = inttoptr i64 %0 to ptr" in p
+        assert "%bc = bitcast i32 %1 to float" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_fp_cast_free_functions():
+    with llvm.ir.Context() as ctx:
+        f32, f64, i32 = llvm.types.f32(), llvm.types.f64(), llvm.types.i32()
+        mod, fn = _fn(ctx, f32, [f32, f64, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, d, n = fn.arg(0), fn.arg(1), fn.arg(2)
+            I.fptrunc(d, f32, "ft")
+            I.fpext(x, f64, "fe")
+            I.fptoui(x, i32, "fu")
+            I.fptosi(x, i32, "fs")
+            I.uitofp(n, f32, "uf")
+            I.sitofp(n, f32, "sf")
+            I.ret(x)
+        p = str(mod)
+        assert "%ft = fptrunc double %1 to float" in p
+        assert "%fe = fpext float %0 to double" in p
+        assert "%fu = fptoui float %0 to i32" in p
+        assert "%fs = fptosi float %0 to i32" in p
+        assert "%uf = uitofp i32 %2 to float" in p
+        assert "%sf = sitofp i32 %2 to float" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_addrspacecast_free_function():
+    with llvm.ir.Context() as ctx:
+        ptr = llvm.types.ptr()
+        mod, fn = _fn(ctx, ptr, [ptr])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.addrspacecast(fn.arg(0), llvm.types.ptr(1), "asc")
+            I.ret(fn.arg(0))
+        assert "%asc = addrspacecast ptr %0 to ptr addrspace(1)" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_select_and_freeze_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [llvm.types.i1(), i32, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            c, t, f = fn.arg(0), fn.arg(1), fn.arg(2)
+            I.freeze(t, "fr")
+            I.ret(I.select(c, t, f, "sel"))
+        p = str(mod)
+        assert "%sel = select i1 %0, i32 %1, i32 %2" in p
+        assert "%fr = freeze i32 %1" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_vector_free_functions():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        vec = llvm.types.vector(i32, 4)
+        mod, fn = _fn(ctx, vec, [vec, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            v, e = fn.arg(0), fn.arg(1)
+            idx = I.i32_const(0)
+            I.extract_element(v, idx, "ee")
+            I.insert_element(v, e, idx, "ie")
+            I.shuffle_vector(v, v, [0, 1, 2, 3], "sh")
+            I.ret(v)
+        p = str(mod)
+        assert "%ee = extractelement <4 x i32> %0, i32 0" in p
+        assert "%ie = insertelement <4 x i32> %0, i32 %1, i32 0" in p
+        assert (
+            "%sh = shufflevector <4 x i32> %0, <4 x i32> %0, "
+            "<4 x i32> <i32 0, i32 1, i32 2, i32 3>" in p
+        )
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_va_arg_free_function():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [llvm.types.ptr()])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.ret(I.va_arg(fn.arg(0), i32, "va"))
+        assert "%va = va_arg ptr %0, i32" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_unreachable_free_function():
+    with llvm.ir.Context() as ctx:
+        mod, fn = _fn(ctx, llvm.types.void(), [])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.unreachable()
+        assert "unreachable" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_ptrtoaddr_free_function():
+    with llvm.ir.Context() as ctx:
+        mod, fn = _fn(ctx, llvm.types.i64(), [llvm.types.ptr()])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.ret(I.ptrtoaddr(fn.arg(0), "pa"))
+        assert "%pa = ptrtoaddr ptr %0 to i64" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_switch_free_function():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        entry = fn.append_basic_block("entry")
+        c1 = fn.append_basic_block("c1")
+        c2 = fn.append_basic_block("c2")
+        default = fn.append_basic_block("default")
+        b = IRBuilder(ctx)
+        with InsertPoint(entry, builder=b):
+            sw = I.switch_(fn.arg(0), default)
+            sw.add_case(I.i32_const(1), c1)
+            sw.add_case(I.i32_const(2), c2)
+        with InsertPoint(c1, builder=b):
+            I.ret(I.i32_const(10))
+        with InsertPoint(c2, builder=b):
+            I.ret(I.i32_const(20))
+        with InsertPoint(default, builder=b):
+            I.ret(I.i32_const(0))
+        p = str(mod)
+        assert "switch i32 %0, label %default [" in p
+        assert "i32 1, label %c1" in p
+        assert "i32 2, label %c2" in p
+        del b, fn, entry, c1, c2, default, sw, mod
+    assert_no_leaks()
+
+
+def test_indirect_br_free_function():
+    with llvm.ir.Context() as ctx:
+        mod, fn = _fn(ctx, llvm.types.void(), [])
+        entry = fn.append_basic_block("entry")
+        t1 = fn.append_basic_block("t1")
+        t2 = fn.append_basic_block("t2")
+        b = IRBuilder(ctx)
+        addr = llvm.ir.BlockAddress.get(fn, t1)
+        with InsertPoint(entry, builder=b):
+            ibr = I.indirect_br(addr)
+            ibr.add_destination(t1)
+            ibr.add_destination(t2)
+        with InsertPoint(t1, builder=b):
+            I.ret()
+        with InsertPoint(t2, builder=b):
+            I.ret()
+        p = str(mod)
+        assert (
+            "indirectbr ptr blockaddress(@f, %t1), [label %t1, label %t2]" in p
+        )
+        del b, fn, entry, t1, t2, ibr, mod
+    assert_no_leaks()
+
+
+def test_resume_free_function():
+    with llvm.ir.Context() as ctx:
+        i32, ptr = llvm.types.i32(), llvm.types.ptr()
+        exn_ty = llvm.types.struct([ptr, i32])
+        mod, fn = _fn(ctx, llvm.types.void(), [exn_ty])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.resume(fn.arg(0))
+        assert "resume { ptr, i32 } %0" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_fence_free_function():
+    with llvm.ir.Context() as ctx:
+        mod, fn = _fn(ctx, llvm.types.void(), [])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.fence(llvm.ir.AtomicOrdering.SequentiallyConsistent)
+            I.fence(llvm.ir.AtomicOrdering.Acquire, single_thread=True)
+            I.ret()
+        p = str(mod)
+        assert "fence seq_cst" in p
+        assert 'fence syncscope("singlethread") acquire' in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_atomic_rmw_free_function():
+    with llvm.ir.Context() as ctx:
+        i32, ptr = llvm.types.i32(), llvm.types.ptr()
+        mod, fn = _fn(ctx, i32, [ptr, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.atomic_rmw(
+                llvm.ir.AtomicRMWBinOp.Add,
+                fn.arg(0),
+                fn.arg(1),
+                llvm.ir.AtomicOrdering.SequentiallyConsistent,
+                name="rmw",
+            )
+            # a value added in the extended BinOp set, single-threaded scope
+            r = I.atomic_rmw(
+                llvm.ir.AtomicRMWBinOp.UIncWrap,
+                fn.arg(0),
+                fn.arg(1),
+                llvm.ir.AtomicOrdering.Monotonic,
+                single_thread=True,
+                name="inc",
+            )
+            I.ret(r)
+        p = str(mod)
+        assert "%rmw = atomicrmw add ptr %0, i32 %1 seq_cst, align 4" in p
+        assert (
+            '%inc = atomicrmw uinc_wrap ptr %0, i32 %1 syncscope("singlethread") '
+            "monotonic, align 4" in p
+        )
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_atomic_cmpxchg_free_function():
+    with llvm.ir.Context() as ctx:
+        i32, ptr = llvm.types.i32(), llvm.types.ptr()
+        mod, fn = _fn(ctx, i32, [ptr, i32, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            cx = I.atomic_cmpxchg(
+                fn.arg(0),
+                fn.arg(1),
+                fn.arg(2),
+                llvm.ir.AtomicOrdering.SequentiallyConsistent,
+                llvm.ir.AtomicOrdering.Monotonic,
+                name="cx",
+            )
+            I.ret(I.extract_value(cx, 0, "old"))
+        p = str(mod)
+        assert "%cx = cmpxchg ptr %0, i32 %1, i32 %2 seq_cst monotonic, align 4" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_atomic_cmpxchg_invalid_orderings_raise():
+    # Release/AcquireRelease/Unordered/NotAtomic are invalid failure orderings,
+    # and Unordered/NotAtomic invalid success orderings; the binding checks
+    # before the AtomicCmpXchgInst ctor would assert, so these raise cleanly
+    # instead of aborting the interpreter.
+    with llvm.ir.Context() as ctx:
+        i32, ptr = llvm.types.i32(), llvm.types.ptr()
+        mod, fn = _fn(ctx, i32, [ptr, i32, i32])
+        b = IRBuilder(ctx)
+        AO = llvm.ir.AtomicOrdering
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(ValueError, match="failure ordering"):
+                I.atomic_cmpxchg(
+                    fn.arg(0), fn.arg(1), fn.arg(2), AO.SequentiallyConsistent, AO.Release
+                )
+            with pytest.raises(ValueError, match="success ordering"):
+                I.atomic_cmpxchg(
+                    fn.arg(0), fn.arg(1), fn.arg(2), AO.Unordered, AO.Monotonic
+                )
+            I.ret(I.i32_const(0))
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_call_intrinsic_free_function():
+    with llvm.ir.Context() as ctx:
+        f32 = llvm.types.f32()
+        mod, fn = _fn(ctx, f32, [f32])
+        b = IRBuilder(ctx)
+        sqrt_id = llvm.intrinsics.lookup_intrinsic_id("llvm.sqrt")
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.ret(I.call_intrinsic(sqrt_id, [f32], [fn.arg(0)], "ci"))
+        assert "%ci = call float @llvm.sqrt.f32(float %0)" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_python_number_operands_become_constants():
+    # A Python number in either operand slot becomes a constant of the sibling
+    # SSA operand's type -- integer sibling -> int constant, float -> fp.
+    with llvm.ir.Context() as ctx:
+        i32, f32 = llvm.types.i32(), llvm.types.f32()
+        mod, fn = _fn(ctx, i32, [i32, f32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            I.add(x, 1, "r")  # literal rhs
+            I.sub(10, x, "l")  # literal lhs
+            I.and_(x, -1, "m")  # negative literal (signed)
+            I.fadd(y, 2, "f")  # int literal coerced to float type
+            I.fmul(y, 1.5, "g")
+            I.ret(x)
+        p = str(mod)
+        assert "%r = add i32 %0, 1" in p
+        assert "%l = sub i32 10, %0" in p
+        assert "%m = and i32 %0, -1" in p
+        assert "%f = fadd float %1, 2.000000e+00" in p
+        assert "%g = fmul float %1, 1.500000e+00" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_python_number_operands_in_compares_and_select():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        f32 = llvm.types.f32()
+        mod, fn = _fn(ctx, i32, [i32, f32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            c = I.icmp(llvm.ir.CmpPredicate.SLT, x, 5, "c")
+            I.fcmp(llvm.ir.CmpPredicate.OGT, y, 0, "fc")
+            I.ret(I.select(c, x, 0, "sel"))  # literal false value
+        p = str(mod)
+        assert "%c = icmp slt i32 %0, 5" in p
+        assert "%fc = fcmp ogt float %1, 0.000000e+00" in p
+        assert "%sel = select i1 %c, i32 %0, i32 0" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_python_int_gep_and_vector_indices():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        vec = llvm.types.vector(i32, 4)
+        mod, fn = _fn(ctx, i32, [llvm.types.ptr(), vec])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            p, v = fn.arg(0), fn.arg(1)
+            I.gep(i32, p, [2], "g")  # int index -> i32 constant
+            I.extract_element(v, 1, "ee")  # int index -> i32 constant
+            I.insert_element(v, I.i32_const(9), 0, "ie")
+            I.ret(I.i32_const(0))
+        p_ = str(mod)
+        assert "%g = getelementptr i32, ptr %0, i32 2" in p_
+        assert "%ee = extractelement <4 x i32> %1, i32 1" in p_
+        assert "%ie = insertelement <4 x i32> %1, i32 9, i32 0" in p_
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_python_number_ret_and_call_args():
+    with llvm.ir.Context() as ctx:
+        i32, f32 = llvm.types.i32(), llvm.types.f32()
+        mod = llvm.ir.Module("m", ctx)
+        callee = llvm.ir.Function.create(
+            llvm.types.function(i32, [i32, f32]), "callee", mod
+        )
+        fn = llvm.ir.Function.create(llvm.types.function(i32, []), "f", mod)
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            # call args coerced against the callee's parameter types
+            I.call(callee, [3, 1.5], "c")
+            I.ret(0)  # coerced against the function's return type
+        p = str(mod)
+        assert "%c = call i32 @callee(i32 3, float 1.500000e+00)" in p
+        assert "ret i32 0" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_call_varargs_prebuilt_value_arg_passes_through():
+    # A vararg operand given as an already-built Value (beyond the callee's
+    # fixed params) passes through untouched; the fixed number arg is coerced.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod = llvm.ir.Module("m", ctx)
+        callee = llvm.ir.Function.create(
+            llvm.types.function(i32, [i32], var_arg=True), "callee", mod
+        )
+        fn = llvm.ir.Function.create(llvm.types.function(i32, []), "f", mod)
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            I.ret(I.call(callee, [1, I.i32_const(2)], "c"))
+        assert "%c = call i32 (i32, ...) @callee(i32 1, i32 2)" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_call_varargs_number_beyond_fixed_params_raises():
+    # A number in a vararg slot has no declared type to coerce against.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod = llvm.ir.Module("m", ctx)
+        callee = llvm.ir.Function.create(
+            llvm.types.function(i32, [i32], var_arg=True), "callee", mod
+        )
+        fn = llvm.ir.Function.create(llvm.types.function(i32, []), "f", mod)
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(TypeError, match="beyond the callee's 1 fixed"):
+                I.call(callee, [1, 2], "c")
+            I.ret(I.i32_const(0))
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_unsigned_range_literal_coerces_by_bit_pattern():
+    # A non-negative literal that overflows the signed range but fits unsigned
+    # (a bitmask like 0xFF into i8, or a >2**31 value into i32) is accepted and
+    # printed by its signed 2's-complement form.
+    with llvm.ir.Context() as ctx:
+        i8, i32 = llvm.types.i8(), llvm.types.i32()
+        mod, fn = _fn(ctx, i8, [i8, i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            x, y = fn.arg(0), fn.arg(1)
+            I.and_(x, 0xFF, "m")  # 255 -> i8 all-ones == -1
+            I.udiv(y, 4000000000, "d")  # > 2**31, fits u32
+            I.ret(x)
+        p = str(mod)
+        assert "%m = and i8 %0, -1" in p
+        assert "%d = udiv i32 %1, -294967296" in p
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_out_of_range_literal_raises_valueerror():
+    # A literal that fits neither signed nor unsigned range surfaces as a
+    # catchable ValueError (const_int guards the LLVM assert), not a crash.
+    with llvm.ir.Context() as ctx:
+        i8 = llvm.types.i8()
+        mod, fn = _fn(ctx, i8, [i8])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(ValueError, match="does not fit"):
+                I.add(fn.arg(0), 5000)  # 5000 fits neither i8 signed nor unsigned
+            I.ret(fn.arg(0))
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_float_literal_into_integer_op_raises():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(TypeError, match="float 1.5 as an integer"):
+                I.add(fn.arg(0), 1.5)
+            I.ret(fn.arg(0))
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_number_coercion_on_explicit_builder_without_context():
+    # Coercion must work off the explicit builder= too, with no active context.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        entry = fn.append_basic_block("entry")
+        b = IRBuilder(ctx)
+        b.set_insert_point(entry)
+        s = I.add(fn.arg(0), 1, "s", builder=b)
+        I.ret(s, builder=b)
+        assert "%s = add i32 %0, 1" in str(mod)
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_ret_number_into_void_function_raises():
+    # ret(<number>) routes through the return type; a void return has no
+    # constant form.
+    with llvm.ir.Context() as ctx:
+        mod, fn = _fn(ctx, llvm.types.void(), [])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(TypeError, match="cannot build a constant"):
+                I.ret(0)
+            I.ret()
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_two_number_operands_raise():
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        mod, fn = _fn(ctx, i32, [i32])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(TypeError, match="at least one operand"):
+                I.add(1, 2)
+            I.ret(fn.arg(0))
+        del b, fn, mod
+    assert_no_leaks()
+
+
+def test_number_against_non_scalar_type_raises():
+    # A number opposite a vector operand has no unambiguous constant form.
+    with llvm.ir.Context() as ctx:
+        i32 = llvm.types.i32()
+        vec = llvm.types.vector(i32, 4)
+        mod, fn = _fn(ctx, vec, [vec])
+        b = IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(TypeError, match="cannot build a constant"):
+                I.add(fn.arg(0), 1)
+            I.ret(fn.arg(0))
+        del b, fn, mod
+    assert_no_leaks()


### PR DESCRIPTION
Two parts:

### 1. Extend the `IRBuilder` binding (`src/IR/Builder.cpp`) to the full instruction set

Previously `IRBuilder` exposed only `ret`/`br`/`cond_br`, `add`..`fdiv`, `icmp`/`fcmp`, `alloca`/`load`/`store`/`gep`, `call`/`phi`, `extract_value`/`insert_value`. Added every remaining LLVM instruction `IRBuilder` can emit (except the funclet-EH ops):

- **Integer/bitwise binary:** `srem`, `urem`, `frem`, `shl`, `lshr`, `ashr`, `and_`, `or_`, `xor`
- **Unary:** `neg`, `fneg`, `not_`, `ptrtoaddr`
- **Casts:** `trunc`, `zext`, `sext`, `fptoui`, `fptosi`, `uitofp`, `sitofp`, `fptrunc`, `fpext`, `ptrtoint`, `inttoptr`, `bitcast`, `addrspacecast`
- **Vectors:** `extract_element`, `insert_element`, `shuffle_vector`
- **Terminators:** `unreachable`, `switch_`, `indirect_br`, `resume`
- **Atomics / intrinsics:** `fence`, `atomic_rmw`, `atomic_cmpxchg`, `call_intrinsic`
- **Misc:** `select`, `freeze`, `va_arg`

`icmp`/`fcmp` already take a predicate, so they cover all compare variants.

Supporting bindings this needed: the `AtomicOrdering` and `AtomicRMWBinOp` enums plus `SwitchInst.add_case` / `IndirectBrInst.add_destination` (`src/IR/Instructions.cpp`), and `BlockAddress.get` (`src/IR/Constants.cpp`) to construct an `indirectbr` target.

### 2. `llvm.instructions` — free-function forms of every emitter

Each mirrors the matching `IRBuilder` method and takes an optional **keyword-only** `builder`; when omitted, the **contextual builder** is used (`current_builder()` — made current by `with builder:` or `with InsertPoint(...):`).

```python
from llvm import instructions as I
with InsertPoint(entry, builder=b):
    s = I.add(x, y, "s")
    m = I.select(c, s, y, "m")
    I.ret(I.trunc(m, i32))
# or explicitly, no context:
I.add(x, y, "s", builder=b)
```

`builder` is keyword-only so it can't be mistaken for a positional operand/`name`; with no builder and no context, the underlying `current_builder()` raises `RuntimeError("no current IRBuilder…")`.

#### Python-number operands become constants (MLIR attribute-builder style)

The free functions also materialize plain Python numbers into constants before emitting, so you rarely need to spell out `i32_const`:

```python
I.add(x, 1)          # 1 -> i32 constant (sibling operand's type)
I.fadd(y, 2)         # 2 -> float constant
I.icmp(pred, x, 5)   # 5 -> i32 constant
I.select(c, x, 0)    # 0 -> i32 constant
I.ret(0)             # 0 -> constant of the function's return type
I.call(f, [3, 1.5])  # coerced to the callee's parameter types
I.gep(i32, p, [0, 2])          # int indices -> i32 constants
I.extract_element(v, 1)        # int index -> i32 constant
```

The constant's type is inferred from a sibling SSA operand (binary ops / comparisons / select), the enclosing function's return type (`ret`), or the callee's parameter type (`call`, including correct pass-through of extra varargs). Integer indices to `gep`/`extract_element`/`insert_element` become `i32` constants (valid for array/pointer indices and mandatory for struct indices). Where no type can be inferred — both operands are numbers, or the sibling operand is a vector — a `TypeError` is raised so you pass an explicit constant.

### Scope / not included
The funclet-based exception-handling ops (`invoke`/`callbr`/`landingpad`/`catchswitch`/`catchpad`/`cleanuppad`/`catchret`/`cleanupret`) are intentionally deferred — they need additional bundle/EH-pad plumbing. `resume` (used by the older landingpad EH model) is included.