### PR TITLE
[eudsl-llvmpy] Rename snake_case C++ lambda params to lowerCamelCase

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -305,16 +305,16 @@ void populate_builder(nb::module_ &m) {
       .def(
           "switch_",
           [](B &self, llvm::Value *v, llvm::BasicBlock *dest,
-             unsigned num_cases) -> llvm::SwitchInst * {
-            return self.CreateSwitch(v, dest, num_cases);
+             unsigned numCases) -> llvm::SwitchInst * {
+            return self.CreateSwitch(v, dest, numCases);
           },
           "value"_a, "default_dest"_a, "num_cases"_a = 10,
           nb::rv_policy::reference_internal)
       .def(
           "indirect_br",
           [](B &self, llvm::Value *addr,
-             unsigned num_dests) -> llvm::IndirectBrInst * {
-            return self.CreateIndirectBr(addr, num_dests);
+             unsigned numDests) -> llvm::IndirectBrInst * {
+            return self.CreateIndirectBr(addr, numDests);
           },
           "address"_a, "num_dests"_a = 10, nb::rv_policy::reference_internal)
       .def(
@@ -325,10 +325,10 @@ void populate_builder(nb::module_ &m) {
       .def(
           "fence",
           [](B &self, llvm::AtomicOrdering ordering,
-             bool single_thread) -> llvm::Value * {
+             bool singleThread) -> llvm::Value * {
             // FenceInst is void-typed, so (unlike the neighboring atomic
             // emitters, which produce a named value) there is no result to name.
-            llvm::SyncScope::ID ssid = single_thread
+            llvm::SyncScope::ID ssid = singleThread
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
             return self.CreateFence(ordering, ssid);
@@ -338,9 +338,9 @@ void populate_builder(nb::module_ &m) {
       .def(
           "atomic_rmw",
           [](B &self, llvm::AtomicRMWInst::BinOp op, llvm::Value *ptr,
-             llvm::Value *val, llvm::AtomicOrdering ordering,
-             bool single_thread, const std::string &name) -> llvm::Value * {
-            llvm::SyncScope::ID ssid = single_thread
+             llvm::Value *val, llvm::AtomicOrdering ordering, bool singleThread,
+             const std::string &name) -> llvm::Value * {
+            llvm::SyncScope::ID ssid = singleThread
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
             // MaybeAlign() -> IRBuilder derives the natural alignment.
@@ -355,10 +355,9 @@ void populate_builder(nb::module_ &m) {
           "name"_a = "", nb::rv_policy::reference_internal)
       .def(
           "atomic_cmpxchg",
-          [](B &self, llvm::Value *ptr, llvm::Value *cmp,
-             llvm::Value *new_value, llvm::AtomicOrdering success,
-             llvm::AtomicOrdering failure, bool single_thread,
-             const std::string &name) -> llvm::Value * {
+          [](B &self, llvm::Value *ptr, llvm::Value *cmp, llvm::Value *newValue,
+             llvm::AtomicOrdering success, llvm::AtomicOrdering failure,
+             bool singleThread, const std::string &name) -> llvm::Value * {
             // The AtomicCmpXchgInst ctor asserts these; check first so a bad
             // ordering raises a catchable Python error instead of aborting.
             if (!llvm::AtomicCmpXchgInst::isValidSuccessOrdering(success)) {
@@ -371,11 +370,11 @@ void populate_builder(nb::module_ &m) {
                   "invalid cmpxchg failure ordering (must not be NotAtomic, "
                   "Unordered, Release, or AcquireRelease)");
             }
-            llvm::SyncScope::ID ssid = single_thread
+            llvm::SyncScope::ID ssid = singleThread
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
             llvm::Value *v = self.CreateAtomicCmpXchg(
-                ptr, cmp, new_value, llvm::MaybeAlign(), success, failure, ssid);
+                ptr, cmp, newValue, llvm::MaybeAlign(), success, failure, ssid);
             if (!name.empty())
               v->setName(name);
             return v;
@@ -385,11 +384,11 @@ void populate_builder(nb::module_ &m) {
           nb::rv_policy::reference_internal)
       .def(
           "call_intrinsic",
-          [](B &self, unsigned intrinsic_id, std::vector<llvm::Type *> types,
+          [](B &self, unsigned intrinsicId, std::vector<llvm::Type *> types,
              std::vector<llvm::Value *> args,
              const std::string &name) -> llvm::Value * {
             llvm::Value *v = self.CreateIntrinsic(
-                static_cast<llvm::Intrinsic::ID>(intrinsic_id), types, args);
+                static_cast<llvm::Intrinsic::ID>(intrinsicId), types, args);
             if (!name.empty())
               v->setName(name);
             return v;
@@ -437,13 +436,12 @@ void populate_builder(nb::module_ &m) {
   nb::class_<InsertPoint>(m, "InsertPoint")
       .def(
           "__init__",
-          [](InsertPoint *self, nb::handle block_or_before,
-             nb::object builder) {
+          [](InsertPoint *self, nb::handle blockOrBefore, nb::object builder) {
             llvm::BasicBlock *bb;
             llvm::Instruction *inst;
-            if (nb::try_cast(block_or_before, bb)) {
+            if (nb::try_cast(blockOrBefore, bb)) {
               new (self) InsertPoint{RawIP(bb, bb->end()), std::move(builder)};
-            } else if (nb::try_cast(block_or_before, inst)) {
+            } else if (nb::try_cast(blockOrBefore, inst)) {
               new (self) InsertPoint{RawIP(inst->getParent(), inst->getIterator()),
                                      std::move(builder)};
             } else {

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -237,8 +237,8 @@ void populate_context(nb::module_ &m) {
   m.def(
       "parse_assembly",
       [](const std::string &ir, eudsl::Context *context,
-         const std::string &module_identifier,
-         const std::string &source_filename) {
+         const std::string &moduleIdentifier,
+         const std::string &sourceFilename) {
         eudsl::Context &ctx = eudsl::currentOr(context);
         llvm::SMDiagnostic err;
         std::unique_ptr<llvm::Module> mod =
@@ -246,11 +246,11 @@ void populate_context(nb::module_ &m) {
         if (!mod) {
           std::string msg;
           llvm::raw_string_ostream os(msg);
-          err.print(module_identifier.c_str(), os);
+          err.print(moduleIdentifier.c_str(), os);
           throw eudsl::ParseError(msg);
         }
-        mod->setModuleIdentifier(module_identifier);
-        mod->setSourceFileName(source_filename);
+        mod->setModuleIdentifier(moduleIdentifier);
+        mod->setSourceFileName(sourceFilename);
         return new eudsl::Module(std::move(mod), ctx);
       },
       "ir"_a, "context"_a.none() = nb::none(),

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -33,12 +33,12 @@ void populate_passes(nb::module_ &m) {
       "run_passes",
       [](eudsl::Module &mod, const std::string &pipeline,
          std::optional<llvm::PipelineTuningOptions> pto, bool debug,
-         bool verify_each) {
+         bool verifyEach) {
         llvm::PipelineTuningOptions opts = pto.value_or(
             llvm::PipelineTuningOptions());
         llvm::PassInstrumentationCallbacks pic;
         llvm::StandardInstrumentations si(mod.get().getContext(), debug,
-                                          verify_each);
+                                          verifyEach);
         si.registerCallbacks(pic);
         llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
         llvm::LoopAnalysisManager lam;
@@ -64,12 +64,12 @@ void populate_passes(nb::module_ &m) {
       "run_default_pipeline",
       [](eudsl::Module &mod, llvm::OptimizationLevel level,
          std::optional<llvm::PipelineTuningOptions> pto, bool debug,
-         bool verify_each) {
+         bool verifyEach) {
         llvm::PipelineTuningOptions opts = pto.value_or(
             llvm::PipelineTuningOptions());
         llvm::PassInstrumentationCallbacks pic;
         llvm::StandardInstrumentations si(mod.get().getContext(), debug,
-                                          verify_each);
+                                          verifyEach);
         si.registerCallbacks(pic);
         llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
         llvm::LoopAnalysisManager lam;


### PR DESCRIPTION
Naming-consistency cleanup, split out from #572 per request.

The IR bindings use **lowerCamelCase** for C++ locals/lambda params and reserve **snake_case** for the Python-facing `"..."_a` argument names. A handful of lambda params (mostly from the recent instruction-set work) broke that split; this renames the C++ identifiers only — the `"..."_a` literals are untouched.

- **Builder.cpp:** `num_cases`→`numCases`, `num_dests`→`numDests`, `single_thread`→`singleThread` (fence / atomic_rmw / atomic_cmpxchg), `new_value`→`newValue`, `intrinsic_id`→`intrinsicId`, `block_or_before`→`blockOrBefore`
- **Context.cpp** (`parse_assembly`): `module_identifier`→`moduleIdentifier`, `source_filename`→`sourceFilename` (the `Module.module_identifier`/`source_filename` `def_prop_rw` names stay snake_case — those are Python API)
- **Passes.cpp:** `verify_each`→`verifyEach` in `run_passes` and `run_default_pipeline`

Pure rename, no behavior change.