### PR TITLE
[eudsl-llvmpy] Support nested control flow (if-in-loop, loop-in-if)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -208,11 +208,15 @@ class MyInt(ir.Value):
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not
-  supported**, and neither is **control flow nested inside a loop body** (an
-  `if` at the top level of a function works; an `if` inside a `while` or `for`
-  body does not). The canonicalizer detects these and raises
-  `NotImplementedError` rather than emitting wrong IR. Nested control flow is
-  the piece most worth revisiting.
+  supported.** They would need edge duplication and predecessor bookkeeping the
+  phi-based yield-protocol lowering does not do; the canonicalizer detects them
+  and raises `NotImplementedError` rather than emitting wrong IR.
+- **`if`/`while`/`for` otherwise compose freely** — an `if` inside a loop, a
+  loop inside an `if` branch, nested loops, etc. — with one caveat: **do not
+  reassign a variable in one `if`/`elif` branch and read it in a sibling
+  branch.** Both branches are traced in the same Python frame, so the
+  reassignment leaks across; `verify()` then rejects the IR. Yield the value out
+  of the region instead (`r = yield x`) or use a distinct name per branch.
 - **The fatal-error path is best-effort.** LLVM's fatal error handler cannot
   return, so where a bad argument would trip it, the bindings validate up front
   and raise. A genuine LLVM fatal error still aborts the process after a warning.

--- a/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/cf_transformers.py
@@ -172,19 +172,6 @@ class ReplaceIfWithWith(StrictTransformer):
             return then_with
 
 
-def _reject_nested_control_flow(body_stmts, where):
-    """The loop transforms lift the body into a nested function the if/else
-    transformers do not revisit, so control flow nested inside a loop body is
-    not lowered. Detect and refuse rather than miscompile."""
-    for stmt in body_stmts:
-        for child in ast.walk(stmt):
-            if isinstance(child, (ast.If, ast.For, ast.While)):
-                raise NotImplementedError(
-                    f"control flow nested inside a `{where}` loop body is not "
-                    "supported"
-                )
-
-
 def _carried_from_yield(yield_value):
     """Names carried by a trailing `yield a, b` (or `yield a`)."""
     if yield_value is None:
@@ -204,112 +191,79 @@ def _carried_from_yield(yield_value):
     return names
 
 
-class WhileToWhileLoop(StrictTransformer):
-    """Rewrite `while COND: BODY; yield carried` into a while_loop call.
+def _loop_lowering(node, loop_expr, iv, carried):
+    """Shared tail for the for/while transforms. Rewrites the loop into
 
-        while COND:
+        __loop_L = <loop_expr>          # range_(...) / while_(...)
+        with __loop_L as <targets>:
             BODY
-            yield acc, i
-        # ->
-        def __wcond_L__(acc, i): return COND
-        def __wbody_L__(acc, i):
-            BODY
-            return (acc, i)
-        (acc, i) = while_loop(__wcond_L__, __wbody_L__, (acc, i))
+            loop_yield(carried...)
+        (carried,) = __loop_L.results   # only when there are carried values
 
-    The loop-carried variables (from the trailing yield) become the parameters
-    and results of the nested cond/body functions, so the while_loop runtime can
-    feed header phis in and thread body results back as phi incomings without
-    rebinding Python closure variables. Straight-line loop bodies only: control
-    flow nested inside a loop body is not lowered (the nested functions are not
-    revisited by the if/else transformers).
+    keeping BODY inline (in the `with`) so nested control flow lowers, and
+    binding post-loop names to the loop results (header phis) rather than the
+    body's last recomputed values. `iv` is the induction-variable name for a
+    `for` (None for a `while`); `carried` is the list of loop-carried names.
     """
+    loop_var = f"__loop_{node.lineno}__"
+    assign_loop = ast.Assign([ast.Name(loop_var, ast.Store())], loop_expr)
 
-    def visit_While(self, node: ast.While) -> list:
-        node = self.generic_visit(node)
-        line = node.lineno
-        last = node.body[-1]
-        if not (isinstance(last, ast.Expr) and isinstance(last.value, ast.Yield)):
-            raise NotImplementedError(
-                "a DSL `while` body must end with `yield <loop-carried vars>`"
+    carried_store = ast.Tuple([ast.Name(n, ast.Store()) for n in carried], ast.Store())
+    if iv is not None:
+        as_target = (
+            ast.Tuple([ast.Name(iv, ast.Store()), carried_store], ast.Store())
+            if carried
+            else ast.Name(iv, ast.Store())
+        )
+    else:
+        as_target = carried_store if carried else None
+
+    body = list(node.body[:-1]) + [
+        ast.Expr(ast_call("loop_yield", [ast.Name(n, ast.Load()) for n in carried]))
+    ]
+    with_node = ast.With(
+        items=[
+            ast.withitem(
+                context_expr=ast.Name(loop_var, ast.Load()), optional_vars=as_target
             )
-        carried = _carried_from_yield(last.value.value)
-        body_stmts = node.body[:-1]
-        _reject_nested_control_flow(body_stmts, "while")
-
-        def params():
-            return ast.arguments(
-                posonlyargs=[],
-                args=[ast.arg(arg=n) for n in carried],
-                vararg=None,
-                kwonlyargs=[],
-                kw_defaults=[],
-                kwarg=None,
-                defaults=[],
+        ],
+        body=body,
+    )
+    out = [assign_loop, with_node]
+    if carried:
+        out.append(
+            ast.Assign(
+                [ast.Tuple([ast.Name(n, ast.Store()) for n in carried], ast.Store())],
+                ast.Attribute(ast.Name(loop_var, ast.Load()), "results", ast.Load()),
             )
-
-        carried_load = ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load())
-        carried_store = ast.Tuple(
-            [ast.Name(n, ast.Store()) for n in carried], ast.Store()
         )
-
-        cond_name = f"__wcond_{line}__"
-        body_name = f"__wbody_{line}__"
-
-        cond_fn = ast.FunctionDef(
-            name=cond_name,
-            args=params(),
-            body=[ast.Return(node.test)],
-            decorator_list=[],
-            type_params=[],
-        )
-        body_fn = ast.FunctionDef(
-            name=body_name,
-            args=params(),
-            body=list(body_stmts) + [ast.Return(carried_load)],
-            decorator_list=[],
-            type_params=[],
-        )
-        call = ast.Assign(
-            targets=[carried_store],
-            value=ast.Call(
-                func=ast.Name("while_loop", ast.Load()),
-                args=[
-                    ast.Name(cond_name, ast.Load()),
-                    ast.Name(body_name, ast.Load()),
-                    ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load()),
-                ],
-                keywords=[],
-            ),
-        )
-        out = [cond_fn, body_fn, call]
-        for n in out:
-            ast.copy_location(n, node)
-            n.end_lineno = n.lineno
-            ast.fix_missing_locations(n)
-        return out
+    for n in out:
+        ast.copy_location(n, node)
+        ast.fix_missing_locations(n)
+    return out
 
 
-class ForToForLoop(StrictTransformer):
-    """Rewrite `for i in range_(...): BODY; yield carried` into a for_loop call.
+class ForToInline(StrictTransformer):
+    """Rewrite `for i in range_(...): BODY; yield carried` into an inline loop.
 
         for i in range_(start, stop, step):
             BODY
             yield acc
         # ->
-        def __fbody_L__(i, acc):
+        __loop_L = range_(start, stop, step, iter_args=(acc,))
+        with __loop_L as (i, (acc,)):
             BODY
-            return (acc,)
-        (acc,) = for_loop(start, stop, step, __fbody_L__, (acc,))
+            loop_yield(acc)
+        (acc,) = __loop_L.results
 
-    Like WhileToWhileLoop, the loop-carried variables come from the trailing
-    yield and become the body function's parameters/results (after the induction
-    variable `i`), so no closure rebinding is needed. Only `range_(...)` iterables
-    are handled; other `for` iterables are left untouched.
+    The body stays inline in the `with`, so control flow nested in it is lowered
+    by the later if/else passes (and any nested loop by this pass, via the
+    postorder generic_visit). Only `range_(...)` iterables are rewritten; other
+    `for` iterables are left as Python loops (unrolled at trace time).
     """
 
     def visit_For(self, node: ast.For) -> object:
-        node = self.generic_visit(node)
+        node = self.generic_visit(node)  # nested loops first (postorder)
         it = node.iter
         if not (
             isinstance(it, ast.Call)
@@ -319,20 +273,7 @@ class ForToForLoop(StrictTransformer):
             return node
         if not isinstance(node.target, ast.Name):
             raise NotImplementedError("for target must be a single name")
-        iv = node.target.id
-        line = node.lineno
-
-        args = list(it.args)
-        if len(args) == 1:
-            start = ast.Constant(0)
-            stop = args[0]
-            step = ast.Constant(1)
-        elif len(args) == 2:
-            start, stop = args
-            step = ast.Constant(1)
-        elif len(args) == 3:
-            start, stop, step = args
-        else:
+        if not 1 <= len(it.args) <= 3:
             raise NotImplementedError("range_ takes 1-3 arguments")
 
         last = node.body[-1]
@@ -341,50 +282,77 @@ class ForToForLoop(StrictTransformer):
                 "a DSL `for` body must end with `yield <loop-carried vars>`"
             )
         carried = _carried_from_yield(last.value.value)
-        body_stmts = node.body[:-1]
-        _reject_nested_control_flow(body_stmts, "for")
 
-        body_name = f"__fbody_{line}__"
-        params = ast.arguments(
-            posonlyargs=[],
-            args=[ast.arg(arg=iv)] + [ast.arg(arg=n) for n in carried],
-            vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[],
-        )
-        carried_load = ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load())
-        carried_store = ast.Tuple(
-            [ast.Name(n, ast.Store()) for n in carried], ast.Store()
-        )
-        body_fn = ast.FunctionDef(
-            name=body_name,
-            args=params,
-            body=list(body_stmts) + [ast.Return(carried_load)],
+        # range_(...) -> range_(..., iter_args=(carried,))
+        it.keywords = list(it.keywords) + [
+            ast.keyword(
+                arg="iter_args",
+                value=ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load()),
+            )
+        ]
+        return _loop_lowering(node, it, node.target.id, carried)
+
+
+class WhileToInline(StrictTransformer):
+    """Rewrite `while COND: BODY; yield carried` into an inline loop.
+
+        while COND:
+            BODY
+            yield acc
+        # ->
+        def __wcond_L__(acc): return COND
+        __loop_L = while_(__wcond_L__, iter_args=(acc,))
+        with __loop_L as (acc,):
+            BODY
+            loop_yield(acc)
+        (acc,) = __loop_L.results
+
+    Only the condition is lifted into a function (a control-flow-free expression
+    evaluated in the header against the carried phis); the body stays inline, so
+    control flow nested in it lowers normally.
+    """
+
+    def visit_While(self, node: ast.While) -> list:
+        node = self.generic_visit(node)  # nested loops first (postorder)
+        line = node.lineno
+        last = node.body[-1]
+        if not (isinstance(last, ast.Expr) and isinstance(last.value, ast.Yield)):
+            raise NotImplementedError(
+                "a DSL `while` body must end with `yield <loop-carried vars>`"
+            )
+        carried = _carried_from_yield(last.value.value)
+
+        cond_name = f"__wcond_{line}__"
+        cond_fn = ast.FunctionDef(
+            name=cond_name,
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg=n) for n in carried],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=[ast.Return(node.test)],
             decorator_list=[],
             type_params=[],
         )
-        call = ast.Assign(
-            targets=[carried_store],
-            value=ast.Call(
-                func=ast.Name("for_loop", ast.Load()),
-                args=[
-                    start,
-                    stop,
-                    step,
-                    ast.Name(body_name, ast.Load()),
-                    ast.Tuple([ast.Name(n, ast.Load()) for n in carried], ast.Load()),
-                ],
-                keywords=[],
-            ),
+        while_expr = ast_call(
+            "while_",
+            [ast.Name(cond_name, ast.Load())],
+            keywords=[
+                ast.keyword(
+                    arg="iter_args",
+                    value=ast.Tuple(
+                        [ast.Name(n, ast.Load()) for n in carried], ast.Load()
+                    ),
+                )
+            ],
         )
-        out = [body_fn, call]
-        for n in out:
-            ast.copy_location(n, node)
-            n.end_lineno = n.lineno
-            ast.fix_missing_locations(n)
-        return out
+        out = _loop_lowering(node, while_expr, None, carried)
+        cond_fn = ast.fix_missing_locations(ast.copy_location(cond_fn, node))
+        return [cond_fn] + out
 
 
 class RejectUnsupportedJumps(StrictTransformer):
@@ -392,10 +360,8 @@ class RejectUnsupportedJumps(StrictTransformer):
 
     break/continue and early `return` inside if/while/for would need edge
     duplication and predecessor bookkeeping the yield-protocol lowering does not
-    do (and the loop transforms lift bodies into nested functions, where a bare
-    return/break/continue would silently mean the wrong thing). Detect and
-    refuse rather than emit wrong IR. Runs before the loop/if transformers, so
-    the constructs are still in their original ast form.
+    do. Detect and refuse rather than emit wrong IR. Runs before the loop/if
+    transformers, so the constructs are still in their original ast form.
     """
 
     def visit_Break(self, node):

--- a/projects/eudsl-llvmpy/src/llvm/ast/util.py
+++ b/projects/eudsl-llvmpy/src/llvm/ast/util.py
@@ -20,10 +20,10 @@ def set_lineno(node, n=1):
 
 
 def ast_call(name, args=None, keywords=None):
-    assert keywords is None, "keywords not supported in ast_call"
-    keywords = []
     if args is None:
         args = []
+    if keywords is None:
+        keywords = []
     call = ast.Call(
         func=ast.Name(name, ctx=ast.Load()),
         args=args,

--- a/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/cf.py
@@ -27,6 +27,12 @@ repoints that false edge to a fresh else block; and the values passed to
 executes in the else branch last, the else-branch `yield_` is the one that
 builds the phis (both incoming edges are then known) and returns them, so `r`
 binds to the phi that `return r` uses.
+
+Loops follow the same "keep the body inline, thread carried values as phis"
+idea (see `_Loop`): `for i in range_(...)` / `while COND` become a `with`
+statement over a loop object whose header phis carry the loop-carried values.
+Because the body stays inline (not lifted into a function), control flow nested
+inside a loop body -- and loops nested inside `if` branches -- lower normally.
 """
 
 from contextlib import contextmanager
@@ -159,77 +165,30 @@ class _InjectCFGlobals(FunctionPatcher):
         g["if_ctx_manager"] = if_ctx_manager
         g["else_ctx_manager"] = else_ctx_manager
         g["placeholder_opaque_t"] = placeholder_opaque_t
-        g["while_loop"] = while_loop
-        g["for_loop"] = for_loop
+        g["loop_yield"] = loop_yield
         g["range_"] = range_
+        g["while_"] = while_
         return f
 
 
 class LLVMCanonicalizer(Canonicalizer):
     cst_transformers = [
-        # Reject unsupported jumps first, on the original AST, before the loop
-        # transforms synthesize their own returns.
+        # Reject unsupported jumps first, on the original AST: break/continue and
+        # early `return` inside control flow are still not modeled.
         _T.RejectUnsupportedJumps,
-        # Loops next: they lift the loop body into nested cond/body functions
-        # before the if/else transformers rewrite yields, so a loop's trailing
-        # `yield` is consumed as its carried-value list rather than becoming an
-        # scf-style yield_().
-        _T.WhileToWhileLoop,
-        _T.ForToForLoop,
+        # Loops next, so a loop's trailing `yield` is consumed as its carried
+        # values (rewritten to loop_yield) before the if/else passes turn any
+        # remaining yields into scf-style yield_(). The loop body stays inline
+        # (in a `with` block), so control flow nested in it is lowered by the
+        # passes below and any nested loop by these two passes.
+        _T.ForToInline,
+        _T.WhileToInline,
         _T.CanonicalizeElIfs,
         _T.InsertEmptyYield,
         _T.ReplaceYieldWithLLVMYield,
         _T.ReplaceIfWithWith,
     ]
     function_patchers = [_InjectCFGlobals]
-
-
-def while_loop(cond_fn, body_fn, inits):
-    """Phi-based while loop.
-
-    cond_fn(*carried) -> i1 and body_fn(*carried) -> next-carried-tuple are both
-    parameterized by the loop-carried values, so the runtime can pass header
-    phis as those arguments -- no closure rebinding needed. Structure:
-
-        preheader: br header
-        header:    <phis> = phi [init, preheader], [next, body]
-                   br cond_fn(phis), body, exit
-        body:      next = body_fn(phis); br header
-        exit:      (phis are the loop results)
-    """
-    b = current_builder()
-    fn = current_function()
-    inits = list(inits)
-
-    preheader = b.insert_block
-    header = fn.append_basic_block("while.header")
-    body_bb = fn.append_basic_block("while.body")
-    exit_bb = fn.append_basic_block("while.end")
-
-    b.br(header)
-
-    b.set_insert_point(header)
-    raw_phis = []
-    carried = []
-    for idx, init in enumerate(inits):
-        phi = b.phi(init.type, f"while.{idx}")
-        phi.add_incoming(init, preheader)
-        raw_phis.append(phi)  # keep the PHINode for add_incoming wiring
-        carried.append(maybe_downcast(phi, fn))  # typed view for the body
-    cond = cond_fn(*carried)
-    b.cond_br(cond, body_bb, exit_bb)
-
-    b.set_insert_point(body_bb)
-    nexts = body_fn(*carried)  # body_fn returns a tuple of next carried values
-    body_end = b.insert_block  # nested control flow may have moved us
-    b.br(header)
-    for phi, nxt in zip(raw_phis, nexts):
-        phi.add_incoming(nxt, body_end)
-
-    b.set_insert_point(exit_bb)
-    # Always return a tuple; the AST transform binds `(names,) = while_loop(...)`
-    # and direct callers unpack. (Single-element tuple for one carried value.)
-    return tuple(carried)
 
 
 def _as_value(x, like):
@@ -239,48 +198,132 @@ def _as_value(x, like):
     return const_int(like.type, int(x), signed=True)
 
 
-def for_loop(start, stop, step, body_fn, inits):
-    """Counted loop built on while_loop, with an induction variable.
+_loop_stack = []
 
-        for i in range_(start, stop, step):
-            BODY
-            yield carried
-        # lowered to a while_loop over (i, *carried):
-        #   cond: i < stop (ascending) or i > stop (descending)
-        #   body: (i + step, *body_fn(i, *carried))
 
-    body_fn(i, *carried) -> next-carried-tuple. Returns the final carried
-    values (the induction variable is internal).
+class _Loop:
+    """A lowered for/while loop: preheader -> header(phis) -> body -> exit.
+
+    Built on ``__enter__``, which appends the blocks, seeds the header phis from
+    the preheader, emits the entry condition, and leaves the persistent builder
+    inside the body block. ``__exit__`` adds the back-edge phi incomings from
+    whatever block the body actually ended in (so nested control flow that moved
+    the builder is handled, just like `_IfOp`), then parks the builder at the
+    exit block. The loop-carried values are the header phis; they are exposed as
+    ``.results`` (valid at the exit block) so post-loop code binds to the loop
+    result rather than the body's last recomputed value.
+
+    The body is left inline in the caller's frame (the AST transform wraps it in
+    ``with``), so `if`/`while`/`for` nested in a loop body lower normally.
     """
-    stop_v = stop
-    start_v = _as_value(start, stop_v if not isinstance(stop, int) else start)
-    inits = [_as_value(v, start_v) for v in inits]
 
-    # Pick comparator based on step sign (negative step → descending).
-    step_negative = step < 0 if isinstance(step, int) else False
+    def __init__(
+        self, kind, *, start=None, stop=None, step=None, cond_fn=None, iter_args=()
+    ):
+        self.kind = kind
+        self.start = start
+        self.stop = stop
+        self.step = step
+        self.cond_fn = cond_fn
+        self.iter_args = list(iter_args)
+        self.next_carried = []
+        self.results = ()
 
-    def cond(iv, *carried):
-        return iv > stop_v if step_negative else iv < stop_v
+    def __enter__(self):
+        b = current_builder()
+        fn = current_function()
+        self.builder = b
+        preheader = b.insert_block
+        self.header = fn.append_basic_block(f"{self.kind}.header")
+        body = fn.append_basic_block(f"{self.kind}.body")
+        self.exit_block = fn.append_basic_block(f"{self.kind}.end")
+        b.br(self.header)
 
-    def body(iv, *carried):
-        # body_fn is the lifted loop body; it returns a tuple of next carried
-        # values (empty for a side-effecting loop with a bare yield).
-        nxt = body_fn(iv, *carried)
-        return (iv + step, *nxt)
+        b.set_insert_point(self.header)
+        # Coerce any Python-int bounds/carried inits to constants. The type
+        # witness is the first Value among the bounds and carried inits; a loop
+        # with an int to coerce but no Value anywhere has no type to infer.
+        witness_candidates = list(self.iter_args)
+        if self.kind == "for":
+            witness_candidates = [self.start, self.stop] + witness_candidates
+        witness = next((c for c in witness_candidates if isinstance(c, Value)), None)
 
-    res = while_loop(cond, body, (start_v, *inits))
-    # while_loop returns a tuple; drop the induction variable and return the
-    # remaining carried values as a tuple (the AST transform tuple-unpacks it).
-    carried = res[1:]
-    return tuple(carried)
+        def coerce(x):
+            if witness is None and not isinstance(x, Value):
+                raise NotImplementedError(
+                    "a DSL loop needs at least one Value bound or loop-carried "
+                    "value to infer the IR type"
+                )
+            return _as_value(x, witness)
+
+        self.iter_args = [coerce(a) for a in self.iter_args]
+
+        self.iv_phi = None
+        iv_typed = None
+        if self.kind == "for":
+            start = coerce(self.start)
+            stop = coerce(self.stop)
+            self.stop = stop
+            self.iv_phi = b.phi(start.type, "for.iv")
+            self.iv_phi.add_incoming(start, preheader)
+            iv_typed = maybe_downcast(self.iv_phi, fn)
+        self.carried_phis = []
+        for k, a in enumerate(self.iter_args):
+            p = b.phi(a.type, f"{self.kind}.{k}")
+            p.add_incoming(a, preheader)
+            self.carried_phis.append(p)
+        carried_typed = tuple(maybe_downcast(p, fn) for p in self.carried_phis)
+        self._iv_typed = iv_typed
+
+        if self.kind == "for":
+            descending = isinstance(self.step, int) and self.step < 0
+            cond = iv_typed > self.stop if descending else iv_typed < self.stop
+        else:
+            cond = self.cond_fn(*carried_typed)
+        b.cond_br(cond, body, self.exit_block)
+
+        b.set_insert_point(body)
+        _loop_stack.append(self)
+        if self.kind == "for":
+            return (iv_typed, carried_typed) if carried_typed else iv_typed
+        return carried_typed
+
+    def __exit__(self, exc_type, exc, tb):
+        _loop_stack.pop()
+        if exc_type is not None:
+            return False
+        b = self.builder
+        body_end = b.insert_block  # nested control flow may have moved us
+        next_iv = self._iv_typed + self.step if self.kind == "for" else None
+        b.br(self.header)
+        if self.kind == "for":
+            self.iv_phi.add_incoming(next_iv, body_end)
+        for phi, nxt in zip(self.carried_phis, self.next_carried):
+            phi.add_incoming(nxt, body_end)
+        b.set_insert_point(self.exit_block)
+        # The header phis hold the final carried values on the exit edge and the
+        # header dominates the exit block, so they are the loop's live-out result.
+        self.results = tuple(
+            maybe_downcast(p, current_function()) for p in self.carried_phis
+        )
+        return False
 
 
-def range_(start, stop=None, step=1):
-    """Marker for `for i in range_(...)`; the AST transform reads its args.
+def loop_yield(*values):
+    """Record this iteration's updated carried values (the loop analogue of
+    yield_). Read by `_Loop.__exit__` to wire the back-edge phi incomings."""
+    _loop_stack[-1].next_carried = list(values)
 
-    Also callable at runtime (returns the (start, stop, step) triple) so the
-    name resolves even outside a transformed function.
-    """
+
+def range_(start, stop=None, step=1, *, iter_args=()):
+    """`for i in range_(...)` loop builder. The AST transform supplies
+    `iter_args` (the loop-carried values) and iterates this via `with`."""
     if stop is None:
         start, stop = 0, start
-    return (start, stop, step)
+    return _Loop("for", start=start, stop=stop, step=step, iter_args=iter_args)
+
+
+def while_(cond_fn, *, iter_args=()):
+    """`while COND` loop builder. The AST transform lifts COND into `cond_fn`
+    (evaluated in the header against the carried phis) and supplies iter_args."""
+    return _Loop("while", cond_fn=cond_fn, iter_args=iter_args)

--- a/projects/eudsl-llvmpy/tests/ast/test_ast.py
+++ b/projects/eudsl-llvmpy/tests/ast/test_ast.py
@@ -236,54 +236,49 @@ def test_rewrite_produces_expected_ast_structure():
     assert else_ctx.func.id == "else_ctx_manager"
 
 
-def test_while_to_while_loop_preserves_lineno():
-    # WhileToWhileLoop replaces the while node with [cond_fn, body_fn, call],
-    # each carrying the original while's lineno via ast.copy_location.
-    src = (
-        "def f():\n"  # line 1
-        "    x = 0\n"  # line 2
-        "    while x:\n"  # line 3
-        "        x = 1\n"  # line 4
-        "        yield x\n"  # line 5
-    )
+def test_while_to_inline_preserves_lineno():
+    # WhileToInline replaces the while node with [cond_fn, __loop = while_(...),
+    # with __loop as (x,): ..., (x,) = __loop.results], each carrying the
+    # original while's lineno via ast.copy_location.
+    src = dedent("""\
+        def f():
+            x = 0
+            while x:
+                x = 1
+                yield x
+        """)  # while is on line 3
     tree = ast.parse(src)
     node = tree.body[0]
-    node = T.WhileToWhileLoop(context=None, first_lineno=0).generic_visit(node)
-    # The while was on line 3; all emitted nodes should carry that lineno.
-    # node.body = [x = 0, cond_fn, body_fn, call]
-    cond_fn = node.body[1]
-    body_fn = node.body[2]
-    call = node.body[3]
+    node = T.WhileToInline(context=None, first_lineno=0).generic_visit(node)
+    # node.body = [x = 0, cond_fn, assign_loop, with_node, results_rebind]
+    cond_fn, assign_loop, with_node, rebind = node.body[1:5]
     assert isinstance(cond_fn, ast.FunctionDef)
-    assert isinstance(body_fn, ast.FunctionDef)
-    assert isinstance(call, ast.Assign)
-    assert cond_fn.lineno == 3
-    assert body_fn.lineno == 3
-    assert call.lineno == 3
-    assert cond_fn.end_lineno == 3
-    assert body_fn.end_lineno == 3
-    assert call.end_lineno == 3
+    assert isinstance(assign_loop, ast.Assign)  # __loop_3__ = while_(...)
+    assert isinstance(with_node, ast.With)
+    assert isinstance(rebind, ast.Assign)  # (x,) = __loop_3__.results
+    for n in (cond_fn, assign_loop, with_node, rebind):
+        assert n.lineno == 3
 
 
-def test_for_to_for_loop_preserves_lineno():
-    # ForToForLoop replaces the for node with [body_fn, call], each carrying
-    # the original for's lineno via ast.copy_location.
-    src = (
-        "def f():\n"  # line 1
-        "    acc = 0\n"  # line 2
-        "    for i in range_(0, 10):\n"  # line 3
-        "        acc = 1\n"  # line 4
-        "        yield acc\n"  # line 5
-    )
+def test_for_to_inline_preserves_lineno():
+    # ForToInline replaces the for node with [__loop = range_(...),
+    # with __loop as (i, (acc,)): ..., (acc,) = __loop.results].
+    src = dedent("""\
+        def f():
+            acc = 0
+            for i in range_(0, 10):
+                acc = 1
+                yield acc
+        """)  # for is on line 3
     tree = ast.parse(src)
     node = tree.body[0]
-    node = T.ForToForLoop(context=None, first_lineno=0).generic_visit(node)
-    # node.body = [acc = 0, body_fn, call]
-    body_fn = node.body[1]
-    call = node.body[2]
-    assert isinstance(body_fn, ast.FunctionDef)
-    assert isinstance(call, ast.Assign)
-    assert body_fn.lineno == 3
-    assert call.lineno == 3
-    assert body_fn.end_lineno == 3
-    assert call.end_lineno == 3
+    node = T.ForToInline(context=None, first_lineno=0).generic_visit(node)
+    # node.body = [acc = 0, assign_loop, with_node, results_rebind]
+    assign_loop, with_node, rebind = node.body[1:4]
+    assert isinstance(
+        assign_loop, ast.Assign
+    )  # __loop_3__ = range_(..., iter_args=(acc,))
+    assert isinstance(with_node, ast.With)
+    assert isinstance(rebind, ast.Assign)  # (acc,) = __loop_3__.results
+    for n in (assign_loop, with_node, rebind):
+        assert n.lineno == 3

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf.py
@@ -137,7 +137,7 @@ def test_for_range_sum_jits():
         return acc
 
     printed = str(mod)
-    assert "while.header" in printed
+    assert "for.header" in printed
     jit = llvm.jit.LLJIT()
     jit.add_module(mod)
     fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
@@ -434,23 +434,69 @@ def test_loop_yield_non_name_raises():
     assert_no_leaks()
 
 
-def test_nested_control_flow_inside_loop_raises():
-    with llvm.ir.Context() as ctx:
-        mod = llvm.ir.Module("m", ctx)
-        i32 = llvm.types.i32(ctx)
-        with pytest.raises(NotImplementedError, match="not supported"):
+def test_nested_if_inside_for_loop_jits():
+    # An `if` nested inside a loop body now lowers to real control flow: the
+    # body stays inline, so the if/else passes reach it. The if yields a value
+    # (a phi) that feeds the loop-carried accumulator.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
 
-            @llvm.dsl.function(module=mod)
-            @canonicalize(using=LLVMCanonicalizer())
-            def f(n: i32, c: llvm.types.i1) -> i32:
-                i = llvm.ir.const_int(i32, 0)
-                while i.ne(n):
-                    if c:
-                        i = i + 1
-                    yield i
-                return i
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def sum_selected(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if c:
+                r = yield i
+            else:
+                r = yield i + i
+            acc = acc + r
+            yield acc
+        return acc
 
-        del mod
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("sum_selected")
+    )
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(5, False) == 2 * (0 + 1 + 2 + 3 + 4)
+    del jit, mod, ctx, sum_selected, i32, fn
+    assert_no_leaks()
+
+
+def test_for_loop_nested_inside_if_jits():
+    # The dual: a loop nested inside an `if` branch. The loop's blocks are
+    # emitted inside the then-branch and the branch's yielded value is the
+    # loop result (a header phi valid at the loop exit).
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def maybe_sum(n: i32, c: llvm.types.i1) -> i32:
+        if c:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            r = yield acc
+        else:
+            r = yield llvm.ir.const_int(i32, -1, signed=True)
+        return r
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("maybe_sum")
+    )
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(5, False) == -1
+    del jit, mod, ctx, maybe_sum, i32, fn
     assert_no_leaks()
 
 
@@ -472,12 +518,724 @@ def test_while_loop_bare_yield_has_no_carried_values():
     assert_no_leaks()
 
 
-def test_range_marker_is_callable_directly():
-    from llvm.dsl.cf import range_
+def test_if_within_if_within_for_jits():
+    # ifs nested inside ifs, inside a loop body.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
 
-    assert range_(5) == (0, 5, 1)
-    assert range_(2, 5) == (2, 5, 1)
-    assert range_(2, 5, 3) == (2, 5, 3)
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1, d: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if c:
+                if d:
+                    r = yield i
+                else:
+                    r = yield i + i
+            else:
+                r = yield llvm.ir.const_int(i32, 0)
+            acc = acc + r
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(5, True, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(5, True, False) == 2 * (0 + 1 + 2 + 3 + 4)
+    assert fn(5, False, False) == 0
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_nested_for_loops_jits():
+    # A loop directly nested in another loop (both carry `acc`): acc += 1 for
+    # each (i, j) pair -> n*n. Exercises the inner loop's result feeding the
+    # outer loop-carried phi via the back-edge.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def grid(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            for j in range_(0, n):
+                acc = acc + llvm.ir.const_int(i32, 1)
+                yield acc
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("grid"))
+    assert fn(3) == 9
+    assert fn(0) == 0  # zero iterations: result is the initial carried value
+    del jit, mod, ctx, grid, i32, fn
+    assert_no_leaks()
+
+
+def test_nested_loops_inside_if_jits():
+    # Loop-in-loop nested inside an `if` branch; the branch yields the loop
+    # result, which must be a header phi valid at the branch merge.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        if c:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                for j in range_(0, n):
+                    acc = acc + llvm.ir.const_int(i32, 1)
+                    yield acc
+                yield acc
+            r = yield acc
+        else:
+            r = yield llvm.ir.const_int(i32, -1, signed=True)
+        return r
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(3, True) == 9
+    assert fn(3, False) == -1
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_while_nested_inside_for_jits():
+    # Mixed loop kinds: a `while` nested in a `for` body (inner while runs `i`
+    # times on outer iteration i -> total sum(0..n-1)).
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            j = llvm.ir.const_int(i32, 0)
+            while j.ne(i):
+                acc = acc + llvm.ir.const_int(i32, 1)
+                j = j + llvm.ir.const_int(i32, 1)
+                yield acc, j
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
+    assert fn(4) == 0 + 1 + 2 + 3
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_for_nested_inside_while_jits():
+    # Mixed loop kinds: a `for` nested in a `while` body.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        i = llvm.ir.const_int(i32, 0)
+        while i.ne(n):
+            for k in range_(0, i):
+                acc = acc + llvm.ir.const_int(i32, 1)
+                yield acc
+            i = i + llvm.ir.const_int(i32, 1)
+            yield acc, i
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
+    assert fn(4) == 0 + 1 + 2 + 3
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_triple_nested_loops_jits():
+    # Three levels of loop nesting: acc += 1 per (i, j, k) -> n**3.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def cube(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            for j in range_(0, n):
+                for k in range_(0, n):
+                    acc = acc + llvm.ir.const_int(i32, 1)
+                    yield acc
+                yield acc
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("cube"))
+    assert fn(2) == 8
+    assert fn(3) == 27
+    del jit, mod, ctx, cube, i32, fn
+    assert_no_leaks()
+
+
+def test_elif_chain_inside_loop_jits():
+    # An elif chain nested inside a loop body.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def bucket(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if i < llvm.ir.const_int(i32, 2):
+                r = yield i
+            elif i < llvm.ir.const_int(i32, 4):
+                r = yield i + llvm.ir.const_int(i32, 10)
+            else:
+                r = yield i + llvm.ir.const_int(i32, 100)
+            acc = acc + r
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("bucket"))
+    # i: 0->0, 1->1, 2->12, 3->13, 4->104, 5->105
+    assert fn(6) == 0 + 1 + 12 + 13 + 104 + 105
+    del jit, mod, ctx, bucket, i32, fn
+    assert_no_leaks()
+
+
+def test_while_with_nested_if_jits():
+    # `while` (not `for`) carrying values, with an `if` in its body whose phi
+    # feeds the loop-carried accumulator.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def cond_sum(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        i = llvm.ir.const_int(i32, 0)
+        while i.ne(n):
+            if c:
+                r = yield acc + i
+            else:
+                r = yield acc
+            acc = r
+            i = i + llvm.ir.const_int(i32, 1)
+            yield acc, i
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("cond_sum")
+    )
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(5, False) == 0
+    del jit, mod, ctx, cond_sum, i32, fn
+    assert_no_leaks()
+
+
+def test_loop_carried_plain_int_init_jits():
+    # The loop-carried init is a plain Python int (not const_int); the loop
+    # coerces it to a constant of the inferred type.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def total(n: i32) -> i32:
+        acc = 0  # plain int, not llvm.ir.const_int(...)
+        for i in range_(0, n):
+            acc = acc + i
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("total"))
+    assert fn(5) == 0 + 1 + 2 + 3 + 4
+    del jit, mod, ctx, total, i32, fn
+    assert_no_leaks()
+
+
+@pytest.mark.xfail(
+    reason="branch-reassignment leakage: both if branches are traced in the same "
+    "Python frame, so a variable reassigned in the then-branch leaks into the "
+    "else-branch. Pre-existing if-lowering limitation; see README Limitations.",
+    strict=True,
+)
+def test_branch_reassign_read_in_else_unsupported():
+    # Catch the VerifyError, clean up, then fail via assert -- so the xfail's
+    # traceback pins nothing live (a raised VerifyError would keep the module
+    # alive past the per-test leak gate).
+    verified = False
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
+        def f(c: llvm.types.i1, a: i32, b: i32) -> i32:
+            acc = a
+            if c:
+                acc = acc + b  # reassigned in then; leaks into else's `acc`
+                r = yield acc
+            else:
+                r = yield acc
+            return r
+
+        try:
+            mod.verify()  # invalid IR: else's acc references the then value
+            verified = True
+        except llvm.ir.VerifyError:
+            verified = False
+        del mod, i32, f
+    assert verified
+
+
+def test_branch_divergence_via_yield_jits():
+    # The supported way to express the above: each branch yields its own value
+    # (distinct names), so nothing reassigned in then is read in else.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(c: llvm.types.i1, a: i32, b: i32) -> i32:
+        if c:
+            r = yield a + b
+        else:
+            r = yield a
+        return r
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_bool, ctypes.c_int32, ctypes.c_int32
+    )(jit.lookup("f"))
+    assert fn(True, 10, 3) == 13
+    assert fn(False, 10, 3) == 10
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+@pytest.mark.xfail(
+    reason="branch-reassignment leakage: the then-branch's inner loop reassigns "
+    "the outer carried `acc`, which leaks into the else-branch. Pre-existing "
+    "if-lowering limitation; see README Limitations.",
+    strict=True,
+)
+def test_loop_in_if_in_loop_reassign_unsupported():
+    verified = False
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
+        def f(n: i32, c: llvm.types.i1) -> i32:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                if c:
+                    for j in range_(0, i):
+                        acc = acc + llvm.ir.const_int(i32, 1)
+                        yield acc
+                    r = yield acc  # then: acc is the inner loop result
+                else:
+                    r = yield acc  # else reads acc -> leaked then value
+                acc = r
+                yield acc
+            return acc
+
+        try:
+            mod.verify()
+            verified = True
+        except llvm.ir.VerifyError:
+            verified = False
+        del mod, i32, f
+    assert verified
+
+
+def test_loop_in_if_in_loop_distinct_names_jits():
+    # Same shape as the xfail above, written correctly: the then-branch's inner
+    # loop accumulates into a distinct name (`inner`), so the outer carried
+    # `acc` is never reassigned inside a branch.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if c:
+                inner = acc
+                for j in range_(0, i):
+                    inner = inner + llvm.ir.const_int(i32, 1)
+                    yield inner
+                r = yield inner
+            else:
+                r = yield acc
+            acc = r
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(4, True) == 0 + 1 + 2 + 3
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(4, False) == 0
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_nested_while_loops_jits():
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        i = llvm.ir.const_int(i32, 0)
+        while i.ne(n):
+            j = llvm.ir.const_int(i32, 0)
+            while j.ne(i):
+                acc = acc + llvm.ir.const_int(i32, 1)
+                j = j + llvm.ir.const_int(i32, 1)
+                yield acc, j
+            i = i + llvm.ir.const_int(i32, 1)
+            yield acc, i
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(jit.lookup("f"))
+    assert fn(4) == 0 + 1 + 2 + 3
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_if_with_loops_in_both_branches_jits():
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        if c:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            r = yield acc
+        else:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                acc = acc + llvm.ir.const_int(i32, 1)
+                yield acc
+            r = yield acc
+        return r
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(4, True) == 0 + 1 + 2 + 3
+    assert fn(4, False) == 4
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_multi_carried_updated_in_nested_if_jits():
+    # Two carried values (acc, cnt); acc is updated via a phi produced by a
+    # nested if inside the loop body -- an if-merge phi feeding a loop phi.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        cnt = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if c:
+                a2 = yield acc + i
+            else:
+                a2 = yield acc
+            acc = a2
+            cnt = cnt + llvm.ir.const_int(i32, 1)
+            yield acc, cnt
+        return acc + cnt
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(5, True) == (0 + 1 + 2 + 3 + 4) + 5
+    assert fn(5, False) == 0 + 5
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_if_nested_in_while_jits():
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        i = llvm.ir.const_int(i32, 0)
+        while i.ne(n):
+            if c:
+                r = yield acc + i
+            else:
+                r = yield acc + llvm.ir.const_int(i32, 1)
+            acc = r
+            i = i + llvm.ir.const_int(i32, 1)
+            yield acc, i
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(5, False) == 5
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+@pytest.mark.xfail(
+    reason="branch-reassignment leakage: the then-branch's inner loop reassigns "
+    "`acc`, which leaks into the else-branch's `yield acc`. Pre-existing "
+    "if-lowering limitation; see README Limitations.",
+    strict=True,
+)
+def test_four_level_for_if_for_if_reassign_unsupported():
+    verified = False
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
+        def f(n: i32, c: llvm.types.i1) -> i32:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                if c:
+                    for j in range_(0, n):
+                        if j < i:
+                            r = yield llvm.ir.const_int(i32, 1)
+                        else:
+                            r = yield llvm.ir.const_int(i32, 0)
+                        acc = acc + r
+                        yield acc
+                    s = yield acc  # then: acc reassigned by the inner loop
+                else:
+                    s = yield acc  # else reads acc -> leaked
+                acc = s
+                yield acc
+            return acc
+
+        try:
+            mod.verify()
+            verified = True
+        except llvm.ir.VerifyError:
+            verified = False
+        del mod, i32, f
+    assert verified
+
+
+def test_four_level_for_if_for_if_distinct_names_jits():
+    # Four levels (for > if > for > if), written correctly with a distinct
+    # inner accumulator so the outer carried `acc` is not reassigned in a branch.
+    ctx = llvm.ir.Context()
+    mod = llvm.ir.Module("m", ctx)
+    i32 = llvm.types.i32(ctx)
+
+    @llvm.dsl.function(module=mod)
+    @canonicalize(using=LLVMCanonicalizer())
+    def f(n: i32, c: llvm.types.i1) -> i32:
+        acc = llvm.ir.const_int(i32, 0)
+        for i in range_(0, n):
+            if c:
+                inner = acc
+                for j in range_(0, n):
+                    if j < i:
+                        r = yield llvm.ir.const_int(i32, 1)
+                    else:
+                        r = yield llvm.ir.const_int(i32, 0)
+                    inner = inner + r
+                    yield inner
+                s = yield inner
+            else:
+                s = yield acc
+            acc = s
+            yield acc
+        return acc
+
+    mod.verify()
+    jit = llvm.jit.LLJIT()
+    jit.add_module(mod)
+    fn = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_bool)(
+        jit.lookup("f")
+    )
+    # c=True: inner adds `i` per outer iteration -> sum(0..n-1)
+    assert fn(4, True) == 0 + 1 + 2 + 3
+    assert fn(5, True) == 0 + 1 + 2 + 3 + 4
+    assert fn(4, False) == 0
+    del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_fully_constant_loop_needs_a_value_raises():
+    # A loop with only Python-int bounds and carries (no Value anywhere) has no
+    # type to infer for its phis; it is rejected with a clear error.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        with pytest.raises(NotImplementedError, match="at least one Value"):
+
+            @llvm.dsl.function(module=mod)
+            @canonicalize(using=LLVMCanonicalizer())
+            def f() -> i32:
+                acc = 0
+                for i in range_(0, 3):
+                    acc = acc + i
+                    yield acc
+                return acc
+
+        del mod
+    assert_no_leaks()
+
+
+def test_if_in_for_ir_structure():
+    # Pin the nested IR shape: the if-merge phi (if.end) feeds the loop-carried
+    # header phi through the loop back-edge -- the core if-inside-loop interaction
+    # that a substring check cannot express.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
+        def nest(n: i32, c: llvm.types.i1) -> i32:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                if c:
+                    r = yield i
+                else:
+                    r = yield i + i
+                acc = acc + r
+                yield acc
+            return acc
+
+        # CHECK: define i32 @nest(i32 %[[N:.*]], i1 %[[C:.*]])
+        # CHECK: for.header:
+        # CHECK: %[[IV:.*]] = phi i32 [ 0, %entry ], [ {{.*}}, %if.end ]
+        # CHECK: %[[ACC:.*]] = phi i32 [ 0, %entry ], [ {{.*}}, %if.end ]
+        # CHECK: br i1 {{.*}}, label %for.body, label %for.end
+        # CHECK: for.body:
+        # CHECK: br i1 %[[C]], label %if.then, label %if.else
+        # CHECK: for.end:
+        # CHECK: ret i32 %[[ACC]]
+        # CHECK: if.end:
+        # CHECK: %[[PHI:.*]] = phi i32 [ %[[IV]], %if.then ], [ {{.*}}, %if.else ]
+        # CHECK: add i32 %[[ACC]], %[[PHI]]
+        # CHECK: br label %for.header
+        filecheck_with_comments(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_nested_loops_ir_structure():
+    # Two loop headers: the inner carried phi is seeded from the outer carried
+    # phi, and its value flows back through the outer loop's back-edge.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+
+        @llvm.dsl.function(module=mod)
+        @canonicalize(using=LLVMCanonicalizer())
+        def grid(n: i32) -> i32:
+            acc = llvm.ir.const_int(i32, 0)
+            for i in range_(0, n):
+                for j in range_(0, n):
+                    acc = acc + llvm.ir.const_int(i32, 1)
+                    yield acc
+                yield acc
+            return acc
+
+        # CHECK: define i32 @grid(i32 %[[N:.*]])
+        # CHECK: for.header:
+        # CHECK: phi i32 [ 0, %entry ], [ {{.*}}, %for.end3 ]
+        # CHECK: %[[OACC:.*]] = phi i32 [ 0, %entry ], [ %[[INNER:.*]], %for.end3 ]
+        # CHECK: br i1 {{.*}}, label %for.body, label %for.end
+        # CHECK: for.body:
+        # CHECK: br label %for.header1
+        # CHECK: for.end:
+        # CHECK: ret i32 %[[OACC]]
+        # CHECK: for.header1:
+        # CHECK: %[[INNER]] = phi i32 [ %[[OACC]], %for.body ], [ {{.*}}, %for.body2 ]
+        # CHECK: for.end3:
+        # CHECK: br label %for.header
+        filecheck_with_comments(mod)
+        del mod
+    assert_no_leaks()
 
 
 def test_for_negative_step_countdown_jits():

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_edges.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_edges.py
@@ -12,6 +12,7 @@ from llvm.ast.canonicalize import canonicalize
 from llvm.dsl.cf import LLVMCanonicalizer
 from llvm.dsl.cf import range_
 from llvm.dsl.values import with_element_type
+from llvm.ir import InsertPoint
 from llvm.testing import assert_no_leaks
 
 
@@ -53,7 +54,7 @@ def test_for_side_effect_bare_yield():
         return n
 
     printed = str(mod)
-    assert "while.header" in printed and "store i32" in printed
+    assert "for.header" in printed and "store i32" in printed
     del mod, ctx, fill, i32
     assert_no_leaks()
 
@@ -174,13 +175,6 @@ def test_elif_multiple_carried_results():
     assert_no_leaks()
 
 
-def test_range_runtime_callable():
-    # range_ is a marker consumed by the transform, but also runtime-callable.
-    assert range_(3) == (0, 3, 1)
-    assert range_(1, 4) == (1, 4, 1)
-    assert range_(1, 10, 2) == (1, 10, 2)
-
-
 def test_for_over_python_list_unrolls():
     # A non-range_ `for` is left as a Python loop and unrolls at trace time.
     ctx = llvm.ir.Context()
@@ -236,4 +230,20 @@ def test_nested_if_in_then_branch():
     assert fn(True, False, 10, 20) == 20
     assert fn(False, True, 10, 20) == 20
     del jit, mod, ctx, f, i32, fn
+    assert_no_leaks()
+
+
+def test_loop_body_exception_propagates():
+    # If the loop body raises, _Loop.__exit__ propagates it rather than trying
+    # to finalize the loop (wire phis / reposition the builder).
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.Module("m", ctx)
+        i32 = llvm.types.i32(ctx)
+        fn = llvm.ir.Function.create(llvm.types.function(i32, [i32]), "f", mod)
+        b = llvm.ir.IRBuilder(ctx)
+        with InsertPoint(fn.append_basic_block("entry"), builder=b):
+            with pytest.raises(RuntimeError, match="boom"):
+                with range_(0, fn.arg(0)):
+                    raise RuntimeError("boom")
+        del b, fn, mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
+++ b/projects/eudsl-llvmpy/tests/dsl/test_dsl_cf_reject.py
@@ -63,25 +63,6 @@ def test_early_return_in_if_raises():
         del mod
 
 
-def test_nested_control_flow_in_loop_raises():
-    with llvm.ir.Context() as ctx:
-        mod = llvm.ir.Module("m", ctx)
-        i32 = llvm.types.i32(ctx)
-        with pytest.raises(NotImplementedError, match="nested inside"):
-
-            @llvm.dsl.function(module=mod)
-            @canonicalize(using=LLVMCanonicalizer())
-            def bad3(n: i32) -> i32:
-                acc = llvm.ir.const_int(i32, 0)
-                for i in range_(0, n):
-                    if i < n:
-                        acc = yield i
-                    yield acc
-                return acc
-
-        del mod
-
-
 def test_trailing_return_is_allowed():
     # The function's own trailing return must NOT be rejected.
     with llvm.ir.Context() as ctx:


### PR DESCRIPTION
Reworks the DSL loop lowering so `if`/`while`/`for` **compose freely**: an `if` inside a loop body, a loop inside an `if` branch, and nested loops all lower correctly. Previously the canonicalizer rejected control flow nested in a loop body with `NotImplementedError`.

### Why it was rejected before
The old lowering lifted a loop body into a nested Python function (`__fbody_L__`/`__wbody_L__`) so loop-carried values could be threaded as function parameters (avoiding closure rebinding). But the if/else transformers are `StrictTransformer`s that don't descend into nested `FunctionDef`s — so any control flow in a lifted body was never lowered. The transform detected this and refused rather than miscompile.

### New approach — keep the body inline
Mirror how `if`/`else` already works. `range_`/`while_` return a `_Loop` object; the AST transforms (`ForToInline`/`WhileToInline`) rewrite a loop into a `with` statement over it, leaving the body **inline**:

```python
for i in range_(0, n):        __loop = range_(0, n, iter_args=(acc,))
    acc = acc + i        ->   with __loop as (i, (acc,)):
    yield acc                     acc = acc + i
                                  loop_yield(acc)
                              (acc,) = __loop.results
```

- `_Loop.__enter__` builds preheader→header(phis)→body→exit and parks the builder in the body.
- The body runs inline; `loop_yield` records the updated carried values.
- `_Loop.__exit__` wires the back-edge phi incomings from **wherever the body actually ended** (`body_end = builder.insert_block`), so nested control flow that moved the builder is handled — exactly the trick `_IfOp` already uses.
- Loop-carried values are header phis, exposed as `.results` (valid at the exit block), so post-loop code binds to the loop result rather than the body's last recomputed value (which doesn't dominate the exit).
- Only the `while` **condition** is still lifted, into a control-flow-free thunk evaluated in the header against the carried phis; the body stays inline.

Because the body is inline (an `ast.With` body, which `StrictTransformer` recurses into), the if/else passes lower any nested `if`, and these two passes lower any nested loop.

### API/behavior changes (beta)
- `range_` is now the loop builder (a `_Loop`), not a tuple marker; the direct-call marker tests are removed.
- `ast_call` gains keyword support.
- for-loops now emit `for.*` blocks (were `while.*` via the old for→while delegation).
- `break`/`continue`/early-`return` remain unsupported (`RejectUnsupportedJumps`).
- README Limitations updated.