### PR TITLE
[eudsl-llvmpy] Audit keep_alive/rv_policy: pin two factories, unify Type accessors

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -93,7 +93,8 @@ void populate_constants(nb::module_ &m) {
           [](llvm::Function *f, llvm::BasicBlock *bb) -> llvm::Constant * {
             return llvm::BlockAddress::get(f, bb);
           },
-          "function"_a, "basic_block"_a, nb::rv_policy::reference)
+          "function"_a, "basic_block"_a, nb::rv_policy::reference,
+          nb::keep_alive<0, 1>())
       .def_prop_ro(
           "function",
           [](llvm::BlockAddress &self) { return self.getFunction(); },

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -130,7 +130,7 @@ void populate_instructions(nb::module_ &m) {
       .def_prop_ro(
           "allocated_type",
           [](llvm::AllocaInst &self) { return self.getAllocatedType(); },
-          nb::rv_policy::reference_internal);
+          nb::rv_policy::reference);
   nb::class_<llvm::LoadInst, llvm::UnaryInstruction>(m, "LoadInst")
       .EUDSL_CAST_CTOR(llvm::LoadInst, llvm::Value)
       .def_prop_ro(
@@ -150,7 +150,7 @@ void populate_instructions(nb::module_ &m) {
           [](llvm::GetElementPtrInst &self) {
             return self.getSourceElementType();
           },
-          nb::rv_policy::reference_internal);
+          nb::rv_policy::reference);
 
   nb::class_<llvm::ReturnInst, llvm::Instruction>(m, "ReturnInst")
       .EUDSL_CAST_CTOR(llvm::ReturnInst, llvm::Value)

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -61,7 +61,7 @@ void populate_values(nb::module_ &m) {
       .def_prop_rw(
           "name", [](llvm::Value &self) { return self.getName().str(); },
           [](llvm::Value &self, const std::string &n) { self.setName(n); })
-      .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference_internal)
+      .def_prop_ro("type", &llvm::Value::getType, nb::rv_policy::reference)
       .def_prop_ro("num_uses",
                    [](llvm::Value &self) { return self.getNumUses(); })
       .def_prop_ro(
@@ -221,7 +221,7 @@ void populate_values(nb::module_ &m) {
                                             name, parent);
           },
           "name"_a = "", "parent"_a = nullptr, "context"_a.none() = nb::none(),
-          nb::rv_policy::reference)
+          nb::rv_policy::reference, nb::keep_alive<0, 2>())
       .def_prop_ro(
           "parent", [](llvm::BasicBlock &self) { return self.getParent(); },
           nb::rv_policy::reference_internal)
@@ -279,13 +279,14 @@ void populate_values(nb::module_ &m) {
           "linkage"_a = llvm::GlobalValue::LinkageTypes::ExternalLinkage,
           nb::rv_policy::reference, nb::keep_alive<0, 3>())
       .def_prop_ro("function_type", &llvm::Function::getFunctionType,
-                   nb::rv_policy::reference_internal)
+                   nb::rv_policy::reference)
       .def_prop_ro("return_type", &llvm::Function::getReturnType,
-                   nb::rv_policy::reference_internal)
+                   nb::rv_policy::reference)
       .def_prop_ro("is_var_arg", &llvm::Function::isVarArg)
       .def_prop_ro("is_declaration", &llvm::Function::isDeclaration)
       .def_prop_ro("num_args", &llvm::Function::arg_size)
-      .def("arg", &llvm::Function::getArg, "index"_a, nb::rv_policy::reference_internal)
+      .def("arg", &llvm::Function::getArg, "index"_a,
+           nb::rv_policy::reference_internal)
       .def_prop_ro(
           "args",
           [](llvm::Function &self) {


### PR DESCRIPTION
Results of a `keep_alive`/`rv_policy` consistency-and-correctness audit of the `src/IR` bindings. No behavior change for well-behaved code; closes two lifetime gaps and makes the Type-accessor policy consistent.

### Audit summary
The model is sound: `reference_internal` is only ever used on instance methods (arg 1 = `self`), never on a `def_static`/`m.def` (the classic footgun); `Sequence` views pin both the container owner and each element's own module owner; type and constant factories consistently pin their context-anchoring argument. Two factories and one accessor family were the exceptions.

### `keep_alive` gaps
Both returned a bound object that pinned **nothing**, unlike their sibling factories:

- **`BlockAddress.get`** (`Constants.cpp`) → add `keep_alive<0, 1>` on the `function`. The returned `BlockAddress` is a context-owned constant; pinning the function chains function → module → context. Every other constant factory (`const_int`/`const_fp`/`const_bool`/`undef`/`poison`/`null`) already pins its context-anchoring arg.
- **`BasicBlock.create`** (`Values.cpp`) → add `keep_alive<0, 2>` on the `parent` (a no-op when `parent` is `None`, so the free-floating case is unaffected). Matches `Function.create`'s `keep_alive<0, 3>` on the module and `append_basic_block`'s `reference_internal` on the function.

### Type-accessor consistency
Type-returning accessors now uniformly use `rv_policy::reference`:
`Value.type`, `Function.function_type`, `Function.return_type`, `AllocaInst.allocated_type`, `GetElementPtrInst.source_element_type` were `reference_internal`; the `element_type`/`param_type`/`params` accessors were already plain `reference`.

**Why it's safe:** LLVM types are interned in the `LLVMContext` and never freed individually, so a `Type*` is valid for the context's whole lifetime. `reference_internal` here only pinned the (non-owning) parent wrapper — it never extended the context's lifetime — so dropping it changes nothing about safety while unifying the policy. Value-returning accessors keep `reference_internal` (values are module-owned; pinning `self` is the right anchor).