### PR TITLE
[eudsl-llvmpy] Add MIR submodule foundation + LowLevelType (LLT) bindings

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -47,7 +47,8 @@ jobs:
           clang-format --version
           clang-format --style=file --dry-run --Werror \
             projects/eudsl-llvmpy/src/IR/*.cpp \
-            projects/eudsl-llvmpy/src/IR/*.h
+            projects/eudsl-llvmpy/src/IR/*.h \
+            projects/eudsl-llvmpy/src/MIR/*.cpp
 
       - name: black (Python)
         run: |

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -40,7 +40,7 @@ add_definitions(${LLVM_DEFINITIONS})
 # C++ source coverage (llvm-cov). When ON, the extension is built with
 # instrumentation; scripts/cpp_coverage.sh runs the test suite (which imports
 # the .so) under LLVM_PROFILE_FILE, merges the profraw, and enforces a
-# src/IR line-coverage threshold via scripts/check_coverage.py.
+# src/IR + src/MIR line-coverage threshold via scripts/check_coverage.py.
 option(EUDSL_LLVMPY_ENABLE_COVERAGE "Instrument eudslllvm_ext for llvm-cov" OFF)
 if(EUDSL_LLVMPY_ENABLE_COVERAGE)
   message(STATUS "EUDSL_LLVMPY: C++ coverage instrumentation enabled")
@@ -124,6 +124,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/Linker.cpp
   src/IR/JIT.cpp
   src/IR/Intrinsics.cpp
+  src/MIR/Machine.cpp
 )
 
 set(eudslllvm_ext_libs
@@ -149,6 +150,10 @@ set(eudslllvm_ext_libs
   LLVMMC
   LLVMMCParser
   LLVMCodeGen
+  LLVMCodeGenTypes
+  LLVMGlobalISel
+  LLVMSelectionDAG
+  LLVMMIRParser
   LLVMTargetParser
   ${EUDSLLLVM_TARGET_LIBS}
 )

--- a/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
+++ b/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
@@ -6,7 +6,7 @@
 # C++ (llvm-cov) coverage for the eudslllvm_ext bindings, analogous to the
 # --cov gate for the Python surface. Builds the extension instrumented, runs
 # the pytest suite (which imports the .so and thereby exercises the C++), merges
-# the profraw, and enforces a src/IR line-coverage threshold.
+# the profraw, and enforces a src/IR + src/MIR line-coverage threshold.
 #
 # Env:
 #   CMAKE_PREFIX_PATH  path to the LLVM install/build (for LLVMConfig.cmake)
@@ -66,10 +66,10 @@ if [[ -z "$SO" || ! -f "$SO" ]]; then
   exit 1
 fi
 
-echo ">> checking src/IR coverage (threshold=${THRESHOLD}%)"
+echo ">> checking src/IR + src/MIR coverage (threshold=${THRESHOLD}%)"
 "$PY" "${PROJ_DIR}/scripts/check_coverage.py" \
   --llvm-cov "$LLVM_COV" \
   --profdata "${COV_DIR}/eudslllvm.profdata" \
   --objects "$SO" \
-  --sources "${PROJ_DIR}/src/IR" \
+  --sources "${PROJ_DIR}/src/IR" "${PROJ_DIR}/src/MIR" \
   --threshold="${THRESHOLD}"

--- a/projects/eudsl-llvmpy/src/IR/Types.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Types.cpp
@@ -46,13 +46,10 @@ void populate_types(nb::module_ &m) {
       .def_prop_ro("is_sized", [](llvm::Type &self) { return self.isSized(); })
       .def_prop_ro("type_id", [](llvm::Type &self) { return self.getTypeID(); })
       .def("__str__", [](llvm::Type &self) { return eudsl::toString(self); })
-      .def("__eq__",
-           [](llvm::Type &self, nb::handle other) {
-             llvm::Type *o;
-             if (!nb::try_cast<llvm::Type *>(other, o))
-               return false;
-             return &self == o;
-           })
+      .def(
+          "__eq__",
+          [](llvm::Type &self, llvm::Type *other) { return &self == other; },
+          nb::is_operator())
       .def("__hash__", [](llvm::Type &self) {
         return static_cast<Py_ssize_t>(reinterpret_cast<std::uintptr_t>(&self));
       });

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -122,13 +122,10 @@ void populate_values(nb::module_ &m) {
           },
           "value"_a, "exceptions"_a)
       .def("__str__", [](llvm::Value &self) { return eudsl::toString(self); })
-      .def("__eq__",
-           [](llvm::Value &self, nb::handle other) {
-             llvm::Value *o;
-             if (!nb::try_cast<llvm::Value *>(other, o))
-               return false;
-             return &self == o;
-           })
+      .def(
+          "__eq__",
+          [](llvm::Value &self, llvm::Value *other) { return &self == other; },
+          nb::is_operator())
       .def("__hash__", [](llvm::Value &self) {
         return static_cast<Py_ssize_t>(reinterpret_cast<std::uintptr_t>(&self));
       });

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -39,12 +39,30 @@ void populate_mir(nb::module_ &m) {
                    [](const llvm::LLT &self) { return self.isPointer(); })
       .def_prop_ro("is_vector",
                    [](const llvm::LLT &self) { return self.isVector(); })
+      .def_prop_ro("is_integer",
+                   [](const llvm::LLT &self) { return self.isInteger(); })
+      .def_prop_ro("is_float",
+                   [](const llvm::LLT &self) { return self.isFloat(); })
       .def_prop_ro("is_valid",
                    [](const llvm::LLT &self) { return self.isValid(); })
-      .def("__eq__", [](const llvm::LLT &self,
-                        const llvm::LLT &other) { return self == other; })
-      .def("__ne__", [](const llvm::LLT &self,
-                        const llvm::LLT &other) { return self != other; })
+      .def("__eq__",
+           [](const llvm::LLT &self, nb::handle other) {
+             llvm::LLT o;
+             if (!nb::try_cast<llvm::LLT>(other, o))
+               return false;
+             return self == o;
+           })
+      .def("__ne__",
+           [](const llvm::LLT &self, nb::handle other) {
+             llvm::LLT o;
+             if (!nb::try_cast<llvm::LLT>(other, o))
+               return true;
+             return self != o;
+           })
+      .def("__hash__",
+           [](const llvm::LLT &self) {
+             return static_cast<Py_ssize_t>(self.getUniqueRAWLLTData());
+           })
       .def("__str__",
            [](const llvm::LLT &self) { return eudsl::toString(self); });
 }

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -45,20 +45,18 @@ void populate_mir(nb::module_ &m) {
                    [](const llvm::LLT &self) { return self.isFloat(); })
       .def_prop_ro("is_valid",
                    [](const llvm::LLT &self) { return self.isValid(); })
-      .def("__eq__",
-           [](const llvm::LLT &self, nb::handle other) {
-             llvm::LLT o;
-             if (!nb::try_cast<llvm::LLT>(other, o))
-               return false;
-             return self == o;
-           })
-      .def("__ne__",
-           [](const llvm::LLT &self, nb::handle other) {
-             llvm::LLT o;
-             if (!nb::try_cast<llvm::LLT>(other, o))
-               return true;
-             return self != o;
-           })
+      .def(
+          "__eq__",
+          [](const llvm::LLT &self, const llvm::LLT &other) {
+            return self == other;
+          },
+          nb::is_operator())
+      .def(
+          "__ne__",
+          [](const llvm::LLT &self, const llvm::LLT &other) {
+            return self != other;
+          },
+          nb::is_operator())
       .def("__hash__",
            [](const llvm::LLT &self) {
              return static_cast<Py_ssize_t>(self.getUniqueRAWLLTData());

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -1,0 +1,50 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+
+#include <llvm/CodeGenTypes/LowLevelType.h>
+
+// LowLevelType (LLT) is the generic-MIR type: a target-independent "bag of
+// bits" describing a scalar/pointer/vector operand, distinct from the uniqued
+// llvm::Type hierarchy. It is a small value type (not context-owned and not
+// polymorphic), so it is bound by value with no ownership/keep_alive plumbing.
+// Binding it first also proves LLVMCodeGenTypes links into the extension.
+void populate_mir(nb::module_ &m) {
+  nb::class_<llvm::LLT>(m, "LLT")
+      .def_static("scalar", &llvm::LLT::scalar, "size_in_bits"_a)
+      .def_static("pointer", &llvm::LLT::pointer, "address_space"_a,
+                  "size_in_bits"_a)
+      .def_static(
+          "fixed_vector",
+          [](unsigned numElements, unsigned scalarSizeInBits) {
+            return llvm::LLT::fixed_vector(numElements, scalarSizeInBits);
+          },
+          "num_elements"_a, "scalar_size_in_bits"_a)
+      .def_prop_ro("size_in_bits",
+                   [](const llvm::LLT &self) {
+                     return self.getSizeInBits().getKnownMinValue();
+                   })
+      .def_prop_ro(
+          "scalar_size_in_bits",
+          [](const llvm::LLT &self) { return self.getScalarSizeInBits(); })
+      .def_prop_ro("num_elements",
+                   [](const llvm::LLT &self) { return self.getNumElements(); })
+      .def_prop_ro("address_space",
+                   [](const llvm::LLT &self) { return self.getAddressSpace(); })
+      .def_prop_ro("is_scalar",
+                   [](const llvm::LLT &self) { return self.isScalar(); })
+      .def_prop_ro("is_pointer",
+                   [](const llvm::LLT &self) { return self.isPointer(); })
+      .def_prop_ro("is_vector",
+                   [](const llvm::LLT &self) { return self.isVector(); })
+      .def_prop_ro("is_valid",
+                   [](const llvm::LLT &self) { return self.isValid(); })
+      .def("__eq__", [](const llvm::LLT &self,
+                        const llvm::LLT &other) { return self == other; })
+      .def("__ne__", [](const llvm::LLT &self,
+                        const llvm::LLT &other) { return self != other; })
+      .def("__str__",
+           [](const llvm::LLT &self) { return eudsl::toString(self); });
+}

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -60,8 +60,7 @@ NB_MODULE(eudslllvm_ext, m) {
   nb::module_ intrinsics = m.def_submodule("intrinsics");
   populate_intrinsics(intrinsics);
 
-  // llvm.mir -- Machine IR: the target-independent LowLevelType (LLT) and,
-  // building on it, the MachineFunction/MachineInstr object model.
+  // llvm.mir -- Machine IR: the target-independent LowLevelType (LLT).
   nb::module_ mir = m.def_submodule("mir");
   populate_mir(mir);
 }

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -23,6 +23,7 @@ void populate_target(nb::module_ &m);
 void populate_linker(nb::module_ &m);
 void populate_jit(nb::module_ &m);
 void populate_intrinsics(nb::module_ &m);
+void populate_mir(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -58,4 +59,9 @@ NB_MODULE(eudslllvm_ext, m) {
   // llvm.intrinsics -- intrinsic lookup and declaration.
   nb::module_ intrinsics = m.def_submodule("intrinsics");
   populate_intrinsics(intrinsics);
+
+  // llvm.mir -- Machine IR: the target-independent LowLevelType (LLT) and,
+  // building on it, the MachineFunction/MachineInstr object model.
+  nb::module_ mir = m.def_submodule("mir");
+  populate_mir(mir);
 }

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -7,7 +7,16 @@
 # Use llvm.ir.Context, llvm.types.i32, llvm.passmanager.run_passes,
 # llvm.jit.LLJIT, llvm.intrinsics.sqrt, llvm.instructions.load, llvm.dsl.function,
 # etc.
-from . import ir, types, passmanager, jit, intrinsics, instructions, dsl  # noqa: F401
+from . import (
+    ir,
+    types,
+    passmanager,
+    jit,
+    intrinsics,
+    instructions,
+    mir,
+    dsl,
+)  # noqa: F401
 
 from .dsl.values import install_value_casters as _install_value_casters
 

--- a/projects/eudsl-llvmpy/src/llvm/mir.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir.py
@@ -1,0 +1,5 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from .eudslllvm_ext.mir import *  # noqa: F401,F403
+from .eudslllvm_ext.mir import __doc__  # noqa: F401

--- a/projects/eudsl-llvmpy/tests/mir/test_foundation.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_foundation.py
@@ -5,7 +5,7 @@
 
 These pin the bare plumbing of the new `llvm.mir` submodule plus the
 target-independent LowLevelType (LLT), which is the first thing bound because
-it proves the CodeGen/CodeGenTypes libraries actually link into the extension.
+it proves the LLVMCodeGenTypes library actually links into the extension.
 LLT is a value type (not uniqued in a Context), so no `with Context()` is
 needed and there is nothing to leak-check here.
 """
@@ -29,6 +29,15 @@ def test_llt_scalar_predicates():
     assert not s.is_pointer
     assert not s.is_vector
     assert s.is_valid
+    # scalar() yields an ANY_SCALAR (neither INTEGER nor FLOAT kind), so both
+    # kind predicates are False; they exist to mirror the full LLT API.
+    assert not s.is_integer
+    assert not s.is_float
+
+
+def test_llt_scalar_size_in_bits_on_scalar_and_pointer():
+    assert mir.LLT.scalar(32).scalar_size_in_bits == 32
+    assert mir.LLT.pointer(0, 64).scalar_size_in_bits == 64
 
 
 def test_llt_pointer():
@@ -37,6 +46,12 @@ def test_llt_pointer():
     assert not p.is_scalar
     assert p.size_in_bits == 64
     assert p.address_space == 0
+
+
+def test_llt_pointer_nonzero_address_space():
+    p = mir.LLT.pointer(3, 64)
+    assert p.address_space == 3
+    assert str(p) == "p3"
 
 
 def test_llt_fixed_vector():
@@ -50,6 +65,23 @@ def test_llt_fixed_vector():
 def test_llt_equality():
     assert mir.LLT.scalar(32) == mir.LLT.scalar(32)
     assert mir.LLT.scalar(32) != mir.LLT.scalar(64)
+    assert not (mir.LLT.scalar(32) == mir.LLT.scalar(64))
+    assert not (mir.LLT.scalar(32) != mir.LLT.scalar(32))
+
+
+def test_llt_equality_with_non_llt():
+    # Comparing against a non-LLT operand returns False/True rather than raising.
+    assert mir.LLT.scalar(32) != 5
+    assert not (mir.LLT.scalar(32) == 5)
+
+
+def test_llt_hashable():
+    # Equal LLTs hash equal and are usable as set/dict keys.
+    assert hash(mir.LLT.scalar(32)) == hash(mir.LLT.scalar(32))
+    assert hash(mir.LLT.scalar(32)) != hash(mir.LLT.scalar(64))
+    types = {mir.LLT.scalar(32), mir.LLT.scalar(32), mir.LLT.fixed_vector(4, 32)}
+    assert len(types) == 2
+    assert mir.LLT.scalar(32) in types
 
 
 def test_llt_str():

--- a/projects/eudsl-llvmpy/tests/mir/test_foundation.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_foundation.py
@@ -1,0 +1,57 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Foundation for the MIR (Machine IR) submodule.
+
+These pin the bare plumbing of the new `llvm.mir` submodule plus the
+target-independent LowLevelType (LLT), which is the first thing bound because
+it proves the CodeGen/CodeGenTypes libraries actually link into the extension.
+LLT is a value type (not uniqued in a Context), so no `with Context()` is
+needed and there is nothing to leak-check here.
+"""
+
+import llvm
+from llvm import mir
+
+
+def test_mir_submodule_is_importable():
+    assert mir is llvm.mir
+
+
+def test_llt_scalar_size_in_bits():
+    assert mir.LLT.scalar(32).size_in_bits == 32
+    assert mir.LLT.scalar(1).size_in_bits == 1
+
+
+def test_llt_scalar_predicates():
+    s = mir.LLT.scalar(32)
+    assert s.is_scalar
+    assert not s.is_pointer
+    assert not s.is_vector
+    assert s.is_valid
+
+
+def test_llt_pointer():
+    p = mir.LLT.pointer(0, 64)
+    assert p.is_pointer
+    assert not p.is_scalar
+    assert p.size_in_bits == 64
+    assert p.address_space == 0
+
+
+def test_llt_fixed_vector():
+    v = mir.LLT.fixed_vector(4, 32)
+    assert v.is_vector
+    assert v.num_elements == 4
+    assert v.scalar_size_in_bits == 32
+    assert v.size_in_bits == 128
+
+
+def test_llt_equality():
+    assert mir.LLT.scalar(32) == mir.LLT.scalar(32)
+    assert mir.LLT.scalar(32) != mir.LLT.scalar(64)
+
+
+def test_llt_str():
+    assert str(mir.LLT.scalar(32)) == "s32"
+    assert str(mir.LLT.fixed_vector(4, 32)) == "<4 x s32>"

--- a/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
+++ b/projects/eudsl-llvmpy/tests/misc/test_cpp_coverage.py
@@ -26,7 +26,9 @@ def test_value_eq_hash_and_operands():
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
         f = mod.get_function("f")
         add = f.arg(0).users[0]
-        # __eq__ against a non-Value returns False (try_cast fails).
+        # __eq__ against a non-Value returns False (nanobind's is_operator
+        # yields NotImplemented on the failed cast, so Python falls back to
+        # identity).
         assert (f.arg(0) == "not a value") is False
         assert (f.arg(0) != "not a value") is True
         # __hash__: usable in a set/dict.


### PR DESCRIPTION
Introduce the llvm.mir submodule (src/MIR/, populate_mir) and link the
CodeGen libraries needed for Machine IR: LLVMCodeGenTypes, LLVMGlobalISel,
LLVMSelectionDAG, LLVMMIRParser. Bind LowLevelType (LLT) -- the
target-independent generic-MIR type -- as the first MIR class; it also proves
the new libraries link. Extend the C++ coverage gate to cover src/MIR.

First PR in the MIR bindings/DSL stack.