### PR TITLE
[eudsl-llvmpy] Reformat all sources with clang-format and black

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,58 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: "Format"
+
+# Formatting checks. Scoped to eudsl-llvmpy for now; other projects can be added
+# as they are brought up to a consistent format.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/format.yml"
+      - ".clang-format"
+      - "projects/eudsl-llvmpy/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/format.yml"
+      - ".clang-format"
+      - "projects/eudsl-llvmpy/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}-format
+  cancel-in-progress: true
+
+jobs:
+  eudsl-llvmpy:
+    name: "clang-format + black (eudsl-llvmpy)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Pinned so CI matches the versions the sources were formatted with; a
+      # different clang-format/black version can reflow differently.
+      - name: Install formatters
+        run: pip install "clang-format==22.1.8" "black==26.5.1"
+
+      - name: clang-format (C++)
+        run: |
+          clang-format --version
+          clang-format --style=file --dry-run --Werror \
+            projects/eudsl-llvmpy/src/IR/*.cpp \
+            projects/eudsl-llvmpy/src/IR/*.h
+
+      - name: black (Python)
+        run: |
+          black --version
+          black --check --diff \
+            projects/eudsl-llvmpy/src/llvm \
+            projects/eudsl-llvmpy/tests \
+            projects/eudsl-llvmpy/scripts

--- a/projects/eudsl-llvmpy/scripts/check_coverage.py
+++ b/projects/eudsl-llvmpy/scripts/check_coverage.py
@@ -177,7 +177,9 @@ def generate_lcov(llvm_cov, profdata, objects):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Check eudsl-llvmpy C++ source coverage")
+    parser = argparse.ArgumentParser(
+        description="Check eudsl-llvmpy C++ source coverage"
+    )
     parser.add_argument("--lcov", default=None, help="Path to LCOV .info file")
     parser.add_argument("--llvm-cov", default=None, help="Path to llvm-cov binary")
     parser.add_argument(
@@ -219,7 +221,9 @@ def main():
     else:
         parser.error("Either --lcov or (--llvm-cov, --profdata, --objects) is required")
 
-    ignore_re = re.compile(args.ignore_filename_regex) if args.ignore_filename_regex else None
+    ignore_re = (
+        re.compile(args.ignore_filename_regex) if args.ignore_filename_regex else None
+    )
 
     file_hits = parse_lcov(lcov_text)
     file_fns = parse_lcov_functions(lcov_text)
@@ -285,8 +289,12 @@ def main():
         else args.threshold
     )
 
-    print(f"eudsl-llvmpy C++ coverage: {covered_lines}/{total_lines} lines ({percent:.2f}%)")
-    print(f"eudsl-llvmpy C++ coverage: {covered_fns}/{total_fns} functions ({fn_percent:.2f}%)")
+    print(
+        f"eudsl-llvmpy C++ coverage: {covered_lines}/{total_lines} lines ({percent:.2f}%)"
+    )
+    print(
+        f"eudsl-llvmpy C++ coverage: {covered_fns}/{total_fns} functions ({fn_percent:.2f}%)"
+    )
 
     # Demangle any missed function names for readable reporting.
     all_missed = [name for s in file_stats.values() for _, name in s["f_missed"]]
@@ -322,7 +330,9 @@ def main():
     fn_ok = fn_percent >= fn_threshold
     if not line_ok or not fn_ok:
         if not line_ok:
-            print(f"\nFAILED: line coverage {percent:.2f}% < threshold {args.threshold:.2f}%")
+            print(
+                f"\nFAILED: line coverage {percent:.2f}% < threshold {args.threshold:.2f}%"
+            )
         if not fn_ok:
             print(
                 f"\nFAILED: function coverage {fn_percent:.2f}% < threshold "

--- a/projects/eudsl-llvmpy/src/IR/Attributes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Attributes.cpp
@@ -10,7 +10,8 @@ void populate_attributes(nb::module_ &m) {
   nb::enum_<llvm::GlobalValue::VisibilityTypes>(m, "Visibility")
       .value("DEFAULT", llvm::GlobalValue::VisibilityTypes::DefaultVisibility)
       .value("HIDDEN", llvm::GlobalValue::VisibilityTypes::HiddenVisibility)
-      .value("PROTECTED", llvm::GlobalValue::VisibilityTypes::ProtectedVisibility);
+      .value("PROTECTED",
+             llvm::GlobalValue::VisibilityTypes::ProtectedVisibility);
 
   nb::enum_<CallingConvEnum>(m, "CallingConv")
       .value("C", CallingConvEnum::C)

--- a/projects/eudsl-llvmpy/src/IR/Builder.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Builder.cpp
@@ -16,23 +16,24 @@
 namespace {
 using RawIP = llvm::IRBuilderBase::InsertPoint;
 
-// MLIR-style insertion point (cf. PyInsertionPoint in MLIR's IRCore.cpp), adapted
-// for LLVM's builder. Wraps the raw llvm insert point (block + iterator) plus an
-// optional explicit builder; `with InsertPoint(bb, builder=b):` positions `b`
-// there and restores it on exit. When `builder` is omitted the current builder
-// is resolved from the thread-local stack (an enclosing `with builder:` or the
-// enclosing InsertPoint's builder).
+// MLIR-style insertion point (cf. PyInsertionPoint in MLIR's IRCore.cpp),
+// adapted for LLVM's builder. Wraps the raw llvm insert point (block +
+// iterator) plus an optional explicit builder; `with InsertPoint(bb,
+// builder=b):` positions `b` there and restores it on exit. When `builder` is
+// omitted the current builder is resolved from the thread-local stack (an
+// enclosing `with builder:` or the enclosing InsertPoint's builder).
 struct InsertPoint {
   RawIP ip;
   nb::object builder; // explicit builder, or None -> resolve the current one
 };
 
 // One entry on the thread-local stack, mirroring MLIR's PyThreadContextEntry.
-// A `with builder:` pushes a builder-only entry; `with InsertPoint(...):` pushes
-// an entry that also records the InsertPoint object and the builder's prior
-// insert point (restored on exit). current_builder() / InsertPoint.current walk
-// the stack for the innermost entry of each kind (cf. getDefault* in MLIR).
-// (eudsl::Context's LLVMContext current-stack is separate; see Ownership.cpp.)
+// A `with builder:` pushes a builder-only entry; `with InsertPoint(...):`
+// pushes an entry that also records the InsertPoint object and the builder's
+// prior insert point (restored on exit). current_builder() /
+// InsertPoint.current walk the stack for the innermost entry of each kind (cf.
+// getDefault* in MLIR). (eudsl::Context's LLVMContext current-stack is
+// separate; see Ownership.cpp.)
 struct ThreadContextEntry {
   nb::object builder;
   nb::object insertPoint; // none for a bare `with builder:` entry
@@ -133,9 +134,9 @@ void populate_builder(nb::module_ &m) {
       EUDSL_BIN("and_", CreateAnd)
       EUDSL_BIN("or_", CreateOr)
       EUDSL_BIN("xor", CreateXor)
-      // clang-format on
+  // clang-format on
 #undef EUDSL_BIN
-      // Unary ops: (value, name) -> value.
+  // Unary ops: (value, name) -> value.
 #define EUDSL_UNARY(pyName, method)                                            \
   .def(                                                                        \
       pyName,                                                                  \
@@ -148,17 +149,16 @@ void populate_builder(nb::module_ &m) {
       EUDSL_UNARY("fneg", CreateFNeg)
       EUDSL_UNARY("not_", CreateNot)
       EUDSL_UNARY("ptrtoaddr", CreatePtrToAddr)
-      // clang-format on
+  // clang-format on
 #undef EUDSL_UNARY
-      // Casts: (value, dest_type, name) -> value.
+  // Casts: (value, dest_type, name) -> value.
 #define EUDSL_CAST(pyName, method)                                             \
   .def(                                                                        \
       pyName,                                                                  \
-      [](B &self, llvm::Value *v, llvm::Type *ty,                              \
-         const std::string &name) -> llvm::Value * {                          \
-        return self.method(v, ty, name);                                       \
-      },                                                                       \
-      "value"_a, "dest_type"_a, "name"_a = "", nb::rv_policy::reference_internal)
+      [](B &self, llvm::Value *v, llvm::Type *ty, const std::string &name)     \
+          -> llvm::Value * { return self.method(v, ty, name); },               \
+      "value"_a, "dest_type"_a, "name"_a = "",                                 \
+      nb::rv_policy::reference_internal)
       // clang-format off
       EUDSL_CAST("trunc", CreateTrunc)
       EUDSL_CAST("zext", CreateZExt)
@@ -173,7 +173,7 @@ void populate_builder(nb::module_ &m) {
       EUDSL_CAST("inttoptr", CreateIntToPtr)
       EUDSL_CAST("bitcast", CreateBitCast)
       EUDSL_CAST("addrspacecast", CreateAddrSpaceCast)
-      // clang-format on
+  // clang-format on
 #undef EUDSL_CAST
       .def(
           "icmp",
@@ -327,7 +327,8 @@ void populate_builder(nb::module_ &m) {
           [](B &self, llvm::AtomicOrdering ordering,
              bool singleThread) -> llvm::Value * {
             // FenceInst is void-typed, so (unlike the neighboring atomic
-            // emitters, which produce a named value) there is no result to name.
+            // emitters, which produce a named value) there is no result to
+            // name.
             llvm::SyncScope::ID ssid = singleThread
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
@@ -344,9 +345,8 @@ void populate_builder(nb::module_ &m) {
                                            ? llvm::SyncScope::SingleThread
                                            : llvm::SyncScope::System;
             // MaybeAlign() -> IRBuilder derives the natural alignment.
-            llvm::Value *v = self.CreateAtomicRMW(op, ptr, val,
-                                                  llvm::MaybeAlign(), ordering,
-                                                  ssid);
+            llvm::Value *v = self.CreateAtomicRMW(
+                op, ptr, val, llvm::MaybeAlign(), ordering, ssid);
             if (!name.empty())
               v->setName(name);
             return v;
@@ -429,8 +429,9 @@ void populate_builder(nb::module_ &m) {
       nb::rv_policy::reference,
       "The function containing the current builder's insertion block.");
 
-  // MLIR-style InsertPoint (see PyInsertionPoint in MLIR's IRCore.cpp). Wraps the
-  // llvm insert point (block + iterator) plus an optional explicit builder; on
+  // MLIR-style InsertPoint (see PyInsertionPoint in MLIR's IRCore.cpp). Wraps
+  // the llvm insert point (block + iterator) plus an optional explicit builder;
+  // on
   // __enter__ it positions that builder here (resolving the current one when
   // omitted) and restores it on __exit__.
   nb::class_<InsertPoint>(m, "InsertPoint")
@@ -442,8 +443,9 @@ void populate_builder(nb::module_ &m) {
             if (nb::try_cast(blockOrBefore, bb)) {
               new (self) InsertPoint{RawIP(bb, bb->end()), std::move(builder)};
             } else if (nb::try_cast(blockOrBefore, inst)) {
-              new (self) InsertPoint{RawIP(inst->getParent(), inst->getIterator()),
-                                     std::move(builder)};
+              new (self)
+                  InsertPoint{RawIP(inst->getParent(), inst->getIterator()),
+                              std::move(builder)};
             } else {
               throw nb::type_error(
                   "InsertPoint expects a BasicBlock (insert at end) or an "
@@ -473,9 +475,9 @@ void populate_builder(nb::module_ &m) {
       .def_static(
           "after",
           [](llvm::Instruction *inst, nb::object builder) {
-            return InsertPoint{RawIP(inst->getParent(),
-                                     std::next(inst->getIterator())),
-                               std::move(builder)};
+            return InsertPoint{
+                RawIP(inst->getParent(), std::next(inst->getIterator())),
+                std::move(builder)};
           },
           "instruction"_a, "builder"_a = nb::none(),
           "Insert immediately after an instruction.")

--- a/projects/eudsl-llvmpy/src/IR/Common.h
+++ b/projects/eudsl-llvmpy/src/IR/Common.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <llvm/IR/CallingConv.h>
 #include "IR/Ownership.h"
+#include <llvm/IR/CallingConv.h>
 
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/Error.h>
@@ -26,7 +26,8 @@ using namespace nb::literals;
 namespace eudsl {
 
 /// Render anything with a `print(raw_ostream&)` method to a std::string.
-template <typename T> std::string toString(const T &t) {
+template <typename T>
+std::string toString(const T &t) {
   std::string s;
   llvm::raw_string_ostream os(s);
   t.print(os);
@@ -35,7 +36,8 @@ template <typename T> std::string toString(const T &t) {
 
 /// Unwrap an llvm::Expected, raising RuntimeError on failure. Callers that
 /// need a more specific Python exception catch and re-raise.
-template <typename T> T unwrap(llvm::Expected<T> &&e) {
+template <typename T>
+T unwrap(llvm::Expected<T> &&e) {
   if (!e)
     throw std::runtime_error(llvm::toString(e.takeError()));
   return std::move(*e);

--- a/projects/eudsl-llvmpy/src/IR/Constants.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Constants.cpp
@@ -37,42 +37,46 @@ void populate_constants(nb::module_ &m) {
   nb::class_<llvm::ConstantAggregateZero, llvm::ConstantData>(
       m, "ConstantAggregateZero");
   nb::class_<llvm::ConstantTokenNone, llvm::ConstantData>(m,
-                                                         "ConstantTokenNone");
+                                                          "ConstantTokenNone");
   nb::class_<llvm::ConstantArray, llvm::ConstantAggregate>(m, "ConstantArray");
-  nb::class_<llvm::ConstantStruct, llvm::ConstantAggregate>(m, "ConstantStruct");
-  nb::class_<llvm::ConstantVector, llvm::ConstantAggregate>(m, "ConstantVector");
+  nb::class_<llvm::ConstantStruct, llvm::ConstantAggregate>(m,
+                                                            "ConstantStruct");
+  nb::class_<llvm::ConstantVector, llvm::ConstantAggregate>(m,
+                                                            "ConstantVector");
   nb::class_<llvm::ConstantDataSequential, llvm::ConstantData>(
       m, "ConstantDataSequential")
-      .def_prop_ro("num_elements", &llvm::ConstantDataSequential::getNumElements)
-      .def("get_element_as_int",
-           [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
-             // getElementAsInteger asserts (aborts the process) on a bad index
-             // or a non-integer element type; surface both as catchable Python
-             // errors instead.
-             Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
-             if (i < 0 || i >= n)
-               throw nb::index_error("element index out of range");
-             if (!self.getElementType()->isIntegerTy())
-               throw nb::value_error("element type is not an integer");
-             return self.getElementAsInteger(static_cast<unsigned>(i));
-           },
-           "index"_a)
-      .def("get_element_as_double",
-           [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
-             // getElementAsDouble likewise asserts on a bad index or a
-             // non-double element type.
-             Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
-             if (i < 0 || i >= n)
-               throw nb::index_error("element index out of range");
-             if (!self.getElementType()->isDoubleTy())
-               throw nb::value_error("element type is not double");
-             return self.getElementAsDouble(static_cast<unsigned>(i));
-           },
-           "index"_a)
-      .def_prop_ro("is_string",
-                   [](llvm::ConstantDataSequential &self) {
-                     return self.isString();
-                   })
+      .def_prop_ro("num_elements",
+                   &llvm::ConstantDataSequential::getNumElements)
+      .def(
+          "get_element_as_int",
+          [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
+            // getElementAsInteger asserts (aborts the process) on a bad index
+            // or a non-integer element type; surface both as catchable Python
+            // errors instead.
+            Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
+            if (i < 0 || i >= n)
+              throw nb::index_error("element index out of range");
+            if (!self.getElementType()->isIntegerTy())
+              throw nb::value_error("element type is not an integer");
+            return self.getElementAsInteger(static_cast<unsigned>(i));
+          },
+          "index"_a)
+      .def(
+          "get_element_as_double",
+          [](llvm::ConstantDataSequential &self, Py_ssize_t i) {
+            // getElementAsDouble likewise asserts on a bad index or a
+            // non-double element type.
+            Py_ssize_t n = static_cast<Py_ssize_t>(self.getNumElements());
+            if (i < 0 || i >= n)
+              throw nb::index_error("element index out of range");
+            if (!self.getElementType()->isDoubleTy())
+              throw nb::value_error("element type is not double");
+            return self.getElementAsDouble(static_cast<unsigned>(i));
+          },
+          "index"_a)
+      .def_prop_ro(
+          "is_string",
+          [](llvm::ConstantDataSequential &self) { return self.isString(); })
       .def_prop_ro("as_string",
                    [](llvm::ConstantDataSequential &self) -> std::string {
                      if (!self.isString())
@@ -138,7 +142,7 @@ void populate_constants(nb::module_ &m) {
         // if the value doesn't fit the type's bit width; check first so an
         // out-of-range value surfaces as a catchable Python exception.
         bool fits = isSigned ? llvm::isIntN(bitWidth, value)
-                              : llvm::isUIntN(bitWidth, uvalue);
+                             : llvm::isUIntN(bitWidth, uvalue);
         if (!fits) {
           throw nb::value_error(
               ("value " + std::to_string(value) + " does not fit in a " +

--- a/projects/eudsl-llvmpy/src/IR/Context.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Context.cpp
@@ -25,27 +25,34 @@
 #include <nanobind/stl/vector.h>
 
 void populate_context(nb::module_ &m) {
-  // GlobalValue linkage kinds (llvm::GlobalValue::LinkageTypes) and thread-local
-  // modes. Registered here, ahead of every other populate_* call, so factories
-  // such as Module.add_global and Function.create can take these as arguments
-  // (rather than hardcoding one choice) with enum defaults.
+  // GlobalValue linkage kinds (llvm::GlobalValue::LinkageTypes) and
+  // thread-local modes. Registered here, ahead of every other populate_* call,
+  // so factories such as Module.add_global and Function.create can take these
+  // as arguments (rather than hardcoding one choice) with enum defaults.
   nb::enum_<llvm::GlobalValue::LinkageTypes>(m, "Linkage")
       .value("EXTERNAL", llvm::GlobalValue::LinkageTypes::ExternalLinkage)
       .value("INTERNAL", llvm::GlobalValue::LinkageTypes::InternalLinkage)
       .value("PRIVATE", llvm::GlobalValue::LinkageTypes::PrivateLinkage)
       .value("LINKONCE", llvm::GlobalValue::LinkageTypes::LinkOnceAnyLinkage)
-      .value("LINKONCE_ODR", llvm::GlobalValue::LinkageTypes::LinkOnceODRLinkage)
+      .value("LINKONCE_ODR",
+             llvm::GlobalValue::LinkageTypes::LinkOnceODRLinkage)
       .value("WEAK", llvm::GlobalValue::LinkageTypes::WeakAnyLinkage)
       .value("COMMON", llvm::GlobalValue::LinkageTypes::CommonLinkage)
       .value("APPENDING", llvm::GlobalValue::LinkageTypes::AppendingLinkage)
-      .value("EXTERNAL_WEAK", llvm::GlobalValue::LinkageTypes::ExternalWeakLinkage);
+      .value("EXTERNAL_WEAK",
+             llvm::GlobalValue::LinkageTypes::ExternalWeakLinkage);
 
   nb::enum_<llvm::GlobalValue::ThreadLocalMode>(m, "ThreadLocalMode")
-      .value("NOT_THREAD_LOCAL", llvm::GlobalValue::ThreadLocalMode::NotThreadLocal)
-      .value("GENERAL_DYNAMIC", llvm::GlobalValue::ThreadLocalMode::GeneralDynamicTLSModel)
-      .value("LOCAL_DYNAMIC", llvm::GlobalValue::ThreadLocalMode::LocalDynamicTLSModel)
-      .value("INITIAL_EXEC", llvm::GlobalValue::ThreadLocalMode::InitialExecTLSModel)
-      .value("LOCAL_EXEC", llvm::GlobalValue::ThreadLocalMode::LocalExecTLSModel);
+      .value("NOT_THREAD_LOCAL",
+             llvm::GlobalValue::ThreadLocalMode::NotThreadLocal)
+      .value("GENERAL_DYNAMIC",
+             llvm::GlobalValue::ThreadLocalMode::GeneralDynamicTLSModel)
+      .value("LOCAL_DYNAMIC",
+             llvm::GlobalValue::ThreadLocalMode::LocalDynamicTLSModel)
+      .value("INITIAL_EXEC",
+             llvm::GlobalValue::ThreadLocalMode::InitialExecTLSModel)
+      .value("LOCAL_EXEC",
+             llvm::GlobalValue::ThreadLocalMode::LocalExecTLSModel);
 
   nb::class_<eudsl::Context>(m, "Context")
       .def(nb::init<>())
@@ -126,8 +133,8 @@ void populate_context(nb::module_ &m) {
           nb::keep_alive<0, 1>())
       .def("__len__",
            [](eudsl::Module &self) {
-             return static_cast<Py_ssize_t>(std::distance(
-                 self.get().begin(), self.get().end()));
+             return static_cast<Py_ssize_t>(
+                 std::distance(self.get().begin(), self.get().end()));
            })
       .def(
           "__getitem__",
@@ -211,9 +218,9 @@ void populate_context(nb::module_ &m) {
              llvm::GlobalValue::LinkageTypes linkage,
              llvm::GlobalValue::ThreadLocalMode tlMode,
              unsigned addressSpace) -> llvm::GlobalVariable * {
-            return new llvm::GlobalVariable(
-                self.get(), ty, isConstant, linkage, init, name, insertBefore,
-                tlMode, addressSpace);
+            return new llvm::GlobalVariable(self.get(), ty, isConstant, linkage,
+                                            init, name, insertBefore, tlMode,
+                                            addressSpace);
           },
           "type"_a, "name"_a, "init"_a = nullptr, "constant"_a = false,
           "insert_before"_a = nullptr,

--- a/projects/eudsl-llvmpy/src/IR/Instructions.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Instructions.cpp
@@ -160,7 +160,8 @@ void populate_instructions(nb::module_ &m) {
           nb::rv_policy::reference_internal);
   nb::class_<llvm::UncondBrInst, llvm::Instruction>(m, "UncondBrInst")
       .EUDSL_CAST_CTOR(llvm::UncondBrInst, llvm::Value)
-      .def_prop_ro("is_conditional", [](llvm::UncondBrInst &) { return false; });
+      .def_prop_ro("is_conditional",
+                   [](llvm::UncondBrInst &) { return false; });
   nb::class_<llvm::CondBrInst, llvm::Instruction>(m, "CondBrInst")
       .EUDSL_CAST_CTOR(llvm::CondBrInst, llvm::Value)
       .def_prop_ro("is_conditional", [](llvm::CondBrInst &) { return true; })
@@ -177,25 +178,25 @@ void populate_instructions(nb::module_ &m) {
   nb::class_<llvm::SelectInst, llvm::Instruction>(m, "SelectInst");
   nb::class_<llvm::VAArgInst, llvm::UnaryInstruction>(m, "VAArgInst");
   nb::class_<llvm::ExtractElementInst, llvm::Instruction>(m,
-                                                         "ExtractElementInst");
+                                                          "ExtractElementInst");
   nb::class_<llvm::InsertElementInst, llvm::Instruction>(m,
-                                                        "InsertElementInst");
+                                                         "InsertElementInst");
   nb::class_<llvm::ShuffleVectorInst, llvm::Instruction>(m,
-                                                        "ShuffleVectorInst");
-  nb::class_<llvm::ExtractValueInst, llvm::UnaryInstruction>(m,
-                                                            "ExtractValueInst");
+                                                         "ShuffleVectorInst");
+  nb::class_<llvm::ExtractValueInst, llvm::UnaryInstruction>(
+      m, "ExtractValueInst");
   nb::class_<llvm::InsertValueInst, llvm::Instruction>(m, "InsertValueInst");
   nb::class_<llvm::LandingPadInst, llvm::Instruction>(m, "LandingPadInst");
   nb::class_<llvm::FreezeInst, llvm::UnaryInstruction>(m, "FreezeInst");
   nb::class_<llvm::FenceInst, llvm::Instruction>(m, "FenceInst");
   nb::class_<llvm::AtomicCmpXchgInst, llvm::Instruction>(m,
-                                                        "AtomicCmpXchgInst");
+                                                         "AtomicCmpXchgInst");
   nb::class_<llvm::AtomicRMWInst, llvm::Instruction>(m, "AtomicRMWInst");
   nb::class_<llvm::CleanupPadInst, llvm::FuncletPadInst>(m, "CleanupPadInst");
   nb::class_<llvm::CatchPadInst, llvm::FuncletPadInst>(m, "CatchPadInst");
   nb::class_<llvm::CatchReturnInst, llvm::Instruction>(m, "CatchReturnInst");
   nb::class_<llvm::CleanupReturnInst, llvm::Instruction>(m,
-                                                        "CleanupReturnInst");
+                                                         "CleanupReturnInst");
   nb::class_<llvm::CatchSwitchInst, llvm::Instruction>(m, "CatchSwitchInst");
   nb::class_<llvm::TruncInst, llvm::CastInst>(m, "TruncInst");
   nb::class_<llvm::ZExtInst, llvm::CastInst>(m, "ZExtInst");
@@ -213,5 +214,5 @@ void populate_instructions(nb::module_ &m) {
   nb::class_<llvm::AddrSpaceCastInst, llvm::CastInst>(m, "AddrSpaceCastInst");
   nb::class_<llvm::FPUnaryOperator, llvm::UnaryOperator>(m, "FPUnaryOperator");
   nb::class_<llvm::FPBinaryOperator, llvm::BinaryOperator>(m,
-                                                          "FPBinaryOperator");
+                                                           "FPBinaryOperator");
 }

--- a/projects/eudsl-llvmpy/src/IR/JIT.cpp
+++ b/projects/eudsl-llvmpy/src/IR/JIT.cpp
@@ -19,8 +19,8 @@
 void populate_jit(nb::module_ &m) {
   nb::class_<llvm::orc::LLJIT>(m, "LLJIT")
       .def(nb::new_([]() -> llvm::orc::LLJIT * {
-             return eudsl::unwrap(llvm::orc::LLJITBuilder().create()).release();
-           }))
+        return eudsl::unwrap(llvm::orc::LLJITBuilder().create()).release();
+      }))
       .def(
           "add_module",
           [](llvm::orc::LLJIT &self, eudsl::Module &mod) {

--- a/projects/eudsl-llvmpy/src/IR/Kinds.h
+++ b/projects/eudsl-llvmpy/src/IR/Kinds.h
@@ -9,9 +9,9 @@
 //
 // INVARIANT: every std::type_info returned here must name a class registered
 // with nanobind, otherwise the conversion raises "Unable to convert function
-// return value to a Python type". valueTypeInfo() guards each return with pick()
-// so a not-yet-registered class falls back to base Value, keeping every commit
-// green while later tasks register the leaves.
+// return value to a Python type". valueTypeInfo() guards each return with
+// pick() so a not-yet-registered class falls back to base Value, keeping every
+// commit green while later tasks register the leaves.
 
 #pragma once
 

--- a/projects/eudsl-llvmpy/src/IR/Ownership.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.cpp
@@ -19,13 +19,13 @@ static int64_t gLiveModules = 0;
 /// llvm::Module pointer captured at construction; the entry is inserted by the
 /// ctors and removed by the dtor, so it tracks *wrapper* lifetime. take() does
 /// not update it: after a module is consumed the wrapper stays registered under
-/// its (now-dangling) former key until the wrapper is destroyed -- moduleWrapperFor
-/// only hashes/compares the pointer and never dereferences it, so a stale key is
-/// not itself unsafe (see the guarded erase in ~Module).
+/// its (now-dangling) former key until the wrapper is destroyed --
+/// moduleWrapperFor only hashes/compares the pointer and never dereferences it,
+/// so a stale key is not itself unsafe (see the guarded erase in ~Module).
 ///
 /// Not synchronized: like the gLiveContexts/gLiveModules counters below, this
-/// map assumes the GIL and is not safe under free-threading (the module is built
-/// Py_MOD_GIL_NOT_USED but thread-safety is not verified).
+/// map assumes the GIL and is not safe under free-threading (the module is
+/// built Py_MOD_GIL_NOT_USED but thread-safety is not verified).
 static std::unordered_map<const llvm::Module *, Module *> &liveModuleMap() {
   static std::unordered_map<const llvm::Module *, Module *> map;
   return map;
@@ -88,10 +88,10 @@ Module::Module(std::unique_ptr<llvm::Module> m, Context &ctx)
 
 Module::~Module() {
   // Guard the erase: only remove the entry if it still maps to *this*. After
-  // take() frees the llvm::Module and a new one is allocated at the same address
-  // and wrapped by a different Module, the map key collides; an unconditional
-  // erase(keyMod) would clobber the newer wrapper's entry (ABA), unpinning its
-  // views back into a use-after-free.
+  // take() frees the llvm::Module and a new one is allocated at the same
+  // address and wrapped by a different Module, the map key collides; an
+  // unconditional erase(keyMod) would clobber the newer wrapper's entry (ABA),
+  // unpinning its views back into a use-after-free.
   if (keyMod) {
     auto &map = liveModuleMap();
     auto it = map.find(keyMod);

--- a/projects/eudsl-llvmpy/src/IR/Ownership.h
+++ b/projects/eudsl-llvmpy/src/IR/Ownership.h
@@ -17,7 +17,8 @@ namespace eudsl {
 /// assert nothing leaked, mirroring mlir/test/python/ir/*.py. The shared_ptr is
 /// so a Module (which holds its own copy) can safely outlive the Python context
 /// manager's __exit__: release() drops this object's reference and the live
-/// count, but the underlying LLVMContext survives until the last Module is gone.
+/// count, but the underlying LLVMContext survives until the last Module is
+/// gone.
 class Context {
 public:
   Context();
@@ -79,12 +80,12 @@ private:
 };
 
 /// The eudsl::Module wrapper registered for `m`, or null. Keyed by the
-/// llvm::Module pointer captured when the wrapper was constructed and tracks the
-/// wrapper's lifetime (not the llvm::Module's): after take() consumes the module
-/// the wrapper stays registered under its former key until destroyed. Lets a
-/// sub-object view resolve the owning module from a bare llvm::Value and pin its
-/// Python wrapper alive, so a held view never outlives the module that owns its
-/// storage.
+/// llvm::Module pointer captured when the wrapper was constructed and tracks
+/// the wrapper's lifetime (not the llvm::Module's): after take() consumes the
+/// module the wrapper stays registered under its former key until destroyed.
+/// Lets a sub-object view resolve the owning module from a bare llvm::Value and
+/// pin its Python wrapper alive, so a held view never outlives the module that
+/// owns its storage.
 Module *moduleWrapperFor(const llvm::Module *m);
 
 } // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -26,16 +26,15 @@ void populate_passes(nb::module_ &m) {
       .def_rw("slp_vectorization",
               &llvm::PipelineTuningOptions::SLPVectorization)
       .def_rw("loop_unrolling", &llvm::PipelineTuningOptions::LoopUnrolling)
-      .def_rw("merge_functions",
-              &llvm::PipelineTuningOptions::MergeFunctions);
+      .def_rw("merge_functions", &llvm::PipelineTuningOptions::MergeFunctions);
 
   m.def(
       "run_passes",
       [](eudsl::Module &mod, const std::string &pipeline,
          std::optional<llvm::PipelineTuningOptions> pto, bool debug,
          bool verifyEach) {
-        llvm::PipelineTuningOptions opts = pto.value_or(
-            llvm::PipelineTuningOptions());
+        llvm::PipelineTuningOptions opts =
+            pto.value_or(llvm::PipelineTuningOptions());
         llvm::PassInstrumentationCallbacks pic;
         llvm::StandardInstrumentations si(mod.get().getContext(), debug,
                                           verifyEach);
@@ -65,8 +64,8 @@ void populate_passes(nb::module_ &m) {
       [](eudsl::Module &mod, llvm::OptimizationLevel level,
          std::optional<llvm::PipelineTuningOptions> pto, bool debug,
          bool verifyEach) {
-        llvm::PipelineTuningOptions opts = pto.value_or(
-            llvm::PipelineTuningOptions());
+        llvm::PipelineTuningOptions opts =
+            pto.value_or(llvm::PipelineTuningOptions());
         llvm::PassInstrumentationCallbacks pic;
         llvm::StandardInstrumentations si(mod.get().getContext(), debug,
                                           verifyEach);

--- a/projects/eudsl-llvmpy/src/IR/Sequence.h
+++ b/projects/eudsl-llvmpy/src/IR/Sequence.h
@@ -16,75 +16,81 @@ namespace eudsl {
 /// indexing does not materialize a list.
 ///
 /// Lifetime: two independent anchors keep storage alive. (1) The accessor sets
-/// `owner` to a strong reference to the Python object that owns the *container's*
-/// storage (usually the Module); holding the view -- which holds `owner` -- keeps
-/// that storage alive, and `owner` is also pinned onto every yielded element.
-/// (2) `ownerOf`, when set, resolves an *individual element's* own storage owner,
-/// which is pinned onto that element too -- so a module-owned element yielded by
-/// a none-owner container (e.g. a GlobalVariable via `ConstantExpr.operands`,
-/// whose ConstantExpr has no module) is anchored to its own module rather than
-/// left dangling. Either may resolve to none (a context-owned constant, or no
-/// live module wrapper); the accessors additionally `keep_alive<0,1>` the view to
-/// its immediate parent.
+/// `owner` to a strong reference to the Python object that owns the
+/// *container's* storage (usually the Module); holding the view -- which holds
+/// `owner` -- keeps that storage alive, and `owner` is also pinned onto every
+/// yielded element. (2) `ownerOf`, when set, resolves an *individual element's*
+/// own storage owner, which is pinned onto that element too -- so a
+/// module-owned element yielded by a none-owner container (e.g. a
+/// GlobalVariable via `ConstantExpr.operands`, whose ConstantExpr has no
+/// module) is anchored to its own module rather than left dangling. Either may
+/// resolve to none (a context-owned constant, or no live module wrapper); the
+/// accessors additionally `keep_alive<0,1>` the view to its immediate parent.
 ///
 /// __len__ and integer __getitem__ (negative-aware, IndexError past the ends)
 /// are lazy; a slice materializes just the requested window into a list.
 /// Iteration uses Python's sequence protocol (__getitem__ until IndexError).
-template <typename T> struct Sequence {
+template <typename T>
+struct Sequence {
   std::function<std::size_t()> length;
   std::function<T *(std::size_t)> at;
   nb::object owner;
   std::function<nb::object(T *)> ownerOf;
 };
 
-template <typename T> void bindSequence(nb::module_ &m, const char *name) {
+template <typename T>
+void bindSequence(nb::module_ &m, const char *name) {
   nb::class_<Sequence<T>>(m, name)
       .def("__len__",
            [](Sequence<T> &self) {
              return static_cast<Py_ssize_t>(self.length());
            })
-      .def("__getitem__", [](Sequence<T> &self, nb::handle index) -> nb::object {
-        // Pin each yielded element to its storage owner(s) so it survives even
-        // if the view itself is dropped -- mirroring MLIR's owner-reference
-        // chain. Pin to both the container's owner and (when known) the
-        // element's own owner: the latter anchors a module-owned element yielded
-        // by a none-owner container to its own module.
-        auto element = [&](std::size_t k) -> nb::object {
-          T *ptr = self.at(k);
-          nb::object obj = nb::cast(ptr, nb::rv_policy::reference);
-          auto pin = [&](const nb::object &o) {
-            // nb::detail::keep_alive is the dynamic (runtime nurse/patient) form
-            // behind rv_policy::reference_internal; it is NB_CORE-exported and
-            // has no public wrapper, so the detail:: reach-in is intentional.
-            if (o.is_valid() && !o.is_none())
-              nb::detail::keep_alive(obj.ptr(), o.ptr());
-          };
-          pin(self.owner);
-          if (self.ownerOf)
-            pin(self.ownerOf(ptr));
-          return obj;
-        };
-        Py_ssize_t n = static_cast<Py_ssize_t>(self.length());
-        if (nb::isinstance<nb::slice>(index)) {
-          auto [start, stop, step, count] =
-              nb::cast<nb::slice>(index).compute(static_cast<size_t>(n));
-          nb::list out;
-          Py_ssize_t idx = start;
-          for (size_t k = 0; k < count; ++k) {
-            out.append(element(static_cast<std::size_t>(idx)));
-            idx += step;
-          }
-          return out;
-        }
-        if (!nb::isinstance<nb::int_>(index))
-          throw nb::type_error("sequence indices must be integers or slices");
-        Py_ssize_t i = nb::cast<Py_ssize_t>(index);
-        if (i < 0)
-          i += n;
-        if (i < 0 || i >= n)
-          throw nb::index_error("index out of range");
-        return element(static_cast<std::size_t>(i));
-      });
+      .def("__getitem__",
+           [](Sequence<T> &self, nb::handle index) -> nb::object {
+             // Pin each yielded element to its storage owner(s) so it survives
+             // even if the view itself is dropped -- mirroring MLIR's
+             // owner-reference chain. Pin to both the container's owner and
+             // (when known) the element's own owner: the latter anchors a
+             // module-owned element yielded by a none-owner container to its
+             // own module.
+             auto element = [&](std::size_t k) -> nb::object {
+               T *ptr = self.at(k);
+               nb::object obj = nb::cast(ptr, nb::rv_policy::reference);
+               auto pin = [&](const nb::object &o) {
+                 // nb::detail::keep_alive is the dynamic (runtime
+                 // nurse/patient) form behind rv_policy::reference_internal; it
+                 // is NB_CORE-exported and has no public wrapper, so the
+                 // detail:: reach-in is intentional.
+                 if (o.is_valid() && !o.is_none())
+                   nb::detail::keep_alive(obj.ptr(), o.ptr());
+               };
+               pin(self.owner);
+               if (self.ownerOf)
+                 pin(self.ownerOf(ptr));
+               return obj;
+             };
+             Py_ssize_t n = static_cast<Py_ssize_t>(self.length());
+             if (nb::isinstance<nb::slice>(index)) {
+               auto [start, stop, step, count] =
+                   nb::cast<nb::slice>(index).compute(static_cast<size_t>(n));
+               nb::list out;
+               Py_ssize_t idx = start;
+               for (size_t k = 0; k < count; ++k) {
+                 out.append(element(static_cast<std::size_t>(idx)));
+                 idx += step;
+               }
+               return out;
+             }
+             if (!nb::isinstance<nb::int_>(index))
+               throw nb::type_error(
+                   "sequence indices must be integers or slices");
+             Py_ssize_t i = nb::cast<Py_ssize_t>(index);
+             if (i < 0)
+               i += n;
+             if (i < 0 || i >= n)
+               throw nb::index_error("index out of range");
+             return element(static_cast<std::size_t>(i));
+           });
 }
 
 } // namespace eudsl

--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -24,9 +24,9 @@ std::string emit(llvm::TargetMachine &self, eudsl::Module &mod,
   llvm::buffer_ostream bos(os);
   llvm::legacy::PassManager pm;
   if (self.addPassesToEmitFile(pm, bos, nullptr, type)) {
-    throw std::runtime_error(  // LCOV_EXCL_LINE
-        "target cannot emit this file type");  // LCOV_EXCL_LINE
-  }  // LCOV_EXCL_LINE
+    throw std::runtime_error(                 // LCOV_EXCL_LINE
+        "target cannot emit this file type"); // LCOV_EXCL_LINE
+  } // LCOV_EXCL_LINE
   pm.run(mod.get());
   return buf;
 }
@@ -36,40 +36,38 @@ void populate_target(nb::module_ &m) {
   m.def("host_triple", []() { return llvm::sys::getDefaultTargetTriple(); });
 
   nb::class_<llvm::TargetMachine>(m, "TargetMachine")
-      .def(
-          nb::new_(
-              [](std::optional<std::string> triple,
-                 std::optional<std::string> cpu,
-                 std::optional<std::vector<std::string>> features)
-                  -> llvm::TargetMachine * {
-                std::string tripleStr =
-                    triple.value_or(llvm::sys::getDefaultTargetTriple());
-                std::string cpuStr = cpu.value_or("");
-                std::string featStr;
-                if (features) {
-                  for (size_t i = 0; i < features->size(); ++i) {
-                    if (i > 0)
-                      featStr += ",";
-                    featStr += (*features)[i];
-                  }
-                }
-                llvm::Triple tt(tripleStr);
-                std::string err;
-                const llvm::Target *target =
-                    llvm::TargetRegistry::lookupTarget(tt, err);
-                if (!target)
-                  throw std::runtime_error(err);
-                llvm::TargetOptions opts;
-                llvm::TargetMachine *tm = target->createTargetMachine(
-                    tt, cpuStr, featStr, opts, std::nullopt);
-                if (!tm) {
-                  throw std::runtime_error(  // LCOV_EXCL_LINE
-                      "could not create TargetMachine for " + tripleStr);  // LCOV_EXCL_LINE
-                }  // LCOV_EXCL_LINE
-                return tm;
-              }),
-          "triple"_a = nb::none(), "cpu"_a = nb::none(),
-          "features"_a = nb::none())
+      .def(nb::new_([](std::optional<std::string> triple,
+                       std::optional<std::string> cpu,
+                       std::optional<std::vector<std::string>> features)
+                        -> llvm::TargetMachine * {
+             std::string tripleStr =
+                 triple.value_or(llvm::sys::getDefaultTargetTriple());
+             std::string cpuStr = cpu.value_or("");
+             std::string featStr;
+             if (features) {
+               for (size_t i = 0; i < features->size(); ++i) {
+                 if (i > 0)
+                   featStr += ",";
+                 featStr += (*features)[i];
+               }
+             }
+             llvm::Triple tt(tripleStr);
+             std::string err;
+             const llvm::Target *target =
+                 llvm::TargetRegistry::lookupTarget(tt, err);
+             if (!target)
+               throw std::runtime_error(err);
+             llvm::TargetOptions opts;
+             llvm::TargetMachine *tm = target->createTargetMachine(
+                 tt, cpuStr, featStr, opts, std::nullopt);
+             if (!tm) { // LCOV_EXCL_START
+               throw std::runtime_error("could not create TargetMachine for " +
+                                        tripleStr);
+             } // LCOV_EXCL_STOP
+             return tm;
+           }),
+           "triple"_a = nb::none(), "cpu"_a = nb::none(),
+           "features"_a = nb::none())
       .def_prop_ro("triple",
                    [](llvm::TargetMachine &self) {
                      return self.getTargetTriple().str();

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -54,8 +54,7 @@ void populate_types(nb::module_ &m) {
              return &self == o;
            })
       .def("__hash__", [](llvm::Type &self) {
-        return static_cast<Py_ssize_t>(
-            reinterpret_cast<std::uintptr_t>(&self));
+        return static_cast<Py_ssize_t>(reinterpret_cast<std::uintptr_t>(&self));
       });
 
   // Primitive type factories. The context is optional: when omitted, the
@@ -97,7 +96,8 @@ void populate_types(nb::module_ &m) {
       .def_static(
           "get",
           [](unsigned bits, eudsl::Context *context) -> llvm::IntegerType * {
-            return llvm::IntegerType::get(eudsl::currentOr(context).get(), bits);
+            return llvm::IntegerType::get(eudsl::currentOr(context).get(),
+                                          bits);
           },
           "bits"_a, "context"_a.none() = nb::none(), nb::rv_policy::reference,
           nb::keep_alive<0, 2>())
@@ -323,4 +323,3 @@ void populate_types(nb::module_ &m) {
       "return_type"_a, "params"_a, "var_arg"_a = false,
       nb::rv_policy::reference, nb::keep_alive<0, 1>());
 }
-

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -15,8 +15,8 @@
 #include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalObject.h>
 #include <llvm/IR/GlobalValue.h>
-#include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/InstIterator.h>
+#include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instruction.h>
 #include <llvm/IR/Use.h>
 #include <llvm/IR/User.h>
@@ -130,8 +130,7 @@ void populate_values(nb::module_ &m) {
              return &self == o;
            })
       .def("__hash__", [](llvm::Value &self) {
-        return static_cast<Py_ssize_t>(
-            reinterpret_cast<std::uintptr_t>(&self));
+        return static_cast<Py_ssize_t>(reinterpret_cast<std::uintptr_t>(&self));
       });
 
   nb::class_<llvm::User, llvm::Value>(m, "User")
@@ -190,10 +189,9 @@ void populate_values(nb::module_ &m) {
 
   nb::class_<llvm::Instruction, llvm::User>(m, "Instruction")
       .EUDSL_CAST_CTOR(llvm::Instruction, llvm::Value)
-      .def_prop_ro("num_successors",
-                   [](llvm::Instruction &self) {
-                     return self.getNumSuccessors();
-                   })
+      .def_prop_ro(
+          "num_successors",
+          [](llvm::Instruction &self) { return self.getNumSuccessors(); })
       .def("successor", &llvm::Instruction::getSuccessor, "index"_a,
            nb::rv_policy::reference_internal)
       .def("set_successor", &llvm::Instruction::setSuccessor, "index"_a,
@@ -241,7 +239,9 @@ void populate_values(nb::module_ &m) {
               return &*it;
             };
             seq.owner = ownerObjectFor(b);
-            seq.ownerOf = [](llvm::Instruction *e) { return ownerObjectFor(e); };
+            seq.ownerOf = [](llvm::Instruction *e) {
+              return ownerObjectFor(e);
+            };
             return seq;
           },
           nb::keep_alive<0, 1>())
@@ -375,8 +375,7 @@ void populate_values(nb::module_ &m) {
             return static_cast<CallingConvEnum>(self.getCallingConv());
           },
           [](llvm::Function &self, CallingConvEnum cc) {
-            self.setCallingConv(
-                static_cast<llvm::CallingConv::ID>(cc));
+            self.setCallingConv(static_cast<llvm::CallingConv::ID>(cc));
           })
       .def(
           "add_fn_attr",

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -12,4 +12,3 @@ from . import ir, types, passmanager, jit, intrinsics, instructions, dsl  # noqa
 from .dsl.values import install_value_casters as _install_value_casters
 
 _install_value_casters()
-

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -248,9 +248,7 @@ class WhileToWhileLoop(StrictTransformer):
                 defaults=[],
             )
 
-        carried_load = ast.Tuple(
-            [ast.Name(n, ast.Load()) for n in carried], ast.Load()
-        )
+        carried_load = ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load())
         carried_store = ast.Tuple(
             [ast.Name(n, ast.Store()) for n in carried], ast.Store()
         )
@@ -279,9 +277,7 @@ class WhileToWhileLoop(StrictTransformer):
                 args=[
                     ast.Name(cond_name, ast.Load()),
                     ast.Name(body_name, ast.Load()),
-                    ast.Tuple(
-                        [ast.Name(n, ast.Load()) for n in carried], ast.Load()
-                    ),
+                    ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load()),
                 ],
                 keywords=[],
             ),
@@ -358,9 +354,7 @@ class ForToForLoop(StrictTransformer):
             kwarg=None,
             defaults=[],
         )
-        carried_load = ast.Tuple(
-            [ast.Name(n, ast.Load()) for n in carried], ast.Load()
-        )
+        carried_load = ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load())
         carried_store = ast.Tuple(
             [ast.Name(n, ast.Store()) for n in carried], ast.Store()
         )
@@ -380,9 +374,7 @@ class ForToForLoop(StrictTransformer):
                     stop,
                     step,
                     ast.Name(body_name, ast.Load()),
-                    ast.Tuple(
-                        [ast.Name(n, ast.Load()) for n in carried], ast.Load()
-                    ),
+                    ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load()),
                 ],
                 keywords=[],
             ),
@@ -407,14 +399,10 @@ class RejectUnsupportedJumps(StrictTransformer):
     """
 
     def visit_Break(self, node):
-        raise NotImplementedError(
-            "`break` inside DSL control flow is not supported"
-        )
+        raise NotImplementedError("`break` inside DSL control flow is not supported")
 
     def visit_Continue(self, node):
-        raise NotImplementedError(
-            "`continue` inside DSL control flow is not supported"
-        )
+        raise NotImplementedError("`continue` inside DSL control flow is not supported")
 
     def _reject_nested_return(self, node):
         for child in ast.walk(node):

--- a/projects/eudsl-llvmpy/src/llvm/dsl/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/__init__.py
@@ -3,4 +3,3 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from .func import function  # noqa: F401
 from .cf import yield_, range_  # noqa: F401
-

--- a/projects/eudsl-llvmpy/src/llvm/dsl/casters.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/casters.py
@@ -23,7 +23,7 @@ def register_value_caster(type_id, caster=None):
     """
 
     def decorator(c):
-        _register(type_id.value if hasattr(type_id, 'value') else int(type_id), c)
+        _register(type_id.value if hasattr(type_id, "value") else int(type_id), c)
         return c
 
     if caster is not None:

--- a/projects/eudsl-llvmpy/src/llvm/dsl/func.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/func.py
@@ -89,9 +89,7 @@ def _body_is_empty(f) -> bool:
     for stmt in fn_node.body:
         if isinstance(stmt, ast.Pass):
             continue
-        if isinstance(stmt, ast.Expr) and isinstance(
-            stmt.value, ast.Constant
-        ):
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
             # `...` (Ellipsis) or a docstring.
             continue
         return False

--- a/projects/eudsl-llvmpy/src/llvm/dsl/values.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/values.py
@@ -58,9 +58,7 @@ class ArithValue(Value):
             raise TypeError(f"mismatched types: {self.type} and {other.type}")
         b = current_builder()
         if self.type.is_floating_point:
-            return self._wrap(
-                b.fcmp(getattr(FCmpPredicate, fcmp_pred), self, other)
-            )
+            return self._wrap(b.fcmp(getattr(FCmpPredicate, fcmp_pred), self, other))
         return self._wrap(b.icmp(getattr(ICmpPredicate, icmp_pred), self, other))
 
     def __add__(self, other):
@@ -176,6 +174,4 @@ def extract(aggregate, index):
     Returned as its registered caster subclass when applicable (e.g. an
     integer/float field becomes an ArithValue).
     """
-    return maybe_downcast(
-        current_builder().extract_value(aggregate, index), aggregate
-    )
+    return maybe_downcast(current_builder().extract_value(aggregate, index), aggregate)

--- a/projects/eudsl-llvmpy/src/llvm/instructions.py
+++ b/projects/eudsl-llvmpy/src/llvm/instructions.py
@@ -19,31 +19,83 @@ the callee's parameter type for ``call``. Integer indices to ``gep``,
 type can be inferred (e.g. both operands are numbers), a ``TypeError`` is
 raised; pass an explicit constant in that case.
 """
+
 from .ir import const_fp, const_int, current_builder
 
 __all__ = [
     # terminators
-    "ret", "br", "cond_br", "unreachable", "switch_", "indirect_br", "resume",
+    "ret",
+    "br",
+    "cond_br",
+    "unreachable",
+    "switch_",
+    "indirect_br",
+    "resume",
     # integer / float binary
-    "add", "fadd", "sub", "fsub", "mul", "fmul", "sdiv", "udiv", "fdiv",
-    "srem", "urem", "frem", "shl", "lshr", "ashr", "and_", "or_", "xor",
+    "add",
+    "fadd",
+    "sub",
+    "fsub",
+    "mul",
+    "fmul",
+    "sdiv",
+    "udiv",
+    "fdiv",
+    "srem",
+    "urem",
+    "frem",
+    "shl",
+    "lshr",
+    "ashr",
+    "and_",
+    "or_",
+    "xor",
     # unary
-    "neg", "fneg", "not_",
+    "neg",
+    "fneg",
+    "not_",
     # comparisons
-    "icmp", "fcmp",
+    "icmp",
+    "fcmp",
     # casts
-    "trunc", "zext", "sext", "fptoui", "fptosi", "uitofp", "sitofp",
-    "fptrunc", "fpext", "ptrtoint", "inttoptr", "bitcast", "addrspacecast",
+    "trunc",
+    "zext",
+    "sext",
+    "fptoui",
+    "fptosi",
+    "uitofp",
+    "sitofp",
+    "fptrunc",
+    "fpext",
+    "ptrtoint",
+    "inttoptr",
+    "bitcast",
+    "addrspacecast",
     "ptrtoaddr",
     # memory / atomics
-    "alloca", "load", "store", "gep", "fence", "atomic_rmw", "atomic_cmpxchg",
+    "alloca",
+    "load",
+    "store",
+    "gep",
+    "fence",
+    "atomic_rmw",
+    "atomic_cmpxchg",
     # calls, phis, constants
-    "call", "call_intrinsic", "phi", "i64_const", "i32_const",
+    "call",
+    "call_intrinsic",
+    "phi",
+    "i64_const",
+    "i32_const",
     # aggregates / vectors
-    "extract_value", "insert_value", "extract_element", "insert_element",
+    "extract_value",
+    "insert_value",
+    "extract_element",
+    "insert_element",
     "shuffle_vector",
     # misc
-    "select", "freeze", "va_arg",
+    "select",
+    "freeze",
+    "va_arg",
 ]
 
 
@@ -66,8 +118,7 @@ def _const_of(value, ref_type):
     if ref_type.is_integer:
         if isinstance(value, float):
             raise TypeError(
-                f"cannot use float {value!r} as an integer constant of "
-                f"{ref_type}"
+                f"cannot use float {value!r} as an integer constant of " f"{ref_type}"
             )
         # Interpret negatives as signed and non-negatives as unsigned so the
         # full [-2**(w-1), 2**w) range is accepted (e.g. the mask 0xFF into i8).

--- a/projects/eudsl-llvmpy/tests/ast/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/ast/test_ast.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import ast
 import sys
+from textwrap import dedent
 
 from llvm.ast import canonicalize, util
 from llvm.ast import cf_transformers as T
@@ -22,7 +23,13 @@ def _rewrite(src):
 
 
 def test_if_becomes_with_if_ctx_manager():
-    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
+    src = dedent("""\
+        def f():
+            if c:
+                x = a
+            else:
+                x = b
+        """)
     out = _rewrite(src)
     assert "if_ctx_manager" in out
     assert "else_ctx_manager" in out
@@ -92,7 +99,13 @@ def test_canonicalize_module_imports_clean():
 
 
 def test_if_rewrite_preserves_linenos():
-    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
+    src = dedent("""\
+        def f():
+            if c:
+                x = a
+            else:
+                x = b
+        """)
     tree = ast.parse(src)
     node = tree.body[0]
     for ctor in (
@@ -194,7 +207,13 @@ def test_replace_yield_with_llvm_yield_preserves_lineno():
 
 
 def test_rewrite_produces_expected_ast_structure():
-    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
+    src = dedent("""\
+        def f():
+            if c:
+                x = a
+            else:
+                x = b
+        """)
     tree = ast.parse(src)
     node = tree.body[0]
     for ctor in (

--- a/projects/eudsl-llvmpy/tests/ast/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/ast/test_ast.py
@@ -22,13 +22,7 @@ def _rewrite(src):
 
 
 def test_if_becomes_with_if_ctx_manager():
-    src = (
-        "def f():\n"
-        "    if c:\n"
-        "        x = a\n"
-        "    else:\n"
-        "        x = b\n"
-    )
+    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
     out = _rewrite(src)
     assert "if_ctx_manager" in out
     assert "else_ctx_manager" in out
@@ -98,13 +92,7 @@ def test_canonicalize_module_imports_clean():
 
 
 def test_if_rewrite_preserves_linenos():
-    src = (
-        "def f():\n"
-        "    if c:\n"
-        "        x = a\n"
-        "    else:\n"
-        "        x = b\n"
-    )
+    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
     tree = ast.parse(src)
     node = tree.body[0]
     for ctor in (
@@ -128,8 +116,8 @@ def test_if_rewrite_preserves_linenos():
 def test_insert_empty_yield_linenos():
     # InsertEmptyYield appends a synthetic yield at end_lineno of the last stmt.
     src = (
-        "def f():\n"       # line 1
-        "    if c:\n"      # line 2
+        "def f():\n"  # line 1
+        "    if c:\n"  # line 2
         "        x = a\n"  # line 3
     )
     tree = ast.parse(src)
@@ -146,10 +134,10 @@ def test_elif_adjacency_lineno_check():
     # ReplaceIfWithWith detects elif via end_lineno + 1 == orelse[0].lineno.
     # When this adjacency holds, the else-With gets copy_location from the elif.
     src = (
-        "def f():\n"           # line 1
-        "    if c1:\n"         # line 2
+        "def f():\n"  # line 1
+        "    if c1:\n"  # line 2
         "        r = yield 1\n"  # line 3
-        "    elif c2:\n"       # line 4
+        "    elif c2:\n"  # line 4
         "        r = yield 2\n"  # line 5
     )
     tree = ast.parse(src)
@@ -172,11 +160,11 @@ def test_canonicalize_elifs_preserves_forwarded_yield_lineno():
     # last_statement.end_lineno. The forwarded yield should sit at the
     # end_lineno of the last statement in the orelse body.
     src = (
-        "def f():\n"           # line 1
-        "    if outer:\n"      # line 2
+        "def f():\n"  # line 1
+        "    if outer:\n"  # line 2
         "        if inner:\n"  # line 3
         "            r = yield 1\n"  # line 4
-        "        x = 2\n"     # line 5
+        "        x = 2\n"  # line 5
     )
     tree = ast.parse(src)
     node = tree.body[0]
@@ -191,8 +179,8 @@ def test_canonicalize_elifs_preserves_forwarded_yield_lineno():
 def test_replace_yield_with_llvm_yield_preserves_lineno():
     # ReplaceYieldWithLLVMYield uses ast.copy_location from the Yield node.
     src = (
-        "def f():\n"           # line 1
-        "    if c:\n"          # line 2
+        "def f():\n"  # line 1
+        "    if c:\n"  # line 2
         "        r = yield a\n"  # line 3
     )
     tree = ast.parse(src)
@@ -206,13 +194,7 @@ def test_replace_yield_with_llvm_yield_preserves_lineno():
 
 
 def test_rewrite_produces_expected_ast_structure():
-    src = (
-        "def f():\n"
-        "    if c:\n"
-        "        x = a\n"
-        "    else:\n"
-        "        x = b\n"
-    )
+    src = "def f():\n" "    if c:\n" "        x = a\n" "    else:\n" "        x = b\n"
     tree = ast.parse(src)
     node = tree.body[0]
     for ctor in (
@@ -239,9 +221,9 @@ def test_while_to_while_loop_preserves_lineno():
     # WhileToWhileLoop replaces the while node with [cond_fn, body_fn, call],
     # each carrying the original while's lineno via ast.copy_location.
     src = (
-        "def f():\n"       # line 1
-        "    x = 0\n"      # line 2
-        "    while x:\n"   # line 3
+        "def f():\n"  # line 1
+        "    x = 0\n"  # line 2
+        "    while x:\n"  # line 3
         "        x = 1\n"  # line 4
         "        yield x\n"  # line 5
     )
@@ -268,8 +250,8 @@ def test_for_to_for_loop_preserves_lineno():
     # ForToForLoop replaces the for node with [body_fn, call], each carrying
     # the original for's lineno via ast.copy_location.
     src = (
-        "def f():\n"         # line 1
-        "    acc = 0\n"      # line 2
+        "def f():\n"  # line 1
+        "    acc = 0\n"  # line 2
         "    for i in range_(0, 10):\n"  # line 3
         "        acc = 1\n"  # line 4
         "        yield acc\n"  # line 5

--- a/projects/eudsl-llvmpy/tests/conftest.py
+++ b/projects/eudsl-llvmpy/tests/conftest.py
@@ -11,6 +11,7 @@ the case a context-only, in-body check cannot: `Context.__exit__` drops the
 context count to zero even while a leaked Module keeps its LLVMContext alive,
 so the Module count (tied to actual destruction) is what makes a leak visible.
 """
+
 import gc
 
 import pytest

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
@@ -172,9 +172,11 @@ def test_function_rejects_unresolvable_annotation():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(TypeError, match="cannot resolve type annotation"):
+
             @llvm.dsl.function(module=mod)
             def bad(x: "not a type") -> i32:
                 return x
+
         del mod
     assert_no_leaks()
 
@@ -287,6 +289,7 @@ def test_break_inside_dsl_control_flow_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="`break`"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -296,6 +299,7 @@ def test_break_inside_dsl_control_flow_raises():
                     i = i + 1
                     yield i
                 return i
+
         del mod
     assert_no_leaks()
 
@@ -305,6 +309,7 @@ def test_continue_inside_dsl_control_flow_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="`continue`"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -314,6 +319,7 @@ def test_continue_inside_dsl_control_flow_raises():
                     i = i + 1
                     yield i
                 return i
+
         del mod
     assert_no_leaks()
 
@@ -323,6 +329,7 @@ def test_early_return_inside_dsl_control_flow_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(c: llvm.types.i1, a: i32) -> i32:
@@ -330,6 +337,7 @@ def test_early_return_inside_dsl_control_flow_raises():
                     return a
                 r = yield a
                 return r
+
         del mod
     assert_no_leaks()
 
@@ -339,6 +347,7 @@ def test_while_body_without_trailing_yield_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with `yield"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -346,6 +355,7 @@ def test_while_body_without_trailing_yield_raises():
                 while i.ne(n):
                     i = i + 1
                 return i
+
         del mod
     assert_no_leaks()
 
@@ -355,6 +365,7 @@ def test_for_body_without_trailing_yield_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="must end with `yield"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -362,6 +373,7 @@ def test_for_body_without_trailing_yield_raises():
                 for i in range_(0, n):
                     acc = acc + i
                 return acc
+
         del mod
     assert_no_leaks()
 
@@ -371,6 +383,7 @@ def test_for_target_must_be_single_name_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="single name"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -379,6 +392,7 @@ def test_for_target_must_be_single_name_raises():
                     acc = acc + i
                     yield acc
                 return acc
+
         del mod
     assert_no_leaks()
 
@@ -388,6 +402,7 @@ def test_for_range_wrong_arg_count_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="1-3 arguments"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -396,6 +411,7 @@ def test_for_range_wrong_arg_count_raises():
                     acc = acc + i
                     yield acc
                 return acc
+
         del mod
     assert_no_leaks()
 
@@ -405,6 +421,7 @@ def test_loop_yield_non_name_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="plain loop-carried"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -412,14 +429,17 @@ def test_loop_yield_non_name_raises():
                 for i in range_(0, n):
                     yield acc + i
                 return acc
+
         del mod
     assert_no_leaks()
+
 
 def test_nested_control_flow_inside_loop_raises():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="not supported"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32, c: llvm.types.i1) -> i32:
@@ -429,6 +449,7 @@ def test_nested_control_flow_inside_loop_raises():
                         i = i + 1
                     yield i
                 return i
+
         del mod
     assert_no_leaks()
 
@@ -642,6 +663,7 @@ def test_early_return_inside_while_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -650,6 +672,7 @@ def test_early_return_inside_while_raises():
                     return acc
                     yield acc
                 return acc
+
         del mod
     assert_no_leaks()
 
@@ -659,6 +682,7 @@ def test_early_return_inside_for_raises():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         with pytest.raises(NotImplementedError, match="early `return`"):
+
             @llvm.dsl.function(module=mod)
             @canonicalize(using=LLVMCanonicalizer())
             def f(n: i32) -> i32:
@@ -667,6 +691,7 @@ def test_early_return_inside_for_raises():
                     return acc
                     yield acc
                 return acc
+
         del mod
     assert_no_leaks()
 
@@ -692,6 +717,8 @@ def test_if_else_phi_has_correct_incomings():
         filecheck_with_comments(mod)
         del mod
     assert_no_leaks()
+
+
 def test_while_loop_verifies_cleanly():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_edges.py
@@ -2,6 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Edge cases and error branches of the DSL control-flow lowering."""
+
 import ctypes
 
 import pytest
@@ -85,7 +86,7 @@ def test_for_non_name_target_raises():
             @canonicalize(using=LLVMCanonicalizer())
             def bad(n: i32) -> i32:
                 acc = llvm.ir.const_int(i32, 0)
-                for (i, j) in range_(0, n):
+                for i, j in range_(0, n):
                     acc = acc + acc
                     yield acc
                 return acc

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
@@ -2,6 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Unsupported control flow must raise NotImplementedError, not miscompile."""
+
 import pytest
 
 import llvm

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_coverage.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_coverage.py
@@ -2,6 +2,7 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Exercises DSL API surface and error paths for coverage + correctness."""
+
 import ctypes
 
 import pytest
@@ -31,8 +32,8 @@ def test_all_binary_dunders():
             _ = a - b
             _ = a * b
             _ = a / b
-            _ = 3 + a       # __radd__
-            _ = 3 * a       # __rmul__
+            _ = 3 + a  # __radd__
+            _ = 3 * a  # __rmul__
             bld.ret(a + b)
         p = str(mod)
         assert "sub i32" in p and "mul i32" in p and "sdiv i32" in p
@@ -151,7 +152,11 @@ def test_typed_pointer_setitem_with_value_index():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         fn = llvm.ir.Function.create(
-            llvm.types.function(llvm.types.void(ctx), [llvm.types.ptr(context=ctx), i32]), "f", mod
+            llvm.types.function(
+                llvm.types.void(ctx), [llvm.types.ptr(context=ctx), i32]
+            ),
+            "f",
+            mod,
         )
         bb = fn.append_basic_block("entry")
         bld = llvm.ir.IRBuilder(ctx)
@@ -172,7 +177,9 @@ def test_maybe_downcast_no_caster_passthrough():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         # A void-typed value has no registered caster: returned unchanged.
-        fn = llvm.ir.Function.create(llvm.types.function(llvm.types.void(ctx), []), "f", mod)
+        fn = llvm.ir.Function.create(
+            llvm.types.function(llvm.types.void(ctx), []), "f", mod
+        )
         v = maybe_downcast(fn, fn)  # Function's type kind has no caster
         assert not isinstance(v, ArithValue)
         del fn, mod

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_func.py
@@ -28,7 +28,9 @@ PTR3 = PointerType[3]
 ARR = ArrayType[IntegerType[32], 4]
 VEC = VectorType[IntegerType[32], 4]
 STRUCT = StructType[IntegerType[32], IntegerType[64]]
-NESTED_STRUCT = StructType[StructType[IntegerType[32], IntegerType[64]], IntegerType[32]]
+NESTED_STRUCT = StructType[
+    StructType[IntegerType[32], IntegerType[64]], IntegerType[32]
+]
 
 
 def test_declaration_has_no_body():

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_values.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_values.py
@@ -429,7 +429,9 @@ def test_pointer_subscript_returns_arithvalue():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32()
-        fn = llvm.ir.Function.create(llvm.types.function(i32, [llvm.types.ptr()]), "g", mod)
+        fn = llvm.ir.Function.create(
+            llvm.types.function(i32, [llvm.types.ptr()]), "g", mod
+        )
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):
@@ -450,7 +452,9 @@ def test_pointer_subscript_accepts_value_index():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32()
-        fn = llvm.ir.Function.create(llvm.types.function(i32, [llvm.types.ptr()]), "g", mod)
+        fn = llvm.ir.Function.create(
+            llvm.types.function(i32, [llvm.types.ptr()]), "g", mod
+        )
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):

--- a/projects/eudsl-llvmpy/tests/dsl/test_insert_point.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_insert_point.py
@@ -6,6 +6,7 @@ for the block, positioned at the target, and restore it on exit. Nested
 InsertPoints omit `builder` to reuse the current one. Also the at_block_begin /
 at_block_terminator / after factories, InsertPoint.current, and current_builder /
 current_function derived from the active InsertPoint."""
+
 import pytest
 
 import llvm
@@ -15,9 +16,7 @@ from llvm.testing import assert_no_leaks, filecheck_with_comments
 
 def _fn(ctx, name="f"):
     mod = llvm.ir.Module("m", ctx)
-    fn = llvm.ir.Function.create(
-        llvm.types.function(llvm.types.void(), []), name, mod
-    )
+    fn = llvm.ir.Function.create(llvm.types.function(llvm.types.void(), []), name, mod)
     return mod, fn
 
 

--- a/projects/eudsl-llvmpy/tests/ir/test_attributes.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_attributes.py
@@ -6,7 +6,9 @@ from llvm.testing import assert_no_leaks
 
 
 def _fn(ctx, mod):
-    return llvm.ir.Function.create(llvm.types.function(llvm.types.void(ctx), []), "f", mod)
+    return llvm.ir.Function.create(
+        llvm.types.function(llvm.types.void(ctx), []), "f", mod
+    )
 
 
 def test_linkage_internal():

--- a/projects/eudsl-llvmpy/tests/ir/test_bindings.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_bindings.py
@@ -8,8 +8,7 @@ from llvm.testing import assert_no_leaks
 
 
 def test_smoke():
-    src = dedent(
-        """\
+    src = dedent("""\
         declare i32 @foo()
         declare i32 @bar()
         define i32 @entry(i32 %argc) {
@@ -27,8 +26,7 @@ def test_smoke():
           %retval.0 = phi i32 [ %call, %if.then ], [ %call1, %if.end ]
           ret i32 %retval.0
         }
-        """
-    )
+        """)
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(src, ctx, "test_smoke")
         assert mod.module_identifier == "test_smoke"

--- a/projects/eudsl-llvmpy/tests/ir/test_builder.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_builder.py
@@ -146,9 +146,7 @@ def test_icmp():
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
         i1 = llvm.types.i1(ctx)
-        fn = llvm.ir.Function.create(
-            llvm.types.function(i1, [i32, i32]), "cmp", mod
-        )
+        fn = llvm.ir.Function.create(llvm.types.function(i1, [i32, i32]), "cmp", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):
@@ -166,9 +164,7 @@ def test_fcmp():
         mod = llvm.ir.Module("m", ctx)
         f64 = llvm.types.f64(ctx)
         i1 = llvm.types.i1(ctx)
-        fn = llvm.ir.Function.create(
-            llvm.types.function(i1, [f64, f64]), "fcmp", mod
-        )
+        fn = llvm.ir.Function.create(llvm.types.function(i1, [f64, f64]), "fcmp", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):
@@ -205,12 +201,8 @@ def test_call():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i32 = llvm.types.i32(ctx)
-        callee = llvm.ir.Function.create(
-            llvm.types.function(i32, [i32]), "callee", mod
-        )
-        fn = llvm.ir.Function.create(
-            llvm.types.function(i32, [i32]), "caller", mod
-        )
+        callee = llvm.ir.Function.create(llvm.types.function(i32, [i32]), "callee", mod)
+        fn = llvm.ir.Function.create(llvm.types.function(i32, [i32]), "caller", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):
@@ -227,9 +219,7 @@ def test_i32_const_and_i64_const():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.Module("m", ctx)
         i64 = llvm.types.i64(ctx)
-        fn = llvm.ir.Function.create(
-            llvm.types.function(i64, []), "consts", mod
-        )
+        fn = llvm.ir.Function.create(llvm.types.function(i64, []), "consts", mod)
         bb = fn.append_basic_block("entry")
         b = llvm.ir.IRBuilder(ctx)
         with InsertPoint(bb, builder=b):

--- a/projects/eudsl-llvmpy/tests/ir/test_cast_constructors.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_cast_constructors.py
@@ -10,6 +10,7 @@ from the other hierarchy entirely (a Value into a Type ctor, or vice versa) is
 rejected by nanobind as a TypeError before the cast body runs. This is the
 parity analogue of MLIR's `IntegerType(t)`.
 """
+
 from textwrap import dedent
 
 import pytest
@@ -17,8 +18,7 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     @g = global i32 0
     declare i32 @callee(i32)
     define i32 @f(i1 %c, ptr %p, i32 %x) {
@@ -39,8 +39,7 @@ _SRC = dedent(
       %phi = phi i32 [ %v, %a ], [ %call, %b ]
       ret i32 %phi
     }
-    """
-)
+    """)
 
 
 def test_type_cast_constructors():
@@ -112,12 +111,10 @@ def test_value_cast_constructors():
         gep = by(llvm.ir.GetElementPtrInst)
         cmp = by(llvm.ir.CmpInst)
         call = by(llvm.ir.CallBase)
-        load_v = next(
-            i for i in entry.instructions if isinstance(i, llvm.ir.LoadInst)
-        )
-        gvar = [
-            i for i in entry.instructions if isinstance(i, llvm.ir.LoadInst)
-        ][-1].pointer_operand
+        load_v = next(i for i in entry.instructions if isinstance(i, llvm.ir.LoadInst))
+        gvar = [i for i in entry.instructions if isinstance(i, llvm.ir.LoadInst)][
+            -1
+        ].pointer_operand
         join = next(b for b in f.basic_blocks if b.name == "join")
         phi = next(i for i in join.instructions if isinstance(i, llvm.ir.PHINode))
         ret = join.terminator

--- a/projects/eudsl-llvmpy/tests/ir/test_const_accessors.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_const_accessors.py
@@ -5,6 +5,7 @@
 ConstantDataArray/Vector element and string access, ConstantExpr.opcode_name,
 BlockAddress.function/basic_block, GlobalAlias.aliasee, GlobalIFunc.resolver.
 """
+
 from textwrap import dedent
 
 import pytest
@@ -12,8 +13,7 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     @g = global i32 7
     @darr = global [4 x i8] c"abcd"
     @sbytes = global [2 x i8] c"\\FF\\7F"
@@ -39,8 +39,7 @@ _SRC = dedent(
       %bp = load ptr, ptr @ba
       ret i32 0
     }
-    """
-)
+    """)
 
 
 def _globals(ctx):

--- a/projects/eudsl-llvmpy/tests/ir/test_constants.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_constants.py
@@ -8,24 +8,20 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_GLOBALS_SRC = dedent(
-    """\
+_GLOBALS_SRC = dedent("""\
     @g_const  = constant i32 42
     @g_var    = global i32 7
     @g_noinit = external global i32
-    """
-)
+    """)
 
-_AGGREGATE_SRC = dedent(
-    """\
+_AGGREGATE_SRC = dedent("""\
     @g_var  = global i32 7
     @arr    = constant [6 x i8] c"hello\\00"
     @zero   = constant [4 x i32] zeroinitializer
     @vec    = constant <4 x i32> <i32 1, i32 2, i32 3, i32 4>
     @strukt = constant { i32, float } { i32 1, float 2.0 }
     @expr   = constant i32* getelementptr (i32, i32* @g_var, i32 1)
-    """
-)
+    """)
 
 
 def test_const_int():
@@ -70,7 +66,10 @@ def test_undef_poison_null():
     with llvm.ir.Context() as ctx:
         assert type(llvm.ir.undef(llvm.types.i32(ctx))).__name__ == "UndefValue"
         assert type(llvm.ir.poison(llvm.types.i32(ctx))).__name__ == "PoisonValue"
-        assert type(llvm.ir.null(llvm.types.ptr(context=ctx))).__name__ == "ConstantPointerNull"
+        assert (
+            type(llvm.ir.null(llvm.types.ptr(context=ctx))).__name__
+            == "ConstantPointerNull"
+        )
         assert llvm.ir.null is llvm.ir.const_null
         assert str(llvm.ir.undef(llvm.types.i32(ctx))) == "i32 undef"
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/ir/test_current_context.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_current_context.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """MLIR-style implicit current context: `with Context():` sets Context.current,
 so the primitive type factories can be called without an explicit context."""
+
 import threading
 
 import pytest

--- a/projects/eudsl-llvmpy/tests/ir/test_delegating_accessors.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_delegating_accessors.py
@@ -16,20 +16,19 @@ The C++ coverage gate now also enforces FUNCTION coverage (each lambda is its
 own function), so a binding whose body is never called fails the gate. This
 file exercises those bindings and checks their results.
 """
+
 from textwrap import dedent
 
 import llvm
 from llvm.testing import assert_no_leaks, filecheck_with_comments
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @f(i32 %x, i32 %y) {
     entry:
       %sum = add i32 %x, %y
       ret i32 %sum
     }
-    """
-)
+    """)
 
 
 def test_type_is_pointer_and_is_label():
@@ -47,7 +46,9 @@ def test_type_is_pointer_and_is_label():
 
 def test_vector_type_element_type():
     with llvm.ir.Context() as ctx:
-        assert llvm.types.vector(llvm.types.f32(ctx), 8).element_type == llvm.types.f32(ctx)
+        assert llvm.types.vector(llvm.types.f32(ctx), 8).element_type == llvm.types.f32(
+            ctx
+        )
     assert_no_leaks()
 
 
@@ -79,8 +80,7 @@ def test_replace_all_uses_with():
 def test_instruction_successor():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define void @f(i1 %c) {
                 entry:
                   br i1 %c, label %a, label %b
@@ -89,8 +89,7 @@ def test_instruction_successor():
                 b:
                   ret void
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )
@@ -105,14 +104,12 @@ def test_instruction_successor():
 def test_function_type_and_var_arg():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 declare i32 @printf(ptr, ...)
                 define i32 @f(i32 %x) {
                   ret i32 %x
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )
@@ -139,8 +136,7 @@ def test_function_visibility_roundtrip():
 def test_global_variable_is_constant():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 @c = constant i32 5
                 @v = global i32 0
                 define i32 @f() {
@@ -149,16 +145,13 @@ def test_global_variable_is_constant():
                   %b = load i32, ptr @v
                   ret i32 %a
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )
         f = mod.get_function("f")
         loads = [
-            i
-            for i in f.entry_block.instructions
-            if type(i).__name__ == "LoadInst"
+            i for i in f.entry_block.instructions if type(i).__name__ == "LoadInst"
         ]
         assert loads[0].pointer_operand.is_constant  # @c
         assert not loads[1].pointer_operand.is_constant  # @v
@@ -190,8 +183,17 @@ def test_builder_binary_ops_and_insert_point():
         b.fdiv(fa, fb)
         b.ret(ia)
         printed = str(mod)
-        for op in ("add i32", "sub i32", "mul i32", "sdiv i32", "udiv i32",
-                   "fadd float", "fsub float", "fmul float", "fdiv float"):
+        for op in (
+            "add i32",
+            "sub i32",
+            "mul i32",
+            "sdiv i32",
+            "udiv i32",
+            "fadd float",
+            "fsub float",
+            "fmul float",
+            "fdiv float",
+        ):
             assert op in printed, op
         del b, bb, fn, ia, ib, fa, fb, mod
     assert_no_leaks()
@@ -200,8 +202,7 @@ def test_builder_binary_ops_and_insert_point():
 def test_instruction_accessors():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 declare i32 @g(i32)
                 define i32 @f(i1 %c, ptr %p) {
                 entry:
@@ -215,8 +216,7 @@ def test_instruction_accessors():
                 b:
                   ret i32 %r
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )
@@ -266,8 +266,7 @@ def test_instruction_set_successor():
     # indirectly by the elif JIT tests; assert it directly here too.
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define void @f(i1 %cond) {
                 entry:
                   br i1 %cond, label %a, label %b
@@ -278,8 +277,7 @@ def test_instruction_set_successor():
                 c:
                   ret void
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )

--- a/projects/eudsl-llvmpy/tests/ir/test_downcast_kinds.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_downcast_kinds.py
@@ -10,6 +10,7 @@ nor function coverage forces a test to ever obtain one. A wrong entry in the
 dispatch (or a missing registration) would go unnoticed. These tests construct
 IR of each kind and assert the downcast produces the expected concrete class.
 """
+
 from textwrap import dedent
 
 import llvm
@@ -122,6 +123,7 @@ _SOURCES = {
     """,
 }
 
+
 def _leaf_instruction_classes():
     """Derive the set of leaf Instruction subclasses from the bindings."""
     instr = llvm.ir.Instruction
@@ -157,12 +159,27 @@ def test_instruction_kinds_downcast():
     # the two files must cover every leaf. Anything missing here means a new
     # source snippet is needed.
     covered_by_opcode_sweep = {
-        "BinaryOperator", "FPBinaryOperator",
-        "TruncInst", "ZExtInst", "SIToFPInst", "FPToSIInst",
-        "BitCastInst", "PtrToIntInst", "IntToPtrInst",
-        "ICmpInst", "FCmpInst", "SelectInst",
-        "AllocaInst", "StoreInst", "LoadInst", "GetElementPtrInst",
-        "CallInst", "UncondBrInst", "CondBrInst", "PHINode", "ReturnInst",
+        "BinaryOperator",
+        "FPBinaryOperator",
+        "TruncInst",
+        "ZExtInst",
+        "SIToFPInst",
+        "FPToSIInst",
+        "BitCastInst",
+        "PtrToIntInst",
+        "IntToPtrInst",
+        "ICmpInst",
+        "FCmpInst",
+        "SelectInst",
+        "AllocaInst",
+        "StoreInst",
+        "LoadInst",
+        "GetElementPtrInst",
+        "CallInst",
+        "UncondBrInst",
+        "CondBrInst",
+        "PHINode",
+        "ReturnInst",
     }
     missing = expected - seen - covered_by_opcode_sweep
     assert not missing, f"instruction kinds not downcast: {sorted(missing)}"
@@ -230,9 +247,14 @@ def test_constant_and_global_kinds_downcast():
         # Constant kinds obtained as initializers.
         inits = {v[1] for v in by_name.values()}
         expected = {
-            "ConstantArray", "ConstantStruct", "ConstantDataArray",
-            "ConstantAggregateZero", "ConstantVector", "ConstantDataVector",
-            "ConstantExpr", "BlockAddress",
+            "ConstantArray",
+            "ConstantStruct",
+            "ConstantDataArray",
+            "ConstantAggregateZero",
+            "ConstantVector",
+            "ConstantDataVector",
+            "ConstantExpr",
+            "BlockAddress",
         }
         assert expected <= inits, f"missing: {sorted(expected - inits)}"
         # ConstantTokenNone is the `within none` operand of the cleanup pad.

--- a/projects/eudsl-llvmpy/tests/ir/test_instruction_functions.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_instruction_functions.py
@@ -4,6 +4,7 @@
 """Free-function instruction emitters (llvm.instructions): they delegate to the
 contextual builder (`with builder:` / `with InsertPoint(...):`) when no `builder`
 is passed, or to an explicit `builder=`."""
+
 import pytest
 
 import llvm
@@ -236,7 +237,10 @@ def test_float_rem_and_fneg_free_functions():
 def test_integer_and_pointer_cast_free_functions():
     with llvm.ir.Context() as ctx:
         i64, i32, ptr, f32 = (
-            llvm.types.i64(), llvm.types.i32(), llvm.types.ptr(), llvm.types.f32()
+            llvm.types.i64(),
+            llvm.types.i32(),
+            llvm.types.ptr(),
+            llvm.types.f32(),
         )
         mod, fn = _fn(ctx, i64, [i64, i32, ptr])
         b = IRBuilder(ctx)
@@ -416,9 +420,7 @@ def test_indirect_br_free_function():
         with InsertPoint(t2, builder=b):
             I.ret()
         p = str(mod)
-        assert (
-            "indirectbr ptr blockaddress(@f, %t1), [label %t1, label %t2]" in p
-        )
+        assert "indirectbr ptr blockaddress(@f, %t1), [label %t1, label %t2]" in p
         del b, fn, entry, t1, t2, ibr, mod
     assert_no_leaks()
 
@@ -518,7 +520,11 @@ def test_atomic_cmpxchg_invalid_orderings_raise():
         with InsertPoint(fn.append_basic_block("entry"), builder=b):
             with pytest.raises(ValueError, match="failure ordering"):
                 I.atomic_cmpxchg(
-                    fn.arg(0), fn.arg(1), fn.arg(2), AO.SequentiallyConsistent, AO.Release
+                    fn.arg(0),
+                    fn.arg(1),
+                    fn.arg(2),
+                    AO.SequentiallyConsistent,
+                    AO.Release,
                 )
             with pytest.raises(ValueError, match="success ordering"):
                 I.atomic_cmpxchg(

--- a/projects/eudsl-llvmpy/tests/ir/test_instructions.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_instructions.py
@@ -8,8 +8,7 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_PHI_SRC = dedent(
-    """\
+_PHI_SRC = dedent("""\
     define i32 @f(i1 %c) {
     entry:
       br i1 %c, label %a, label %b
@@ -22,14 +21,12 @@ _PHI_SRC = dedent(
       %eq = icmp eq i32 %p, 1
       ret i32 %p
     }
-    """
-)
+    """)
 
 # Exercises the memory, call, cast and fcmp accessors that _PHI_SRC does not
 # reach. Several results (%gep, %fc) are intentionally unused; the parser keeps
 # them and that is all these accessor tests need.
-_MEM_SRC = dedent(
-    """\
+_MEM_SRC = dedent("""\
     declare i32 @g(i32, i32)
 
     define i32 @f(i32 %x, ptr %p) {
@@ -42,8 +39,7 @@ _MEM_SRC = dedent(
       %fc = fcmp ogt float 1.0, 2.0
       ret i32 %cl
     }
-    """
-)
+    """)
 
 
 def _insts_by_class(mod, name):

--- a/projects/eudsl-llvmpy/tests/ir/test_iteration.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_iteration.py
@@ -7,6 +7,7 @@ Module iterates its functions, Function its basic blocks, BasicBlock its
 instructions, and User its operands. Each supports len(), negative and
 bounds-checked __getitem__ (IndexError past the ends), and iteration.
 """
+
 from textwrap import dedent
 
 import pytest
@@ -14,8 +15,7 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     declare i32 @ext(i32)
     define i32 @f(i32 %x, i32 %y) {
     entry:
@@ -26,8 +26,7 @@ _SRC = dedent(
     entry:
       ret void
     }
-    """
-)
+    """)
 
 
 def test_iteration_and_indexing():

--- a/projects/eudsl-llvmpy/tests/ir/test_lazy_views.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_lazy_views.py
@@ -4,6 +4,7 @@
 """The traversal accessors return lazy sequence views (not materialized lists):
 len(), negative/bounds-checked indexing, slicing, and iteration, computed on
 demand. Covers every Sequence<T> instantiation."""
+
 from textwrap import dedent
 
 import gc
@@ -14,8 +15,7 @@ import llvm
 from llvm.ir import InsertPoint
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @f(i32 %x, i32 %y) {
     entry:
       %s = add i32 %x, %y
@@ -25,8 +25,7 @@ _SRC = dedent(
     entry:
       ret void
     }
-    """
-)
+    """)
 
 
 def test_lazy_sequence_views():

--- a/projects/eudsl-llvmpy/tests/ir/test_use_def.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_use_def.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """MLIR-parity use-def APIs: Value.uses (Use edges), replace_all_uses_except,
 and Function.walk()."""
+
 from textwrap import dedent
 
 import pytest
@@ -15,8 +16,7 @@ _EDGE_SRC = (
     "entry:\n  %sum = add i32 %x, %y\n  ret i32 %sum\n}\n"
 )
 
-_RAUW_SRC = dedent(
-    """\
+_RAUW_SRC = dedent("""\
     define i32 @f(i32 %x) {
     entry:
       %a = add i32 %x, 1
@@ -24,8 +24,7 @@ _RAUW_SRC = dedent(
       %c = add i32 %a, 3
       ret i32 %b
     }
-    """
-)
+    """)
 
 
 def test_use_edges():
@@ -132,8 +131,7 @@ def test_replace_all_uses_except_type_mismatch_raises():
 def test_function_walk():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define i32 @f(i32 %x) {
                 entry:
                   %a = add i32 %x, 1
@@ -142,8 +140,7 @@ def test_function_walk():
                   %b = mul i32 %a, 2
                   ret i32 %b
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )

--- a/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_value_lifetimes.py
@@ -10,6 +10,7 @@ module (== 0). The count assertion runs before any dereference, so an accessor
 that fails to pin fails cleanly rather than segfaulting. (Consuming the module
 via take()/_take() hands its storage to the JIT and is outside this guarantee;
 see test_take_consumes_module_and_is_outside_pinning_guarantee.)"""
+
 import gc
 
 import pytest
@@ -61,41 +62,115 @@ def _load_ptr(m, name):
 # e.g. name -> ""), which is the `== 1` count assertion that precedes it.
 CASES = [
     ("get_function", lambda m: m.get_function("f"), lambda v: v.name == "f"),
-    ("get_global_variable", lambda m: m.get_global_variable("g"), lambda v: v.name == "g"),
+    (
+        "get_global_variable",
+        lambda m: m.get_global_variable("g"),
+        lambda v: v.name == "g",
+    ),
     ("module_getitem", lambda m: m[0], lambda v: v.name == "f"),
     ("module_functions_view", lambda m: m.functions[0], lambda v: v.name == "f"),
     ("function_arg", lambda m: m.get_function("f").arg(0), lambda v: v.arg_no == 0),
-    ("function_args_view", lambda m: m.get_function("f").args[0], lambda v: v.arg_no == 0),
-    ("function_entry_block", lambda m: m.get_function("f").entry_block, lambda v: v.name == "entry"),
-    ("function_bbs_view", lambda m: m.get_function("f").basic_blocks[0], lambda v: v.name == "entry"),
+    (
+        "function_args_view",
+        lambda m: m.get_function("f").args[0],
+        lambda v: v.arg_no == 0,
+    ),
+    (
+        "function_entry_block",
+        lambda m: m.get_function("f").entry_block,
+        lambda v: v.name == "entry",
+    ),
+    (
+        "function_bbs_view",
+        lambda m: m.get_function("f").basic_blocks[0],
+        lambda v: v.name == "entry",
+    ),
     ("function_getitem", lambda m: m.get_function("f")[0], lambda v: v.name == "entry"),
-    ("bb_parent", lambda m: m.get_function("f").entry_block.parent, lambda v: v.name == "f"),
-    ("bb_terminator", lambda m: m.get_function("f").entry_block.terminator, lambda v: v.is_terminator),
-    ("bb_instructions_view", lambda m: m.get_function("f").entry_block.instructions[0], lambda v: v.name == "gv"),
-    ("bb_getitem", lambda m: m.get_function("f").entry_block[0], lambda v: v.name == "gv"),
+    (
+        "bb_parent",
+        lambda m: m.get_function("f").entry_block.parent,
+        lambda v: v.name == "f",
+    ),
+    (
+        "bb_terminator",
+        lambda m: m.get_function("f").entry_block.terminator,
+        lambda v: v.is_terminator,
+    ),
+    (
+        "bb_instructions_view",
+        lambda m: m.get_function("f").entry_block.instructions[0],
+        lambda v: v.name == "gv",
+    ),
+    (
+        "bb_getitem",
+        lambda m: m.get_function("f").entry_block[0],
+        lambda v: v.name == "gv",
+    ),
     ("inst_parent", lambda m: _add(m).parent, lambda v: v.name == "entry"),
     ("inst_operand", lambda m: _add(m).operand(0), lambda v: v.name == "x"),
     ("inst_operands_view", lambda m: _add(m).operands[0], lambda v: v.name == "x"),
     ("user_getitem", lambda m: _add(m)[0], lambda v: v.name == "x"),
-    ("arg_parent", lambda m: m.get_function("f").arg(0).parent, lambda v: v.name == "f"),
-    ("arg_users_view", lambda m: m.get_function("f").arg(0).users[0], lambda v: v.name == "s"),
-    ("arg_uses_view", lambda m: m.get_function("f").arg(0).uses[0], lambda v: v.operand_number == 0),
-    ("use_user", lambda m: m.get_function("f").arg(0).uses[0].user, lambda v: v.name == "s"),
-    ("gvar_initializer", lambda m: m.get_global_variable("g").initializer, lambda v: str(v) == "i32 7"),
+    (
+        "arg_parent",
+        lambda m: m.get_function("f").arg(0).parent,
+        lambda v: v.name == "f",
+    ),
+    (
+        "arg_users_view",
+        lambda m: m.get_function("f").arg(0).users[0],
+        lambda v: v.name == "s",
+    ),
+    (
+        "arg_uses_view",
+        lambda m: m.get_function("f").arg(0).uses[0],
+        lambda v: v.operand_number == 0,
+    ),
+    (
+        "use_user",
+        lambda m: m.get_function("f").arg(0).uses[0].user,
+        lambda v: v.name == "s",
+    ),
+    (
+        "gvar_initializer",
+        lambda m: m.get_global_variable("g").initializer,
+        lambda v: str(v) == "i32 7",
+    ),
     ("load_pointer_operand", lambda m: _load_ptr(m, "g"), lambda v: v.name == "g"),
-    ("global_alias_aliasee", lambda m: _load_ptr(m, "al").aliasee, lambda v: v.name == "g"),
-    ("global_ifunc_resolver", lambda m: _load_ptr(m, "fp").resolver, lambda v: v.name == "res"),
-    ("block_address_function", lambda m: _load_ptr(m, "ba").initializer.function, lambda v: v.name == "f"),
-    ("block_address_block", lambda m: _load_ptr(m, "ba").initializer.basic_block, lambda v: v.name == "b"),
+    (
+        "global_alias_aliasee",
+        lambda m: _load_ptr(m, "al").aliasee,
+        lambda v: v.name == "g",
+    ),
+    (
+        "global_ifunc_resolver",
+        lambda m: _load_ptr(m, "fp").resolver,
+        lambda v: v.name == "res",
+    ),
+    (
+        "block_address_function",
+        lambda m: _load_ptr(m, "ba").initializer.function,
+        lambda v: v.name == "f",
+    ),
+    (
+        "block_address_block",
+        lambda m: _load_ptr(m, "ba").initializer.basic_block,
+        lambda v: v.name == "b",
+    ),
     # A none-owner container (the ConstantExpr `ptrtoint (ptr @g to i64)`, which
     # has no module) yielding a module-owned element (@g): the element must pin
     # its OWN module, not the container's. Before the per-element owner fix this
     # failed cleanly at count 0.
-    ("const_expr_operand_module_owned", lambda m: m.get_global_variable("ce").initializer.operands[0], lambda v: v.name == "g"),
+    (
+        "const_expr_operand_module_owned",
+        lambda m: m.get_global_variable("ce").initializer.operands[0],
+        lambda v: v.name == "g",
+    ),
 ]
 
 
-@pytest.mark.parametrize("make,touch", [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES])
+@pytest.mark.parametrize(
+    "make,touch", [(c[1], c[2]) for c in CASES], ids=[c[0] for c in CASES]
+)
 def test_accessor_result_pins_module(make, touch):
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
@@ -114,9 +189,21 @@ def test_accessor_result_pins_module(make, touch):
 
 _ITER_CASES = [
     ("module_iter", lambda m: next(iter(m)), lambda v: v.name == "f"),  # -> Function
-    ("function_iter", lambda m: next(iter(m.get_function("f"))), lambda v: v.name == "entry"),  # -> BasicBlock
-    ("bb_iter", lambda m: next(iter(m.get_function("f").entry_block)), lambda v: v.name == "gv"),  # -> Instruction
-    ("user_iter", lambda m: next(iter(_add(m))), lambda v: v.name == "x"),  # -> operand Value
+    (
+        "function_iter",
+        lambda m: next(iter(m.get_function("f"))),
+        lambda v: v.name == "entry",
+    ),  # -> BasicBlock
+    (
+        "bb_iter",
+        lambda m: next(iter(m.get_function("f").entry_block)),
+        lambda v: v.name == "gv",
+    ),  # -> Instruction
+    (
+        "user_iter",
+        lambda m: next(iter(_add(m))),
+        lambda v: v.name == "x",
+    ),  # -> operand Value
 ]
 
 

--- a/projects/eudsl-llvmpy/tests/ir/test_values.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_values.py
@@ -8,15 +8,13 @@ import gc
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @f(i32 %x, i32 %y) {
     entry:
       %sum = add i32 %x, %y
       ret i32 %sum
     }
-    """
-)
+    """)
 
 
 def test_value_and_user_registered():

--- a/projects/eudsl-llvmpy/tests/jit/test_jit.py
+++ b/projects/eudsl-llvmpy/tests/jit/test_jit.py
@@ -9,15 +9,13 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @sub(i32 %a, i32 %b) {
     entry:
       %s = sub i32 %a, %b
       ret i32 %s
     }
-    """
-)
+    """)
 
 
 def test_jit_execute():

--- a/projects/eudsl-llvmpy/tests/jit/test_linker.py
+++ b/projects/eudsl-llvmpy/tests/jit/test_linker.py
@@ -13,13 +13,11 @@ def test_link_two_modules():
     with llvm.ir.Context() as ctx:
         dest = llvm.ir.parse_assembly("declare i32 @a()\n", ctx, "dest")
         src = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define i32 @a() {
                   ret i32 7
                 }
-                """
-            ),
+                """),
             ctx,
             "src",
         )
@@ -36,13 +34,11 @@ def test_consumed_source_cannot_be_linked_again():
     with llvm.ir.Context() as ctx:
         dest = llvm.ir.parse_assembly("declare i32 @a()\n", ctx, "dest")
         src = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define i32 @a() {
                   ret i32 7
                 }
-                """
-            ),
+                """),
             ctx,
             "src",
         )

--- a/projects/eudsl-llvmpy/tests/jit/test_target.py
+++ b/projects/eudsl-llvmpy/tests/jit/test_target.py
@@ -10,26 +10,22 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @add(i32 %a, i32 %b) {
     entry:
       %s = add i32 %a, %b
       ret i32 %s
     }
-    """
-)
+    """)
 
 # Same symbol name @add, different body, so any difference in emitted assembly
 # comes from codegen of the body rather than the symbol/label text.
-_SRC_CONST = dedent(
-    """\
+_SRC_CONST = dedent("""\
     define i32 @add(i32 %a, i32 %b) {
     entry:
       ret i32 12345
     }
-    """
-)
+    """)
 
 
 def test_host_triple_is_nonempty():

--- a/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
+++ b/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Exercises C++ binding paths (llvm-cov) not hit by the behavioral tests:
 identity/hash dunders, operand/metadata accessors, and error paths."""
+
 from textwrap import dedent
 
 import pytest
@@ -11,15 +12,13 @@ import llvm
 from llvm.ir import InsertPoint
 from llvm.testing import assert_no_leaks
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @f(i32 %x, i32 %y) {
     entry:
       %s = add i32 %x, %y
       ret i32 %s
     }
-    """
-)
+    """)
 
 
 def test_value_eq_hash_and_operands():
@@ -93,12 +92,8 @@ def test_target_machine_bad_triple_raises():
 
 def test_linker_conflicting_symbols_raises():
     with llvm.ir.Context() as ctx:
-        a = llvm.ir.parse_assembly(
-            "define i32 @dup() {\n ret i32 1\n}\n", ctx, "a"
-        )
-        b = llvm.ir.parse_assembly(
-            "define i32 @dup() {\n ret i32 2\n}\n", ctx, "b"
-        )
+        a = llvm.ir.parse_assembly("define i32 @dup() {\n ret i32 1\n}\n", ctx, "a")
+        b = llvm.ir.parse_assembly("define i32 @dup() {\n ret i32 2\n}\n", ctx, "b")
         with pytest.raises(RuntimeError, match="linkModules failed"):
             llvm.jit.link_into(a, b)
         del a, b
@@ -112,7 +107,9 @@ def test_builder_fcmp_gep_call():
         i32 = llvm.types.i32(ctx)
         callee = llvm.ir.Function.create(llvm.types.function(i32, [i32]), "callee", mod)
         fn = llvm.ir.Function.create(
-            llvm.types.function(llvm.types.i1(ctx), [f32, f32, llvm.types.ptr(context=ctx), i32]),
+            llvm.types.function(
+                llvm.types.i1(ctx), [f32, f32, llvm.types.ptr(context=ctx), i32]
+            ),
             "f",
             mod,
         )
@@ -134,8 +131,7 @@ def test_builder_fcmp_gep_call():
 
 
 def test_constant_int_zext_and_global_initializer():
-    src = dedent(
-        """\
+    src = dedent("""\
         @g = global i32 5
         @e = external global i32
         define i32 @f() {
@@ -144,8 +140,7 @@ def test_constant_int_zext_and_global_initializer():
           %b = load i32, ptr @e
           ret i32 %a
         }
-        """
-    )
+        """)
     with llvm.ir.Context() as ctx:
         assert llvm.ir.const_int(llvm.types.i32(ctx), 7).zext_value == 7
         mod = llvm.ir.parse_assembly(src, ctx, "m")
@@ -162,7 +157,6 @@ def test_constant_int_zext_and_global_initializer():
         assert e.initializer is None  # @e is external, no initializer
         del loads, g, e, mod
     assert_no_leaks()
-
 
 
 def test_verify_rejects_malformed_module():
@@ -186,8 +180,7 @@ def test_parse_bitcode_garbage_raises():
 
 
 def test_callinst_arg_operand_and_gep_source_type():
-    src = dedent(
-        """\
+    src = dedent("""\
         declare i32 @g(i32)
         define i32 @f(ptr %p) {
         entry:
@@ -195,8 +188,7 @@ def test_callinst_arg_operand_and_gep_source_type():
           %c = call i32 @g(i32 7)
           ret i32 %c
         }
-        """
-    )
+        """)
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(src, ctx, "m")
         f = mod.get_function("f")
@@ -212,9 +204,7 @@ def test_callinst_arg_operand_and_gep_source_type():
 
 def test_jit_lookup_missing_symbol_raises():
     ctx = llvm.ir.Context()
-    mod = llvm.ir.parse_assembly(
-        "define i32 @present() {\n ret i32 0\n}\n", ctx, "m"
-    )
+    mod = llvm.ir.parse_assembly("define i32 @present() {\n ret i32 0\n}\n", ctx, "m")
     jit = llvm.jit.LLJIT()
     jit.add_module(mod)
     with pytest.raises(RuntimeError, match="Symbols not found"):
@@ -231,8 +221,7 @@ def test_module_context_accessor():
 
 
 def test_valuetypeinfo_downcasts_many_opcodes_and_kinds():
-    src = dedent(
-        """\
+    src = dedent("""\
         @g = global i32 0
         define i32 @f(i32 %x, ptr %p, float %fp) {
         entry:
@@ -262,8 +251,7 @@ def test_valuetypeinfo_downcasts_many_opcodes_and_kinds():
           %ph = phi i32 [ %add, %entry ]
           ret i32 %ph
         }
-        """
-    )
+        """)
     expected_per_name = {
         "add": "BinaryOperator",
         "sub": "BinaryOperator",
@@ -302,16 +290,18 @@ def test_valuetypeinfo_downcasts_many_opcodes_and_kinds():
                 named_insts["__ret__"] = "ReturnInst"
         for name, expected_cls in expected_per_name.items():
             actual = named_insts.get(name)
-            assert actual == expected_cls, (
-                f"%{name}: expected {expected_cls}, got {actual}"
-            )
+            assert (
+                actual == expected_cls
+            ), f"%{name}: expected {expected_cls}, got {actual}"
         assert named_insts.get("__br__") == "UncondBrInst"
         assert named_insts.get("__ret__") == "ReturnInst"
         assert type(f).__name__ == "Function"
         assert type(f.arg(0)).__name__ == "Argument"
         # StoreInst has no name; check it separately.
         store_insts = [
-            inst for bb in f.basic_blocks for inst in bb.instructions
+            inst
+            for bb in f.basic_blocks
+            for inst in bb.instructions
             if type(inst).__name__ == "StoreInst"
         ]
         assert len(store_insts) == 1
@@ -326,6 +316,9 @@ def test_valuetypeinfo_downcasts_constant_kinds():
         assert type(llvm.ir.const_fp(llvm.types.f32(ctx), 1.0)).__name__ == "ConstantFP"
         assert type(llvm.ir.undef(i32)).__name__ == "UndefValue"
         assert type(llvm.ir.poison(i32)).__name__ == "PoisonValue"
-        assert type(llvm.ir.null(llvm.types.ptr(context=ctx))).__name__ == "ConstantPointerNull"
+        assert (
+            type(llvm.ir.null(llvm.types.ptr(context=ctx))).__name__
+            == "ConstantPointerNull"
+        )
         assert type(llvm.ir.null(i32)).__name__ == "ConstantInt"  # zero int
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
+++ b/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
@@ -92,8 +92,24 @@ def test_target_machine_bad_triple_raises():
 
 def test_linker_conflicting_symbols_raises():
     with llvm.ir.Context() as ctx:
-        a = llvm.ir.parse_assembly("define i32 @dup() {\n ret i32 1\n}\n", ctx, "a")
-        b = llvm.ir.parse_assembly("define i32 @dup() {\n ret i32 2\n}\n", ctx, "b")
+        a = llvm.ir.parse_assembly(
+            dedent("""\
+                define i32 @dup() {
+                 ret i32 1
+                }
+                """),
+            ctx,
+            "a",
+        )
+        b = llvm.ir.parse_assembly(
+            dedent("""\
+                define i32 @dup() {
+                 ret i32 2
+                }
+                """),
+            ctx,
+            "b",
+        )
         with pytest.raises(RuntimeError, match="linkModules failed"):
             llvm.jit.link_into(a, b)
         del a, b
@@ -204,7 +220,15 @@ def test_callinst_arg_operand_and_gep_source_type():
 
 def test_jit_lookup_missing_symbol_raises():
     ctx = llvm.ir.Context()
-    mod = llvm.ir.parse_assembly("define i32 @present() {\n ret i32 0\n}\n", ctx, "m")
+    mod = llvm.ir.parse_assembly(
+        dedent("""\
+            define i32 @present() {
+             ret i32 0
+            }
+            """),
+        ctx,
+        "m",
+    )
     jit = llvm.jit.LLJIT()
     jit.add_module(mod)
     with pytest.raises(RuntimeError, match="Symbols not found"):

--- a/projects/eudsl-llvmpy/tests/misc/test_filecheck.py
+++ b/projects/eudsl-llvmpy/tests/misc/test_filecheck.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """The filecheck_with_comments harness itself: it matches ordered # CHECK
 directives against printed IR and fails on a mismatch (unlike substring `in`)."""
+
 import pytest
 
 import llvm

--- a/projects/eudsl-llvmpy/tests/misc/test_verify_bitcode.py
+++ b/projects/eudsl-llvmpy/tests/misc/test_verify_bitcode.py
@@ -8,14 +8,12 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks
 
-_GOOD = dedent(
-    """\
+_GOOD = dedent("""\
     define i32 @f(i32 %x) {
     entry:
       ret i32 %x
     }
-    """
-)
+    """)
 
 
 def test_verify_accepts_good_module():
@@ -29,8 +27,7 @@ def test_verify_accepts_good_module():
 def test_verify_rejects_bad_module():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(
-            dedent(
-                """\
+            dedent("""\
                 define i32 @f(i32 %x) {
                 entry:
                   br label %body
@@ -40,8 +37,7 @@ def test_verify_rejects_bad_module():
                   %y = add i32 %x, 1
                   br label %body
                 }
-                """
-            ),
+                """),
             ctx,
             "m",
         )

--- a/projects/eudsl-llvmpy/tests/passmanager/test_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_passes.py
@@ -8,15 +8,13 @@ import pytest
 import llvm
 from llvm.testing import assert_no_leaks, filecheck_with_comments
 
-_SRC = dedent(
-    """\
+_SRC = dedent("""\
     define i32 @f(i32 %x) {
     entry:
       %a = add i32 %x, 0
       ret i32 %a
     }
-    """
-)
+    """)
 
 
 def test_instcombine_removes_add_zero():
@@ -86,7 +84,9 @@ def test_default_pipeline_with_tuning():
         pto = llvm.passmanager.PipelineTuningOptions()
         pto.loop_vectorization = False
         pto.slp_vectorization = False
-        llvm.passmanager.run_default_pipeline(mod, llvm.passmanager.OptLevel.O2, tuning=pto)
+        llvm.passmanager.run_default_pipeline(
+            mod, llvm.passmanager.OptLevel.O2, tuning=pto
+        )
         # CHECK-NOT: add i32 %x, 0
         # CHECK: ret i32 %x
         filecheck_with_comments(mod)
@@ -126,7 +126,9 @@ def test_run_passes_with_verify_each():
 def test_default_pipeline_with_debug():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
-        llvm.passmanager.run_default_pipeline(mod, llvm.passmanager.OptLevel.O1, debug=True)
+        llvm.passmanager.run_default_pipeline(
+            mod, llvm.passmanager.OptLevel.O1, debug=True
+        )
         assert "define" in str(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/types/test_types.py
+++ b/projects/eudsl-llvmpy/tests/types/test_types.py
@@ -62,18 +62,40 @@ def test_derived_types_print():
         assert str(llvm.types.ptr(3, context=ctx)) == "ptr addrspace(3)"
         assert str(llvm.types.array(llvm.types.i32(ctx), 4)) == "[4 x i32]"
         assert str(llvm.types.vector(llvm.types.f32(ctx), 8)) == "<8 x float>"
-        assert str(llvm.types.vector(llvm.types.f32(ctx), 8, scalable=True)) == "<vscale x 8 x float>"
-        assert str(llvm.types.struct([llvm.types.i32(ctx), llvm.types.f64(ctx)], context=ctx)) == "{ i32, double }"
         assert (
-            str(llvm.types.struct([llvm.types.i8(ctx), llvm.types.i32(ctx)], packed=True, context=ctx))
+            str(llvm.types.vector(llvm.types.f32(ctx), 8, scalable=True))
+            == "<vscale x 8 x float>"
+        )
+        assert (
+            str(
+                llvm.types.struct(
+                    [llvm.types.i32(ctx), llvm.types.f64(ctx)], context=ctx
+                )
+            )
+            == "{ i32, double }"
+        )
+        assert (
+            str(
+                llvm.types.struct(
+                    [llvm.types.i8(ctx), llvm.types.i32(ctx)], packed=True, context=ctx
+                )
+            )
             == "<{ i8, i32 }>"
         )
         assert (
-            str(llvm.types.function(llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)]))
+            str(
+                llvm.types.function(
+                    llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)]
+                )
+            )
             == "i32 (i32, float)"
         )
         assert (
-            str(llvm.types.function(llvm.types.void(ctx), [llvm.types.ptr(context=ctx)], var_arg=True))
+            str(
+                llvm.types.function(
+                    llvm.types.void(ctx), [llvm.types.ptr(context=ctx)], var_arg=True
+                )
+            )
             == "void (ptr, ...)"
         )
     assert_no_leaks()
@@ -107,9 +129,13 @@ def test_types_downcast_to_concrete_classes():
         assert isinstance(
             llvm.types.vector(llvm.types.i32(ctx), 2), llvm.types.VectorType
         )
-        assert type(llvm.types.struct([llvm.types.i32(ctx)], context=ctx)).__name__ == "StructType"
         assert (
-            type(llvm.types.function(llvm.types.void(ctx), [])).__name__ == "FunctionType"
+            type(llvm.types.struct([llvm.types.i32(ctx)], context=ctx)).__name__
+            == "StructType"
+        )
+        assert (
+            type(llvm.types.function(llvm.types.void(ctx), [])).__name__
+            == "FunctionType"
         )
         # Types with no concrete subclass stay Type.
         assert type(llvm.types.void(ctx)).__name__ == "Type"
@@ -140,8 +166,12 @@ def test_concrete_type_accessors():
         assert s.num_elements == 2
         assert s.element_type(1) == llvm.types.f64(ctx)
         assert not s.is_packed
-        assert llvm.types.struct([llvm.types.i8(ctx)], packed=True, context=ctx).is_packed
-        ft = llvm.types.function(llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)])
+        assert llvm.types.struct(
+            [llvm.types.i8(ctx)], packed=True, context=ctx
+        ).is_packed
+        ft = llvm.types.function(
+            llvm.types.i32(ctx), [llvm.types.i32(ctx), llvm.types.f32(ctx)]
+        )
         assert ft.return_type == llvm.types.i32(ctx)
         assert ft.num_params == 2
         assert ft.param_type(1) == llvm.types.f32(ctx)

--- a/projects/eudsl-llvmpy/tests/types/test_types_generic.py
+++ b/projects/eudsl-llvmpy/tests/types/test_types_generic.py
@@ -3,6 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Types as nb::is_generic GenericAliases: subscript with no live context, and
 .get(...) factories that evaluate against a context."""
+
 import types
 from typing import get_args
 


### PR DESCRIPTION
Mechanical, no behavior change:
- C++ (src/IR/*.cpp, *.h): clang-format with the repo .clang-format (LLVM style).
- Python (src/llvm, tests, scripts): black with defaults.

Also converts the createTargetMachine error path in Target.cpp to
LCOV_EXCL_START/STOP so the coverage exclusion survives clang-format's
line wrapping. Full suite green (430 passed); C++ line+function coverage 100%.