### PR TITLE
[eudsl-llvmpy] Clean up binding idioms: optional context as Context*, "_a" args, brace style

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -59,10 +59,10 @@ void populate_builder(nb::module_ &m) {
   nb::class_<B>(m, "IRBuilder")
       .def(
           "__init__",
-          [](B *self, nb::handle context) {
+          [](B *self, eudsl::Context *context) {
             new (self) B(eudsl::currentOr(context).get());
           },
-          "context"_a = nb::none(), nb::keep_alive<1, 2>())
+          "context"_a.none() = nb::none(), nb::keep_alive<1, 2>())
       .def(
           "set_insert_point",
           [](B &self, llvm::BasicBlock *bb) { self.SetInsertPoint(bb); },
@@ -86,8 +86,7 @@ void populate_builder(nb::module_ &m) {
             }
             stack.pop_back();
           },
-          nb::arg("exc_type").none(), nb::arg("exc_value").none(),
-          nb::arg("traceback").none())
+          "exc_type"_a.none(), "exc_value"_a.none(), "traceback"_a.none())
       .def_prop_ro(
           "insert_block", [](B &self) { return self.GetInsertBlock(); },
           nb::rv_policy::reference_internal)
@@ -105,10 +104,8 @@ void populate_builder(nb::module_ &m) {
           "dest"_a, nb::rv_policy::reference_internal)
       .def(
           "cond_br",
-          [](B &self, llvm::Value *c, llvm::BasicBlock *t,
-             llvm::BasicBlock *f) -> llvm::Value * {
-            return self.CreateCondBr(c, t, f);
-          },
+          [](B &self, llvm::Value *c, llvm::BasicBlock *t, llvm::BasicBlock *f)
+              -> llvm::Value * { return self.CreateCondBr(c, t, f); },
           "cond"_a, "true_dest"_a, "false_dest"_a,
           nb::rv_policy::reference_internal)
 #define EUDSL_BIN(pyName, method)                                              \
@@ -180,32 +177,29 @@ void populate_builder(nb::module_ &m) {
 #undef EUDSL_CAST
       .def(
           "icmp",
-          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l, llvm::Value *r,
-             const std::string &name) -> llvm::Value * {
+          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l,
+             llvm::Value *r, const std::string &name) -> llvm::Value * {
             return self.CreateICmp(p, l, r, name);
           },
           "predicate"_a, "lhs"_a, "rhs"_a, "name"_a = "",
           nb::rv_policy::reference_internal)
       .def(
           "fcmp",
-          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l, llvm::Value *r,
-             const std::string &name) -> llvm::Value * {
+          [](B &self, llvm::CmpInst::Predicate p, llvm::Value *l,
+             llvm::Value *r, const std::string &name) -> llvm::Value * {
             return self.CreateFCmp(p, l, r, name);
           },
           "predicate"_a, "lhs"_a, "rhs"_a, "name"_a = "",
           nb::rv_policy::reference_internal)
       .def(
           "alloca",
-          [](B &self, llvm::Type *ty, const std::string &name) -> llvm::Value * {
-            return self.CreateAlloca(ty, nullptr, name);
-          },
+          [](B &self, llvm::Type *ty, const std::string &name)
+              -> llvm::Value * { return self.CreateAlloca(ty, nullptr, name); },
           "type"_a, "name"_a = "", nb::rv_policy::reference_internal)
       .def(
           "load",
-          [](B &self, llvm::Type *ty, llvm::Value *ptr,
-             const std::string &name) -> llvm::Value * {
-            return self.CreateLoad(ty, ptr, name);
-          },
+          [](B &self, llvm::Type *ty, llvm::Value *ptr, const std::string &name)
+              -> llvm::Value * { return self.CreateLoad(ty, ptr, name); },
           "type"_a, "ptr"_a, "name"_a = "", nb::rv_policy::reference_internal)
       .def(
           "store",
@@ -269,9 +263,8 @@ void populate_builder(nb::module_ &m) {
           nb::rv_policy::reference_internal)
       .def(
           "freeze",
-          [](B &self, llvm::Value *v, const std::string &name) -> llvm::Value * {
-            return self.CreateFreeze(v, name);
-          },
+          [](B &self, llvm::Value *v, const std::string &name)
+              -> llvm::Value * { return self.CreateFreeze(v, name); },
           "value"_a, "name"_a = "", nb::rv_policy::reference_internal)
       .def(
           "extract_element",
@@ -279,7 +272,8 @@ void populate_builder(nb::module_ &m) {
              const std::string &name) -> llvm::Value * {
             return self.CreateExtractElement(vec, idx, name);
           },
-          "vector"_a, "index"_a, "name"_a = "", nb::rv_policy::reference_internal)
+          "vector"_a, "index"_a, "name"_a = "",
+          nb::rv_policy::reference_internal)
       .def(
           "insert_element",
           [](B &self, llvm::Value *vec, llvm::Value *elt, llvm::Value *idx,
@@ -325,9 +319,8 @@ void populate_builder(nb::module_ &m) {
           "address"_a, "num_dests"_a = 10, nb::rv_policy::reference_internal)
       .def(
           "resume",
-          [](B &self, llvm::Value *exn) -> llvm::Value * {
-            return self.CreateResume(exn);
-          },
+          [](B &self, llvm::Value *exn)
+              -> llvm::Value * { return self.CreateResume(exn); },
           "exn"_a, nb::rv_policy::reference_internal)
       .def(
           "fence",
@@ -345,8 +338,8 @@ void populate_builder(nb::module_ &m) {
       .def(
           "atomic_rmw",
           [](B &self, llvm::AtomicRMWInst::BinOp op, llvm::Value *ptr,
-             llvm::Value *val, llvm::AtomicOrdering ordering, bool single_thread,
-             const std::string &name) -> llvm::Value * {
+             llvm::Value *val, llvm::AtomicOrdering ordering,
+             bool single_thread, const std::string &name) -> llvm::Value * {
             llvm::SyncScope::ID ssid = single_thread
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
@@ -362,9 +355,10 @@ void populate_builder(nb::module_ &m) {
           "name"_a = "", nb::rv_policy::reference_internal)
       .def(
           "atomic_cmpxchg",
-          [](B &self, llvm::Value *ptr, llvm::Value *cmp, llvm::Value *new_value,
-             llvm::AtomicOrdering success, llvm::AtomicOrdering failure,
-             bool single_thread, const std::string &name) -> llvm::Value * {
+          [](B &self, llvm::Value *ptr, llvm::Value *cmp,
+             llvm::Value *new_value, llvm::AtomicOrdering success,
+             llvm::AtomicOrdering failure, bool single_thread,
+             const std::string &name) -> llvm::Value * {
             // The AtomicCmpXchgInst ctor asserts these; check first so a bad
             // ordering raises a catchable Python error instead of aborting.
             if (!llvm::AtomicCmpXchgInst::isValidSuccessOrdering(success)) {
@@ -443,7 +437,8 @@ void populate_builder(nb::module_ &m) {
   nb::class_<InsertPoint>(m, "InsertPoint")
       .def(
           "__init__",
-          [](InsertPoint *self, nb::handle block_or_before, nb::object builder) {
+          [](InsertPoint *self, nb::handle block_or_before,
+             nb::object builder) {
             llvm::BasicBlock *bb;
             llvm::Instruction *inst;
             if (nb::try_cast(block_or_before, bb)) {
@@ -515,16 +510,13 @@ void populate_builder(nb::module_ &m) {
             stack.pop_back();
             nb::cast<B *>(frame.builder)->restoreIP(frame.previous);
           },
-          nb::arg("exc_type").none(), nb::arg("exc_value").none(),
-          nb::arg("traceback").none())
-      .def_prop_ro_static(
-          "current",
-          [](nb::handle) -> nb::object {
-            auto &stack = threadContextStack();
-            for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
-              if (!it->insertPoint.is_none())
-                return it->insertPoint;
-            }
-            throw nb::value_error("no current InsertPoint");
-          });
+          "exc_type"_a.none(), "exc_value"_a.none(), "traceback"_a.none())
+      .def_prop_ro_static("current", [](nb::handle) -> nb::object {
+        auto &stack = threadContextStack();
+        for (auto it = stack.rbegin(); it != stack.rend(); ++it) {
+          if (!it->insertPoint.is_none())
+            return it->insertPoint;
+        }
+        throw nb::value_error("no current InsertPoint");
+      });
 }

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -62,14 +62,15 @@ T *nthOrThrow(const std::vector<T *> &items, Py_ssize_t i) {
 /// Resolve a factory's optional `context` argument: use the passed Context, or
 /// fall back to the thread-local current one (set by `with Context():`). Raises
 /// if neither is available, mirroring MLIR's implicit-context factories.
-inline Context &currentOr(nb::handle context) {
-  if (!context.is_none())
-    return nb::cast<Context &>(context);
+inline Context &currentOr(Context *context) {
+  if (context)
+    return *context;
   Context *cur = Context::current();
-  if (!cur)
+  if (!cur) {
     throw std::runtime_error(
         "no context given and no current Context; pass context= or enter a "
         "'with Context():' block");
+  }
   return *cur;
 }
 
@@ -96,8 +97,7 @@ enum class CallingConvEnum : unsigned {
           return d;                                                            \
         throw nb::value_error("value is not a " #Derived);                     \
       }),                                                                      \
-      nb::arg("value").none(), nb::rv_policy::reference,                       \
-      nb::keep_alive<0, 1>())
+      "value"_a.none(), nb::rv_policy::reference, nb::keep_alive<0, 1>())
 
 // Pulled in here so every translation unit that returns an llvm::Type* or
 // llvm::Value* sees the downcasting type_hook specializations. Without this a

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -138,22 +138,23 @@ void populate_constants(nb::module_ &m) {
         // out-of-range value surfaces as a catchable Python exception.
         bool fits = isSigned ? llvm::isIntN(bitWidth, value)
                               : llvm::isUIntN(bitWidth, uvalue);
-        if (!fits)
+        if (!fits) {
           throw nb::value_error(
               ("value " + std::to_string(value) + " does not fit in a " +
                std::to_string(bitWidth) + "-bit " +
                (isSigned ? "signed" : "unsigned") + " integer")
                   .c_str());
+        }
         return llvm::ConstantInt::get(ity, uvalue, isSigned);
       },
       "type"_a, "value"_a, "signed"_a = false, nb::rv_policy::reference,
       nb::keep_alive<0, 1>());
   m.def(
       "const_bool",
-      [](bool b, nb::handle context) -> llvm::Constant * {
+      [](bool b, eudsl::Context *context) -> llvm::Constant * {
         return llvm::ConstantInt::getBool(eudsl::currentOr(context).get(), b);
       },
-      "value"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+      "value"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
       nb::keep_alive<0, 2>());
   m.def(
       "const_fp",

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -62,8 +62,7 @@ void populate_context(nb::module_ &m) {
             self.popCurrent();
             self.release();
           },
-          nb::arg("exc_type").none(), nb::arg("exc_value").none(),
-          nb::arg("traceback").none())
+          "exc_type"_a.none(), "exc_value"_a.none(), "traceback"_a.none())
       .def_static(
           "current",
           []() -> eudsl::Context * { return eudsl::Context::current(); },
@@ -75,10 +74,11 @@ void populate_context(nb::module_ &m) {
   nb::class_<eudsl::Module>(m, "Module")
       .def(
           "__init__",
-          [](eudsl::Module *self, const std::string &name, nb::handle context) {
+          [](eudsl::Module *self, const std::string &name,
+             eudsl::Context *context) {
             new (self) eudsl::Module(name, eudsl::currentOr(context));
           },
-          "name"_a, "context"_a = nb::none(), nb::keep_alive<1, 3>())
+          "name"_a, "context"_a.none() = nb::none(), nb::keep_alive<1, 3>())
       .def_prop_rw(
           "module_identifier",
           [](eudsl::Module &self) { return self.get().getModuleIdentifier(); },
@@ -101,7 +101,9 @@ void populate_context(nb::module_ &m) {
            })
       .def_prop_ro(
           "context",
-          [](eudsl::Module &self) -> eudsl::Context & { return self.context(); },
+          [](eudsl::Module &self) -> eudsl::Context & {
+            return self.context();
+          },
           nb::rv_policy::reference_internal)
       .def_prop_ro(
           "functions",
@@ -166,9 +168,10 @@ void populate_context(nb::module_ &m) {
           "named_metadata",
           [](eudsl::Module &self, const std::string &name) {
             std::vector<llvm::MDNode *> out;
-            if (auto *nmd = self.get().getNamedMetadata(name))
+            if (auto *nmd = self.get().getNamedMetadata(name)) {
               for (llvm::MDNode *op : nmd->operands())
                 out.push_back(op);
+            }
             return out;
           },
           "name"_a)
@@ -186,13 +189,14 @@ void populate_context(nb::module_ &m) {
              if (llvm::verifyModule(self.get(), &os))
                throw eudsl::VerifyError(msg);
            })
-      .def("to_bitcode", [](eudsl::Module &self) {
-        std::string buf;
-        llvm::raw_string_ostream os(buf);
-        llvm::WriteBitcodeToFile(self.get(), os);
-        os.flush();
-        return nb::bytes(buf.data(), buf.size());
-      })
+      .def("to_bitcode",
+           [](eudsl::Module &self) {
+             std::string buf;
+             llvm::raw_string_ostream os(buf);
+             llvm::WriteBitcodeToFile(self.get(), os);
+             os.flush();
+             return nb::bytes(buf.data(), buf.size());
+           })
       .def(
           "set_data_layout_from",
           [](eudsl::Module &self, llvm::TargetMachine &tm) {
@@ -203,7 +207,7 @@ void populate_context(nb::module_ &m) {
           "add_global",
           [](eudsl::Module &self, llvm::Type *ty, const std::string &name,
              llvm::Constant *init, bool isConstant,
-             llvm::GlobalVariable* insertBefore,
+             llvm::GlobalVariable *insertBefore,
              llvm::GlobalValue::LinkageTypes linkage,
              llvm::GlobalValue::ThreadLocalMode tlMode,
              unsigned addressSpace) -> llvm::GlobalVariable * {
@@ -214,7 +218,8 @@ void populate_context(nb::module_ &m) {
           "type"_a, "name"_a, "init"_a = nullptr, "constant"_a = false,
           "insert_before"_a = nullptr,
           "linkage"_a = llvm::GlobalValue::LinkageTypes::ExternalLinkage,
-          "thread_local_mode"_a = llvm::GlobalValue::ThreadLocalMode::NotThreadLocal,
+          "thread_local_mode"_a =
+              llvm::GlobalValue::ThreadLocalMode::NotThreadLocal,
           "address_space"_a = 0, nb::rv_policy::reference_internal)
       .def(
           "get_global",
@@ -231,7 +236,7 @@ void populate_context(nb::module_ &m) {
 
   m.def(
       "parse_assembly",
-      [](const std::string &ir, nb::handle context,
+      [](const std::string &ir, eudsl::Context *context,
          const std::string &module_identifier,
          const std::string &source_filename) {
         eudsl::Context &ctx = eudsl::currentOr(context);
@@ -248,13 +253,13 @@ void populate_context(nb::module_ &m) {
         mod->setSourceFileName(source_filename);
         return new eudsl::Module(std::move(mod), ctx);
       },
-      "ir"_a, "context"_a = nb::none(), "module_identifier"_a = "<string>",
-      "source_filename"_a = "", nb::keep_alive<0, 2>(),
-      "Parse LLVM textual IR into a new Module.");
+      "ir"_a, "context"_a.none() = nb::none(),
+      "module_identifier"_a = "<string>", "source_filename"_a = "",
+      nb::keep_alive<0, 2>(), "Parse LLVM textual IR into a new Module.");
 
   m.def(
       "parse_bitcode",
-      [](nb::bytes data, nb::handle context) {
+      [](nb::bytes data, eudsl::Context *context) {
         eudsl::Context &ctx = eudsl::currentOr(context);
         llvm::StringRef ref(data.c_str(), data.size());
         auto buf = llvm::MemoryBuffer::getMemBuffer(ref, "<bitcode>", false);
@@ -264,7 +269,7 @@ void populate_context(nb::module_ &m) {
           throw eudsl::ParseError(llvm::toString(mod.takeError()));
         return new eudsl::Module(std::move(*mod), ctx);
       },
-      "data"_a, "context"_a = nb::none(), nb::keep_alive<0, 2>(),
+      "data"_a, "context"_a.none() = nb::none(), nb::keep_alive<0, 2>(),
       "Parse an LLVM bitcode buffer into a new Module.");
 
   eudsl::initializeTargets();

--- a/projects/eudsl-llvmpy/src/IR/Metadata.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Metadata.cpp
@@ -29,17 +29,17 @@ void populate_metadata(nb::module_ &m) {
 
   m.def(
       "md_string",
-      [](const std::string &s, nb::handle context) -> llvm::MDString * {
+      [](const std::string &s, eudsl::Context *context) -> llvm::MDString * {
         return llvm::MDString::get(eudsl::currentOr(context).get(), s);
       },
-      "value"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+      "value"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
       nb::keep_alive<0, 2>());
   m.def(
       "md_node",
       [](std::vector<llvm::Metadata *> ops,
-         nb::handle context) -> llvm::MDNode * {
+         eudsl::Context *context) -> llvm::MDNode * {
         return llvm::MDNode::get(eudsl::currentOr(context).get(), ops);
       },
-      "operands"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+      "operands"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
       nb::keep_alive<0, 2>());
 }

--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -23,9 +23,10 @@ std::string emit(llvm::TargetMachine &self, eudsl::Module &mod,
   llvm::raw_string_ostream os(buf);
   llvm::buffer_ostream bos(os);
   llvm::legacy::PassManager pm;
-  if (self.addPassesToEmitFile(pm, bos, nullptr, type))
+  if (self.addPassesToEmitFile(pm, bos, nullptr, type)) {
     throw std::runtime_error(  // LCOV_EXCL_LINE
         "target cannot emit this file type");  // LCOV_EXCL_LINE
+  }  // LCOV_EXCL_LINE
   pm.run(mod.get());
   return buf;
 }
@@ -61,9 +62,10 @@ void populate_target(nb::module_ &m) {
                 llvm::TargetOptions opts;
                 llvm::TargetMachine *tm = target->createTargetMachine(
                     tt, cpuStr, featStr, opts, std::nullopt);
-                if (!tm)
+                if (!tm) {
                   throw std::runtime_error(  // LCOV_EXCL_LINE
                       "could not create TargetMachine for " + tripleStr);  // LCOV_EXCL_LINE
+                }  // LCOV_EXCL_LINE
                 return tm;
               }),
           "triple"_a = nb::none(), "cpu"_a = nb::none(),

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -64,10 +64,10 @@ void populate_types(nb::module_ &m) {
 #define EUDSL_PRIMITIVE_TYPE(pyName, getter)                                   \
   m.def(                                                                       \
       pyName,                                                                  \
-      [](nb::handle context) -> llvm::Type * {                                 \
+      [](eudsl::Context *context) -> llvm::Type * {                            \
         return llvm::Type::getter(eudsl::currentOr(context).get());            \
       },                                                                       \
-      "context"_a = nb::none(), nb::rv_policy::reference,                      \
+      "context"_a.none() = nb::none(), nb::rv_policy::reference,               \
       nb::keep_alive<0, 1>())
 
   EUDSL_PRIMITIVE_TYPE("void", getVoidTy);
@@ -96,10 +96,10 @@ void populate_types(nb::module_ &m) {
       .EUDSL_CAST_CTOR(llvm::IntegerType, llvm::Type)
       .def_static(
           "get",
-          [](unsigned bits, nb::handle context) -> llvm::IntegerType * {
+          [](unsigned bits, eudsl::Context *context) -> llvm::IntegerType * {
             return llvm::IntegerType::get(eudsl::currentOr(context).get(), bits);
           },
-          "bits"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+          "bits"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
           nb::keep_alive<0, 2>())
       .def_prop_ro("bit_width", &llvm::IntegerType::getBitWidth);
 
@@ -107,11 +107,12 @@ void populate_types(nb::module_ &m) {
       .EUDSL_CAST_CTOR(llvm::PointerType, llvm::Type)
       .def_static(
           "get",
-          [](unsigned addressSpace, nb::handle context) -> llvm::PointerType * {
+          [](unsigned addressSpace,
+             eudsl::Context *context) -> llvm::PointerType * {
             return llvm::PointerType::get(eudsl::currentOr(context).get(),
                                           addressSpace);
           },
-          "address_space"_a = 0, "context"_a = nb::none(),
+          "address_space"_a = 0, "context"_a.none() = nb::none(),
           nb::rv_policy::reference, nb::keep_alive<0, 2>())
       .def_prop_ro("address_space", &llvm::PointerType::getAddressSpace);
 
@@ -120,12 +121,13 @@ void populate_types(nb::module_ &m) {
       .def_static(
           "get",
           [](std::vector<llvm::Type *> elts, bool packed,
-             nb::handle context) -> llvm::StructType * {
+             eudsl::Context *context) -> llvm::StructType * {
             return llvm::StructType::get(eudsl::currentOr(context).get(), elts,
                                          packed);
           },
-          "element_types"_a, "packed"_a = false, "context"_a = nb::none(),
-          nb::rv_policy::reference, nb::keep_alive<0, 3>())
+          "element_types"_a, "packed"_a = false,
+          "context"_a.none() = nb::none(), nb::rv_policy::reference,
+          nb::keep_alive<0, 3>())
       .def_prop_ro("name",
                    [](llvm::StructType &self) -> std::optional<std::string> {
                      if (!self.hasName())
@@ -147,17 +149,18 @@ void populate_types(nb::module_ &m) {
       .EUDSL_CAST_CTOR(llvm::ArrayType, llvm::Type)
       .def_static(
           "get",
-          [](llvm::Type *elt, uint64_t n, nb::handle context) -> llvm::ArrayType * {
+          [](llvm::Type *elt, uint64_t n,
+             eudsl::Context *context) -> llvm::ArrayType * {
             // The element type already pins the context; a passed `context` is
             // accepted for uniform dispatch but must not name a different one.
-            if (!context.is_none() &&
+            if (context &&
                 &elt->getContext() != &eudsl::currentOr(context).get()) {
               throw nb::value_error(
                   "element type belongs to a different context");
             }
             return llvm::ArrayType::get(elt, n);
           },
-          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          "element_type"_a, "num_elements"_a, "context"_a.none() = nb::none(),
           nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("num_elements", &llvm::ArrayType::getNumElements)
       .def_prop_ro("element_type", &llvm::ArrayType::getElementType,
@@ -168,8 +171,8 @@ void populate_types(nb::module_ &m) {
       .def_static(
           "get",
           [](llvm::Type *elt, unsigned n, bool scalable,
-             nb::handle context) -> llvm::VectorType * {
-            if (!context.is_none() &&
+             eudsl::Context *context) -> llvm::VectorType * {
+            if (context &&
                 &elt->getContext() != &eudsl::currentOr(context).get()) {
               throw nb::value_error(
                   "element type belongs to a different context");
@@ -177,7 +180,7 @@ void populate_types(nb::module_ &m) {
             return llvm::VectorType::get(elt, n, scalable);
           },
           "element_type"_a, "num_elements"_a, "scalable"_a = false,
-          "context"_a = nb::none(), nb::rv_policy::reference,
+          "context"_a.none() = nb::none(), nb::rv_policy::reference,
           nb::keep_alive<0, 1>())
       .def_prop_ro("min_num_elements",
                    [](llvm::VectorType &self) {
@@ -199,43 +202,44 @@ void populate_types(nb::module_ &m) {
       .def_static(
           "get",
           [](llvm::Type *elt, unsigned n,
-             nb::handle context) -> llvm::FixedVectorType * {
-            if (!context.is_none() &&
+             eudsl::Context *context) -> llvm::FixedVectorType * {
+            if (context &&
                 &elt->getContext() != &eudsl::currentOr(context).get()) {
               throw nb::value_error(
                   "element type belongs to a different context");
             }
             return llvm::FixedVectorType::get(elt, n);
           },
-          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          "element_type"_a, "num_elements"_a, "context"_a.none() = nb::none(),
           nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("num_elements", &llvm::FixedVectorType::getNumElements);
 
-  nb::class_<llvm::ScalableVectorType, llvm::VectorType>(m, "ScalableVectorType",
-                                                         nb::is_generic())
+  nb::class_<llvm::ScalableVectorType, llvm::VectorType>(
+      m, "ScalableVectorType", nb::is_generic())
       .def_static(
           "get",
           [](llvm::Type *elt, unsigned n,
-             nb::handle context) -> llvm::ScalableVectorType * {
-            if (!context.is_none() &&
+             eudsl::Context *context) -> llvm::ScalableVectorType * {
+            if (context &&
                 &elt->getContext() != &eudsl::currentOr(context).get()) {
               throw nb::value_error(
                   "element type belongs to a different context");
             }
             return llvm::ScalableVectorType::get(elt, n);
           },
-          "element_type"_a, "num_elements"_a, "context"_a = nb::none(),
+          "element_type"_a, "num_elements"_a, "context"_a.none() = nb::none(),
           nb::rv_policy::reference, nb::keep_alive<0, 1>())
       .def_prop_ro("min_num_elements",
                    &llvm::ScalableVectorType::getMinNumElements);
 
-  nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType", nb::is_generic())
+  nb::class_<llvm::FunctionType, llvm::Type>(m, "FunctionType",
+                                             nb::is_generic())
       .EUDSL_CAST_CTOR(llvm::FunctionType, llvm::Type)
       .def_static(
           "get",
           [](llvm::Type *ret, std::vector<llvm::Type *> params, bool varArg,
-             nb::handle context) -> llvm::FunctionType * {
-            if (!context.is_none()) {
+             eudsl::Context *context) -> llvm::FunctionType * {
+            if (context) {
               llvm::LLVMContext *c = &eudsl::currentOr(context).get();
               if (&ret->getContext() != c) {
                 throw nb::value_error(
@@ -251,7 +255,7 @@ void populate_types(nb::module_ &m) {
             return llvm::FunctionType::get(ret, params, varArg);
           },
           "return_type"_a, "params"_a, "var_arg"_a = false,
-          "context"_a = nb::none(), nb::rv_policy::reference,
+          "context"_a.none() = nb::none(), nb::rv_policy::reference,
           nb::keep_alive<0, 1>())
       .def_prop_ro("return_type", &llvm::FunctionType::getReturnType,
                    nb::rv_policy::reference)
@@ -267,34 +271,34 @@ void populate_types(nb::module_ &m) {
 
   m.def(
       "int",
-      [](unsigned bits, nb::handle context) -> llvm::Type * {
+      [](unsigned bits, eudsl::Context *context) -> llvm::Type * {
         return llvm::IntegerType::get(eudsl::currentOr(context).get(), bits);
       },
-      "bits"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+      "bits"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
       nb::keep_alive<0, 2>());
   m.def(
       "ptr",
-      [](unsigned addressSpace, nb::handle context) -> llvm::Type * {
+      [](unsigned addressSpace, eudsl::Context *context) -> llvm::Type * {
         return llvm::PointerType::get(eudsl::currentOr(context).get(),
                                       addressSpace);
       },
-      "address_space"_a = 0, "context"_a = nb::none(), nb::rv_policy::reference,
-      nb::keep_alive<0, 2>());
+      "address_space"_a = 0, "context"_a.none() = nb::none(),
+      nb::rv_policy::reference, nb::keep_alive<0, 2>());
   m.def(
       "struct",
       [](std::vector<llvm::Type *> elts, bool packed,
-         nb::handle context) -> llvm::Type * {
+         eudsl::Context *context) -> llvm::Type * {
         return llvm::StructType::get(eudsl::currentOr(context).get(), elts,
                                      packed);
       },
-      "element_types"_a, "packed"_a = false, "context"_a = nb::none(),
+      "element_types"_a, "packed"_a = false, "context"_a.none() = nb::none(),
       nb::rv_policy::reference, nb::keep_alive<0, 3>());
   m.def(
       "named_struct",
-      [](const std::string &name, nb::handle context) -> llvm::Type * {
+      [](const std::string &name, eudsl::Context *context) -> llvm::Type * {
         return llvm::StructType::create(eudsl::currentOr(context).get(), name);
       },
-      "name"_a, "context"_a = nb::none(), nb::rv_policy::reference,
+      "name"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
       nb::keep_alive<0, 2>());
   m.def(
       "array",

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -111,9 +111,10 @@ void populate_values(nb::module_ &m) {
              std::vector<llvm::User *> exceptions) {
             // replaceUsesWithIf asserts the types match and would otherwise
             // abort the interpreter; reject the mismatch as a Python error.
-            if (newValue->getType() != self.getType())
+            if (newValue->getType() != self.getType()) {
               throw nb::value_error(
                   "replacement value type does not match the value's type");
+            }
             self.replaceUsesWithIf(newValue, [&](llvm::Use &u) {
               return std::find(exceptions.begin(), exceptions.end(),
                                u.getUser()) == exceptions.end();
@@ -215,11 +216,11 @@ void populate_values(nb::module_ &m) {
       .def_static(
           "create",
           [](const std::string &name, llvm::Function *parent,
-             nb::handle context) {
+             eudsl::Context *context) {
             return llvm::BasicBlock::Create(eudsl::currentOr(context).get(),
                                             name, parent);
           },
-          "name"_a = "", "parent"_a = nullptr, "context"_a = nb::none(),
+          "name"_a = "", "parent"_a = nullptr, "context"_a.none() = nb::none(),
           nb::rv_policy::reference)
       .def_prop_ro(
           "parent", [](llvm::BasicBlock &self) { return self.getParent(); },


### PR DESCRIPTION
Consistency cleanup of the `src/IR` bindings. No behavior change beyond stricter argument type-checking.

### 1. Optional `context` args: `nb::handle` → nullable `eudsl::Context *`
The factory `context` argument was an `nb::handle` defaulting to `None` and resolved with `.is_none()` inside `currentOr`. Since `eudsl::Context` is a bound class, the "concrete type or None" form is a nullable pointer: nanobind maps `None` → `nullptr`, `currentOr` resolves `nullptr` to the thread-local current context, and the implicit-current-context behavior is unchanged. Bonus: a wrong-typed `context=` now raises a clear `TypeError` at the boundary instead of failing later inside `nb::cast`.

Touches: the type factories (`Types.cpp`), `Module`/`parse_assembly`/`parse_bitcode` (`Context.cpp`), `md_string`/`md_node` (`Metadata.cpp`), `const_bool` (`Constants.cpp`), `BasicBlock.create` (`Values.cpp`), the `IRBuilder` ctor (`Builder.cpp`), and `currentOr` (`Common.h`).

### 2. `nb::arg("x")...` → `"x"_a...`
The three `__exit__` methods and the `EUDSL_CAST_CTOR` macro used `nb::arg("...")`; everywhere else uses the `"..."_a` literal. Converted them (`"x"_a.none()`).

### 3. Brace style
Added braces to conditionals whose body spans multiple lines (a wrapped `throw`, or an `if` wrapping a `for`), per the LLVM brace rule in `CLAUDE.md` — `Constants.cpp`, `Context.cpp`, `Target.cpp` (×2), `Values.cpp` (`Common.h`'s `currentOr` picked up braces in the rewrite). The two `Target.cpp` error paths keep their `// LCOV_EXCL_LINE` markers (including the new closing brace).

### Notes
- The snake_case→camelCase C++ parameter renames are a **separate PR**.
- `clang-format` reflowed some adjacent untouched lines in the edited files.

### Verification
Full suite green (430 passed); C++ line + function coverage stays at **100%**.