### PR TITLE
[eudsl-llvmpy] Add MIR inspection from codegen + .mir round-trip

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -16,8 +16,11 @@
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalValue.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Support/MemoryBuffer.h>
@@ -168,10 +171,33 @@ void populate_mir(nb::module_ &m) {
   // target's real registers).
   nb::class_<llvm::Register>(m, "Register")
       .def_prop_ro("id", [](llvm::Register &self) { return self.id(); })
+      .def_prop_ro("is_valid",
+                   [](llvm::Register &self) { return self.isValid(); })
       .def_prop_ro("is_virtual",
                    [](llvm::Register &self) { return self.isVirtual(); })
       .def_prop_ro("is_physical",
-                   [](llvm::Register &self) { return self.isPhysical(); });
+                   [](llvm::Register &self) { return self.isPhysical(); })
+      .def_prop_ro("virt_reg_index",
+                   [](llvm::Register &self) {
+                     if (!self.isVirtual())
+                       throw nb::value_error("register is not virtual");
+                     return self.virtRegIndex();
+                   })
+      .def(
+          "__eq__",
+          [](llvm::Register &self, llvm::Register other) {
+            return self == other;
+          },
+          nb::is_operator())
+      .def(
+          "__ne__",
+          [](llvm::Register &self, llvm::Register other) {
+            return self != other;
+          },
+          nb::is_operator())
+      .def("__hash__", [](llvm::Register &self) {
+        return static_cast<Py_ssize_t>(self.id());
+      });
 
   // llvm::MachineOperand -- one operand of a MachineInstr. is_def/is_use are
   // register-only in LLVM (they assert otherwise), so they are guarded to
@@ -200,6 +226,107 @@ void populate_mir(nb::module_ &m) {
                      if (!self.isImm())
                        throw nb::value_error("operand is not an immediate");
                      return self.getImm();
+                   })
+      // Remaining register-operand flags (read side).
+      .def_prop_ro("is_debug",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isDebug();
+                   })
+      .def_prop_ro("is_internal_read",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isInternalRead();
+                   })
+      .def_prop_ro("is_tied",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isTied();
+                   })
+      .def_prop_ro(
+          "target_flags",
+          [](llvm::MachineOperand &self) { return self.getTargetFlags(); })
+      // Operand-kind predicates (mirror MachineOperand::isX()).
+      .def_prop_ro("is_cimm",
+                   [](llvm::MachineOperand &self) { return self.isCImm(); })
+      .def_prop_ro("is_fpimm",
+                   [](llvm::MachineOperand &self) { return self.isFPImm(); })
+      .def_prop_ro("is_mbb",
+                   [](llvm::MachineOperand &self) { return self.isMBB(); })
+      .def_prop_ro("is_fi",
+                   [](llvm::MachineOperand &self) { return self.isFI(); })
+      .def_prop_ro("is_cpi",
+                   [](llvm::MachineOperand &self) { return self.isCPI(); })
+      .def_prop_ro("is_jti",
+                   [](llvm::MachineOperand &self) { return self.isJTI(); })
+      .def_prop_ro(
+          "is_target_index",
+          [](llvm::MachineOperand &self) { return self.isTargetIndex(); })
+      .def_prop_ro("is_global",
+                   [](llvm::MachineOperand &self) { return self.isGlobal(); })
+      .def_prop_ro("is_symbol",
+                   [](llvm::MachineOperand &self) { return self.isSymbol(); })
+      .def_prop_ro(
+          "is_block_address",
+          [](llvm::MachineOperand &self) { return self.isBlockAddress(); })
+      .def_prop_ro("is_reg_mask",
+                   [](llvm::MachineOperand &self) { return self.isRegMask(); })
+      .def_prop_ro("is_metadata",
+                   [](llvm::MachineOperand &self) { return self.isMetadata(); })
+      .def_prop_ro(
+          "is_predicate",
+          [](llvm::MachineOperand &self) { return self.isPredicate(); })
+      // Kind-specific getters (guarded; each asserts its kind in LLVM).
+      .def_prop_ro(
+          "cimm",
+          [](llvm::MachineOperand &self) -> const llvm::ConstantInt * {
+            if (!self.isCImm())
+              throw nb::value_error("operand is not a CImm");
+            return self.getCImm();
+          },
+          nb::rv_policy::reference)
+      .def_prop_ro(
+          "fpimm",
+          [](llvm::MachineOperand &self) -> const llvm::ConstantFP * {
+            if (!self.isFPImm())
+              throw nb::value_error("operand is not an FPImm");
+            return self.getFPImm();
+          },
+          nb::rv_policy::reference)
+      .def_prop_ro(
+          "mbb",
+          [](llvm::MachineOperand &self) -> llvm::MachineBasicBlock * {
+            if (!self.isMBB())
+              throw nb::value_error("operand is not a MachineBasicBlock");
+            return self.getMBB();
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("index",
+                   [](llvm::MachineOperand &self) {
+                     if (!self.isFI() && !self.isCPI() && !self.isJTI() &&
+                         !self.isTargetIndex())
+                       throw nb::value_error("operand has no index");
+                     return self.getIndex();
+                   })
+      .def_prop_ro(
+          "global_value",
+          [](llvm::MachineOperand &self) -> const llvm::GlobalValue * {
+            if (!self.isGlobal())
+              throw nb::value_error("operand is not a global address");
+            return self.getGlobal();
+          },
+          nb::rv_policy::reference)
+      .def_prop_ro("symbol_name",
+                   [](llvm::MachineOperand &self) {
+                     if (!self.isSymbol())
+                       throw nb::value_error(
+                           "operand is not an external symbol");
+                     return std::string(self.getSymbolName());
+                   })
+      .def_prop_ro("offset",
+                   [](llvm::MachineOperand &self) {
+                     if (!self.isGlobal() && !self.isSymbol() &&
+                         !self.isCPI() && !self.isTargetIndex() &&
+                         !self.isBlockAddress())
+                       throw nb::value_error("operand has no offset");
+                     return self.getOffset();
                    })
       .def("__str__",
            [](llvm::MachineOperand &self) { return eudsl::toString(self); });
@@ -240,6 +367,51 @@ void populate_mir(nb::module_ &m) {
             return &self.getOperand(i);
           },
           "index"_a, nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "parent",
+          [](llvm::MachineInstr &self) -> const llvm::MachineBasicBlock * {
+            return self.getParent();
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("num_defs",
+                   [](llvm::MachineInstr &self) { return self.getNumDefs(); })
+      .def_prop_ro("num_explicit_operands",
+                   [](llvm::MachineInstr &self) {
+                     return self.getNumExplicitOperands();
+                   })
+      // Classification predicates (query the MCInstrDesc; mirror MachineInstr).
+      .def_prop_ro("is_terminator",
+                   [](llvm::MachineInstr &self) { return self.isTerminator(); })
+      .def_prop_ro("is_branch",
+                   [](llvm::MachineInstr &self) { return self.isBranch(); })
+      .def_prop_ro(
+          "is_conditional_branch",
+          [](llvm::MachineInstr &self) { return self.isConditionalBranch(); })
+      .def_prop_ro(
+          "is_unconditional_branch",
+          [](llvm::MachineInstr &self) { return self.isUnconditionalBranch(); })
+      .def_prop_ro(
+          "is_indirect_branch",
+          [](llvm::MachineInstr &self) { return self.isIndirectBranch(); })
+      .def_prop_ro("is_barrier",
+                   [](llvm::MachineInstr &self) { return self.isBarrier(); })
+      .def_prop_ro("is_call",
+                   [](llvm::MachineInstr &self) { return self.isCall(); })
+      .def_prop_ro("is_return",
+                   [](llvm::MachineInstr &self) { return self.isReturn(); })
+      .def_prop_ro("is_copy",
+                   [](llvm::MachineInstr &self) { return self.isCopy(); })
+      .def_prop_ro("is_phi",
+                   [](llvm::MachineInstr &self) { return self.isPHI(); })
+      .def_prop_ro(
+          "is_implicit_def",
+          [](llvm::MachineInstr &self) { return self.isImplicitDef(); })
+      .def_prop_ro("may_load",
+                   [](llvm::MachineInstr &self) { return self.mayLoad(); })
+      .def_prop_ro("may_store",
+                   [](llvm::MachineInstr &self) { return self.mayStore(); })
+      .def_prop_ro("is_debug_instr",
+                   [](llvm::MachineInstr &self) { return self.isDebugInstr(); })
       .def("__str__",
            [](llvm::MachineInstr &self) { return eudsl::toString(self); });
 
@@ -261,6 +433,31 @@ void populate_mir(nb::module_ &m) {
             return instrs;
           },
           nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "parent",
+          [](llvm::MachineBasicBlock &self) -> llvm::MachineFunction * {
+            return self.getParent();
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "is_entry_block",
+          [](llvm::MachineBasicBlock &self) { return self.isEntryBlock(); })
+      .def_prop_ro(
+          "successors",
+          [](llvm::MachineBasicBlock &self) {
+            std::vector<llvm::MachineBasicBlock *> succs(self.succ_begin(),
+                                                         self.succ_end());
+            return succs;
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "predecessors",
+          [](llvm::MachineBasicBlock &self) {
+            std::vector<llvm::MachineBasicBlock *> preds(self.pred_begin(),
+                                                         self.pred_end());
+            return preds;
+          },
+          nb::rv_policy::reference_internal)
       .def("__str__",
            [](llvm::MachineBasicBlock &self) { return eudsl::toString(self); });
 
@@ -279,6 +476,14 @@ void populate_mir(nb::module_ &m) {
             for (llvm::MachineBasicBlock &mbb : self)
               blocks.push_back(&mbb);
             return blocks;
+          },
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("num_blocks",
+                   [](llvm::MachineFunction &self) { return self.size(); })
+      .def_prop_ro(
+          "function",
+          [](llvm::MachineFunction &self) -> const llvm::Function * {
+            return &self.getFunction();
           },
           nb::rv_policy::reference_internal)
       .def("__str__",
@@ -305,6 +510,19 @@ void populate_mir(nb::module_ &m) {
             return mf;
           },
           "name"_a, nb::rv_policy::reference_internal)
+      .def_prop_ro(
+          "machine_functions",
+          [](MachineModuleInfo &self) {
+            std::vector<llvm::MachineFunction *> mfs;
+            for (llvm::Function &f : *self.module) {
+              if (llvm::MachineFunction *mf = self.mmi->getMachineFunction(f))
+                mfs.push_back(mf);
+            }
+            return mfs;
+          },
+          nb::rv_policy::reference_internal,
+          "The MachineFunctions in the module (functions without one -- e.g. "
+          "declarations -- are skipped).")
       .def(
           "to_mir", [](MachineModuleInfo &self) { return self.toMIR(); },
           "Serialize the whole module (IR block + machine functions) as .mir "

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -16,6 +16,9 @@
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Target/TargetMachine.h>
@@ -26,14 +29,56 @@
 
 namespace {
 
+// MIR parsing and codegen report failures through LLVMContext::diagnose --
+// their return values are only a bare success/failure bit, so the rich reason
+// (line, column, message) would otherwise be lost to the default handler's
+// stderr print, which is invisible under the Python/nanobind harness. This RAII
+// guard installs a handler that captures error-severity diagnostics into `sink`
+// for the duration of one parse/codegen call, restoring the previous handler on
+// scope exit so the capture buffer (a caller stack local) never outlives the
+// handler that points at it.
+struct ScopedDiagnosticCapture {
+  llvm::LLVMContext &ctx;
+  llvm::DiagnosticHandler::DiagnosticHandlerTy prevHandler;
+  void *prevContext;
+
+  ScopedDiagnosticCapture(llvm::LLVMContext &ctx, std::string &sink)
+      : ctx(ctx), prevHandler(ctx.getDiagnosticHandlerCallBack()),
+        prevContext(ctx.getDiagnosticContext()) {
+    ctx.setDiagnosticHandlerCallBack(
+        [](const llvm::DiagnosticInfo *di, void *context) {
+          if (di->getSeverity() == llvm::DS_Error) {
+            auto *out = static_cast<std::string *>(context);
+            llvm::raw_string_ostream os(*out);
+            llvm::DiagnosticPrinterRawOStream printer(os);
+            di->print(printer);
+          }
+        },
+        &sink);
+  }
+  ~ScopedDiagnosticCapture() {
+    ctx.setDiagnosticHandlerCallBack(prevHandler, prevContext);
+  }
+  ScopedDiagnosticCapture(const ScopedDiagnosticCapture &) = delete;
+  ScopedDiagnosticCapture &operator=(const ScopedDiagnosticCapture &) = delete;
+};
+
+// "<base>" when no diagnostic was captured, else "<base>: <detail>".
+std::string withDetail(llvm::StringRef base, const std::string &detail) {
+  if (detail.empty())
+    return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
+  return (base + ": " + detail).str();
+}
+
 // Owns everything the inspected MachineFunctions transitively depend on, so
-// none of it is freed out from under them: the IR Module (whose Functions the
-// MachineFunctions reference) and the MachineModuleInfo that owns the
-// MachineFunctions. The MMI is owned two ways depending on how it was built:
-// the codegen path (run_codegen_to_mir) leaves it inside a
-// MachineModuleInfoWrapperPass owned by `pm`; the parse path (parse_mir) owns
-// it directly via `ownedMmi`. `mmi` is the query handle either way. The
-// TargetMachine is a separate Python object kept alive by a keep_alive.
+// none of it is freed out from under them: the LLVMContext (pinned by
+// `ctxKeepAlive`), the IR Module (whose Functions the MachineFunctions
+// reference), and the MachineModuleInfo that owns the MachineFunctions. The MMI
+// is owned two ways depending on how it was built: the codegen path
+// (run_codegen_to_mir) leaves it inside a MachineModuleInfoWrapperPass owned by
+// `pm`; the parse path (parse_mir) owns it directly via `ownedMmi`. `mmi` is
+// the query handle either way. The TargetMachine is a separate Python object
+// kept alive by a keep_alive.
 struct MachineModuleInfo {
   std::shared_ptr<llvm::LLVMContext> ctxKeepAlive;
   std::unique_ptr<llvm::Module> module;
@@ -42,7 +87,10 @@ struct MachineModuleInfo {
   llvm::MachineModuleInfo *mmi;
 
   // Print the whole module as .mir text: the IR block, then each function's
-  // machine-level block, matching what `llc -stop-after` emits.
+  // machine-level block, matching what `llc -stop-after=finalize-isel` emits. A
+  // function with no MachineFunction is skipped -- expected for declarations
+  // (nothing to lower); a definition only lacks one if codegen failed, which
+  // run_codegen_to_mir now reports as an exception rather than reaching here.
   std::string toMIR() {
     std::string buf;
     llvm::raw_string_ostream os(buf);
@@ -164,8 +212,20 @@ void populate_mir(nb::module_ &m) {
                    [](llvm::MachineInstr &self) { return self.getOpcode(); })
       .def_prop_ro("opcode_name",
                    [](llvm::MachineInstr &self) {
+                     const llvm::MachineFunction *mf = self.getMF();
+                     // LCOV_EXCL_START -- block instrs are always attached
+                     if (!mf) {
+                       throw nb::value_error(
+                           "instruction is not attached to a MachineFunction");
+                     }
+                     // LCOV_EXCL_STOP
                      const llvm::TargetInstrInfo *tii =
-                         self.getMF()->getSubtarget().getInstrInfo();
+                         mf->getSubtarget().getInstrInfo();
+                     // LCOV_EXCL_START -- AArch64 always has a TargetInstrInfo
+                     if (!tii) {
+                       throw nb::value_error("target has no TargetInstrInfo");
+                     }
+                     // LCOV_EXCL_STOP
                      return tii->getName(self.getOpcode()).str();
                    })
       .def_prop_ro(
@@ -224,21 +284,24 @@ void populate_mir(nb::module_ &m) {
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
-  // The result of run_codegen_to_mir: owns the MachineFunctions and everything
-  // they depend on. `machine_function` resolves one by its IR Function name.
+  // The result of run_codegen_to_mir or parse_mir: owns the MachineFunctions
+  // and everything they depend on. `machine_function` resolves one by its IR
+  // Function name.
   nb::class_<MachineModuleInfo>(m, "MachineModuleInfo")
       .def(
           "machine_function",
           [](MachineModuleInfo &self,
              const std::string &name) -> llvm::MachineFunction * {
             llvm::Function *f = self.module->getFunction(name);
-            if (!f)
+            if (!f) {
               throw nb::key_error(
                   ("no function named '" + name + "' in the module").c_str());
+            }
             llvm::MachineFunction *mf = self.mmi->getMachineFunction(*f);
-            if (!mf)
+            if (!mf) {
               throw nb::key_error(
                   ("function '" + name + "' has no MachineFunction").c_str());
+            }
             return mf;
           },
           "name"_a, nb::rv_policy::reference_internal)
@@ -251,9 +314,10 @@ void populate_mir(nb::module_ &m) {
   // MachineModuleInfo that owns the resulting MachineFunctions. Consumes the
   // module (like adding it to the JIT): the MachineFunctions reference its
   // Functions, so ownership moves into the returned wrapper. Only the ISel
-  // passes are added -- not addMachinePasses -- so the MachineFunctions are
-  // retained (not freed by FreeMachineFunctionPass) for inspection, the state
-  // `llc -stop-after=finalize-isel` produces.
+  // passes are added -- not the object-emission pipeline (addPassesToEmitFile),
+  // which would append FreeMachineFunctionPass -- so the MachineFunctions are
+  // retained for inspection, the state `llc -stop-after=finalize-isel`
+  // produces.
   m.def(
       "run_codegen_to_mir",
       [](eudsl::Module &mod, llvm::TargetMachine &tm) {
@@ -267,11 +331,29 @@ void populate_mir(nb::module_ &m) {
         pm->add(tpc);
         auto *mmiwp = new llvm::MachineModuleInfoWrapperPass(&tm);
         pm->add(mmiwp);
-        if (tpc->addISelPasses())
-          throw std::runtime_error( // LCOV_EXCL_LINE
-              "target cannot add instruction-selection passes"); // LCOV_EXCL_LINE
+        // LCOV_EXCL_START -- only a misconfigured target fails to add ISel
+        if (tpc->addISelPasses()) {
+          throw std::runtime_error(
+              "target cannot add instruction-selection passes");
+        }
+        // LCOV_EXCL_STOP
         tpc->setInitialized();
-        pm->run(*module);
+
+        // Codegen reports failures (e.g. an un-selectable construct) through
+        // the context diagnostic handler, not pm->run()'s return value; capture
+        // them so a failed selection surfaces as an exception instead of a
+        // silently-empty MachineModuleInfo.
+        std::string diag;
+        {
+          ScopedDiagnosticCapture capture(module->getContext(), diag);
+          pm->run(*module);
+        }
+        // LCOV_EXCL_START -- needs an un-selectable input to trigger
+        if (!diag.empty()) {
+          throw std::runtime_error(
+              withDetail("instruction selection failed", diag));
+        }
+        // LCOV_EXCL_STOP
 
         return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
                                      std::move(pm), /*ownedMmi=*/nullptr,
@@ -289,18 +371,29 @@ void populate_mir(nb::module_ &m) {
       [](const std::string &text, eudsl::Context &context,
          llvm::TargetMachine &tm) {
         std::shared_ptr<llvm::LLVMContext> ctxKeepAlive = context.shared();
+        // The MIR parser reports syntax/semantic errors through the context
+        // diagnostic handler and only returns a bare null/true; capture the
+        // real diagnostic so the thrown message carries the line and reason.
+        std::string diag;
+        ScopedDiagnosticCapture capture(context.get(), diag);
         std::unique_ptr<llvm::MIRParser> parser = llvm::createMIRParser(
             llvm::MemoryBuffer::getMemBuffer(text, "<mir>"), context.get());
-        if (!parser)
-          throw std::runtime_error(           // LCOV_EXCL_LINE
-              "could not create MIR parser"); // LCOV_EXCL_LINE
+        // LCOV_EXCL_START -- createMIRParser only fails on internal error
+        if (!parser) {
+          throw std::runtime_error("could not create MIR parser");
+        }
+        // LCOV_EXCL_STOP
         std::unique_ptr<llvm::Module> module = parser->parseIRModule();
-        if (!module)
-          throw std::runtime_error("failed to parse the IR portion of the MIR");
+        if (!module) {
+          throw std::runtime_error(
+              withDetail("failed to parse the IR portion of the MIR", diag));
+        }
         module->setDataLayout(tm.createDataLayout());
         auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
-        if (parser->parseMachineFunctions(*module, *ownedMmi))
-          throw std::runtime_error("failed to parse machine functions");
+        if (parser->parseMachineFunctions(*module, *ownedMmi)) {
+          throw std::runtime_error(
+              withDetail("failed to parse machine functions", diag));
+        }
         llvm::MachineModuleInfo *mmi = ownedMmi.get();
         return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
                                      /*pm=*/nullptr, std::move(ownedMmi), mmi};

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -3,8 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "IR/Common.h"
+#include "IR/Ownership.h"
 
+#include <llvm/CodeGen/MIRParser/MIRParser.h>
+#include <llvm/CodeGen/MIRPrinter.h>
+#include <llvm/CodeGen/MachineBasicBlock.h>
+#include <llvm/CodeGen/MachineFunction.h>
+#include <llvm/CodeGen/MachineInstr.h>
+#include <llvm/CodeGen/MachineModuleInfo.h>
+#include <llvm/CodeGen/MachineOperand.h>
+#include <llvm/CodeGen/TargetInstrInfo.h>
+#include <llvm/CodeGen/TargetPassConfig.h>
+#include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Target/TargetMachine.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Owns everything the inspected MachineFunctions transitively depend on, so
+// none of it is freed out from under them: the IR Module (whose Functions the
+// MachineFunctions reference) and the MachineModuleInfo that owns the
+// MachineFunctions. The MMI is owned two ways depending on how it was built:
+// the codegen path (run_codegen_to_mir) leaves it inside a
+// MachineModuleInfoWrapperPass owned by `pm`; the parse path (parse_mir) owns
+// it directly via `ownedMmi`. `mmi` is the query handle either way. The
+// TargetMachine is a separate Python object kept alive by a keep_alive.
+struct MachineModuleInfo {
+  std::shared_ptr<llvm::LLVMContext> ctxKeepAlive;
+  std::unique_ptr<llvm::Module> module;
+  std::unique_ptr<llvm::legacy::PassManager> pm;     // codegen path
+  std::unique_ptr<llvm::MachineModuleInfo> ownedMmi; // parse path
+  llvm::MachineModuleInfo *mmi;
+
+  // Print the whole module as .mir text: the IR block, then each function's
+  // machine-level block, matching what `llc -stop-after` emits.
+  std::string toMIR() {
+    std::string buf;
+    llvm::raw_string_ostream os(buf);
+    llvm::printMIR(os, *module);
+    for (llvm::Function &f : *module) {
+      if (llvm::MachineFunction *mf = mmi->getMachineFunction(f))
+        llvm::printMIR(os, *mmi, *mf);
+    }
+    return buf;
+  }
+};
+
+} // namespace
 
 // LowLevelType (LLT) is the generic-MIR type: a target-independent "bag of
 // bits" describing a scalar/pointer/vector operand, distinct from the uniqued
@@ -63,4 +114,196 @@ void populate_mir(nb::module_ &m) {
            })
       .def("__str__",
            [](const llvm::LLT &self) { return eudsl::toString(self); });
+
+  // llvm::Register -- a machine register operand's value (a tagged unsigned:
+  // virtual registers are SSA-ish temporaries from ISel, physical are the
+  // target's real registers).
+  nb::class_<llvm::Register>(m, "Register")
+      .def_prop_ro("id", [](llvm::Register &self) { return self.id(); })
+      .def_prop_ro("is_virtual",
+                   [](llvm::Register &self) { return self.isVirtual(); })
+      .def_prop_ro("is_physical",
+                   [](llvm::Register &self) { return self.isPhysical(); });
+
+  // llvm::MachineOperand -- one operand of a MachineInstr. is_def/is_use are
+  // register-only in LLVM (they assert otherwise), so they are guarded to
+  // report false for non-register operands rather than crash.
+  nb::class_<llvm::MachineOperand>(m, "MachineOperand")
+      .def_prop_ro("is_reg",
+                   [](llvm::MachineOperand &self) { return self.isReg(); })
+      .def_prop_ro("is_imm",
+                   [](llvm::MachineOperand &self) { return self.isImm(); })
+      .def_prop_ro("is_def",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isDef();
+                   })
+      .def_prop_ro("is_use",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isUse();
+                   })
+      .def_prop_ro("reg",
+                   [](llvm::MachineOperand &self) -> llvm::Register {
+                     if (!self.isReg())
+                       throw nb::value_error("operand is not a register");
+                     return self.getReg();
+                   })
+      .def_prop_ro("imm",
+                   [](llvm::MachineOperand &self) {
+                     if (!self.isImm())
+                       throw nb::value_error("operand is not an immediate");
+                     return self.getImm();
+                   })
+      .def("__str__",
+           [](llvm::MachineOperand &self) { return eudsl::toString(self); });
+
+  // llvm::MachineInstr -- one machine instruction. opcode is the target opcode
+  // number; opcode_name resolves its mnemonic via the function's
+  // TargetInstrInfo. Non-owning (lives in its MachineBasicBlock).
+  nb::class_<llvm::MachineInstr>(m, "MachineInstr")
+      .def_prop_ro("opcode",
+                   [](llvm::MachineInstr &self) { return self.getOpcode(); })
+      .def_prop_ro("opcode_name",
+                   [](llvm::MachineInstr &self) {
+                     const llvm::TargetInstrInfo *tii =
+                         self.getMF()->getSubtarget().getInstrInfo();
+                     return tii->getName(self.getOpcode()).str();
+                   })
+      .def_prop_ro(
+          "num_operands",
+          [](llvm::MachineInstr &self) { return self.getNumOperands(); })
+      .def(
+          "operand",
+          [](llvm::MachineInstr &self,
+             unsigned i) -> const llvm::MachineOperand * {
+            if (i >= self.getNumOperands())
+              throw nb::index_error("operand index out of range");
+            return &self.getOperand(i);
+          },
+          "index"_a, nb::rv_policy::reference_internal)
+      .def("__str__",
+           [](llvm::MachineInstr &self) { return eudsl::toString(self); });
+
+  // llvm::MachineBasicBlock -- a machine basic block. `instructions` is the
+  // ordered list of its MachineInstrs.
+  nb::class_<llvm::MachineBasicBlock>(m, "MachineBasicBlock")
+      .def_prop_ro(
+          "name",
+          [](llvm::MachineBasicBlock &self) { return self.getName().str(); })
+      .def_prop_ro(
+          "number",
+          [](llvm::MachineBasicBlock &self) { return self.getNumber(); })
+      .def_prop_ro(
+          "instructions",
+          [](llvm::MachineBasicBlock &self) {
+            std::vector<llvm::MachineInstr *> instrs;
+            for (llvm::MachineInstr &mi : self)
+              instrs.push_back(&mi);
+            return instrs;
+          },
+          nb::rv_policy::reference_internal)
+      .def("__str__",
+           [](llvm::MachineBasicBlock &self) { return eudsl::toString(self); });
+
+  // llvm::MachineFunction -- the machine-level body of one IR Function after
+  // instruction selection. Non-owning: it lives inside the MachineModuleInfo
+  // that produced it, so it is returned by pointer with the owning wrapper kept
+  // alive (reference_internal).
+  nb::class_<llvm::MachineFunction>(m, "MachineFunction")
+      .def_prop_ro(
+          "name",
+          [](llvm::MachineFunction &self) { return self.getName().str(); })
+      .def_prop_ro(
+          "blocks",
+          [](llvm::MachineFunction &self) {
+            std::vector<llvm::MachineBasicBlock *> blocks;
+            for (llvm::MachineBasicBlock &mbb : self)
+              blocks.push_back(&mbb);
+            return blocks;
+          },
+          nb::rv_policy::reference_internal)
+      .def("__str__",
+           [](llvm::MachineFunction &self) { return eudsl::toString(self); });
+
+  // The result of run_codegen_to_mir: owns the MachineFunctions and everything
+  // they depend on. `machine_function` resolves one by its IR Function name.
+  nb::class_<MachineModuleInfo>(m, "MachineModuleInfo")
+      .def(
+          "machine_function",
+          [](MachineModuleInfo &self,
+             const std::string &name) -> llvm::MachineFunction * {
+            llvm::Function *f = self.module->getFunction(name);
+            if (!f)
+              throw nb::key_error(
+                  ("no function named '" + name + "' in the module").c_str());
+            llvm::MachineFunction *mf = self.mmi->getMachineFunction(*f);
+            if (!mf)
+              throw nb::key_error(
+                  ("function '" + name + "' has no MachineFunction").c_str());
+            return mf;
+          },
+          "name"_a, nb::rv_policy::reference_internal)
+      .def(
+          "to_mir", [](MachineModuleInfo &self) { return self.toMIR(); },
+          "Serialize the whole module (IR block + machine functions) as .mir "
+          "text.");
+
+  // Run instruction selection on an IR module and hand back the
+  // MachineModuleInfo that owns the resulting MachineFunctions. Consumes the
+  // module (like adding it to the JIT): the MachineFunctions reference its
+  // Functions, so ownership moves into the returned wrapper. Only the ISel
+  // passes are added -- not addMachinePasses -- so the MachineFunctions are
+  // retained (not freed by FreeMachineFunctionPass) for inspection, the state
+  // `llc -stop-after=finalize-isel` produces.
+  m.def(
+      "run_codegen_to_mir",
+      [](eudsl::Module &mod, llvm::TargetMachine &tm) {
+        std::shared_ptr<llvm::LLVMContext> ctxKeepAlive =
+            mod.context().shared();
+        std::unique_ptr<llvm::Module> module = mod.take();
+        module->setDataLayout(tm.createDataLayout());
+
+        auto pm = std::make_unique<llvm::legacy::PassManager>();
+        llvm::TargetPassConfig *tpc = tm.createPassConfig(*pm);
+        pm->add(tpc);
+        auto *mmiwp = new llvm::MachineModuleInfoWrapperPass(&tm);
+        pm->add(mmiwp);
+        if (tpc->addISelPasses())
+          throw std::runtime_error( // LCOV_EXCL_LINE
+              "target cannot add instruction-selection passes"); // LCOV_EXCL_LINE
+        tpc->setInitialized();
+        pm->run(*module);
+
+        return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
+                                     std::move(pm), /*ownedMmi=*/nullptr,
+                                     &mmiwp->getMMI()};
+      },
+      "module"_a, "target_machine"_a, nb::keep_alive<0, 2>());
+
+  // Parse .mir text into a MachineModuleInfo. Mirrors run_codegen_to_mir's
+  // result but builds the MachineFunctions by deserialization rather than
+  // instruction selection. The context is kept alive by the returned wrapper;
+  // the TargetMachine (which the parsed MachineFunctions bind to) by
+  // keep_alive.
+  m.def(
+      "parse_mir",
+      [](const std::string &text, eudsl::Context &context,
+         llvm::TargetMachine &tm) {
+        std::shared_ptr<llvm::LLVMContext> ctxKeepAlive = context.shared();
+        std::unique_ptr<llvm::MIRParser> parser = llvm::createMIRParser(
+            llvm::MemoryBuffer::getMemBuffer(text, "<mir>"), context.get());
+        if (!parser)
+          throw std::runtime_error(           // LCOV_EXCL_LINE
+              "could not create MIR parser"); // LCOV_EXCL_LINE
+        std::unique_ptr<llvm::Module> module = parser->parseIRModule();
+        if (!module)
+          throw std::runtime_error("failed to parse the IR portion of the MIR");
+        module->setDataLayout(tm.createDataLayout());
+        auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
+        if (parser->parseMachineFunctions(*module, *ownedMmi))
+          throw std::runtime_error("failed to parse machine functions");
+        llvm::MachineModuleInfo *mmi = ownedMmi.get();
+        return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
+                                     /*pm=*/nullptr, std::move(ownedMmi), mmi};
+      },
+      "text"_a, "context"_a, "target_machine"_a, nb::keep_alive<0, 3>());
 }

--- a/projects/eudsl-llvmpy/tests/mir/test_inspect.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_inspect.py
@@ -11,6 +11,8 @@ inspected. The reference shapes asserted here were produced with
 
 from textwrap import dedent
 
+import gc
+
 import pytest
 
 import llvm
@@ -45,6 +47,36 @@ _DECL_SRC = dedent("""\
     entry:
       %s = add i32 %a, %b
       ret i32 %s
+    }
+    """)
+
+# A loop cannot collapse to a single block (a plain conditional branch would be
+# if-converted to a CSEL), so its machine blocks get distinct, non-zero numbers.
+_LOOP_SRC = dedent("""\
+    define void @count(i32 %n) {
+    entry:
+      br label %head
+    head:
+      %i = phi i32 [ 0, %entry ], [ %i.next, %body ]
+      %c = icmp slt i32 %i, %n
+      br i1 %c, label %body, label %exit
+    body:
+      %i.next = add i32 %i, 1
+      br label %head
+    exit:
+      ret void
+    }
+    """)
+
+# Two definitions, so to_mir's per-function loop runs more than once.
+_TWO_FN_SRC = dedent("""\
+    define i32 @add(i32 %a, i32 %b) {
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    define i32 @sub(i32 %a, i32 %b) {
+      %d = sub i32 %a, %b
+      ret i32 %d
     }
     """)
 
@@ -103,6 +135,7 @@ def test_addwrr_operands_are_one_def_two_uses():
         assert add.operand(1).is_use
         assert add.operand(2).is_use
         assert add.operand(0).reg.is_virtual
+        assert not add.operand(0).reg.is_physical
     assert_no_leaks()
 
 
@@ -121,6 +154,7 @@ def test_object_model_accessors():
         last_copy = [i for i in block.instructions if i.opcode_name == "COPY"][-1]
         phys = last_copy.operand(0)
         assert phys.reg.is_physical
+        assert not phys.reg.is_virtual
         assert phys.reg.id > 0
         assert "w0" in str(phys)
     assert_no_leaks()
@@ -160,8 +194,60 @@ def test_immediate_operand_and_kind_guards():
         mov = next(i for i in block.instructions if i.opcode_name == "MOVi32imm")
         assert mov.operand(1).is_imm
         assert mov.operand(1).imm == 42
+        # is_def/is_use are register-only; a non-register operand reports False
+        # rather than tripping LLVM's isReg() assert.
+        assert not mov.operand(1).is_def
+        assert not mov.operand(1).is_use
         with pytest.raises(ValueError):
             mov.operand(1).reg  # an immediate operand has no register
         with pytest.raises(ValueError):
             mov.operand(0).imm  # a register operand has no immediate
+    assert_no_leaks()
+
+
+def test_run_codegen_to_mir_consumes_module():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE))
+        assert mod._is_consumed
+        with pytest.raises(RuntimeError):
+            mod.functions  # the module moved into the wrapper; it can't be used
+    assert_no_leaks()
+
+
+def test_machine_function_outlives_dropped_mmi_handle():
+    with ir.Context() as ctx:
+        mmi = _add_machine_module(ctx)
+        mf = mmi.machine_function("add")
+        block = mf.blocks[0]
+        del mmi
+        gc.collect()
+        # reference_internal pins the owning MachineModuleInfo through mf/block,
+        # so the machine function stays valid after the Python handle is dropped.
+        assert mf.name == "add"
+        assert any(i.opcode_name == "ADDWrr" for i in block.instructions)
+    assert_no_leaks()
+
+
+def test_multi_block_function_numbers_its_blocks():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_LOOP_SRC, ctx, "m")
+        mmi = mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE))
+        blocks = mmi.machine_function("count").blocks
+        numbers = [b.number for b in blocks]
+        assert len(blocks) >= 2
+        assert numbers == sorted(numbers)
+        assert max(numbers) >= 1  # not every block is number 0
+    assert_no_leaks()
+
+
+def test_to_mir_emits_every_defined_function():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_TWO_FN_SRC, ctx, "m")
+        mmi = mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE))
+        assert mmi.machine_function("add").name == "add"
+        assert mmi.machine_function("sub").name == "sub"
+        text = mmi.to_mir()
+        assert "name:            add" in text
+        assert "name:            sub" in text
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_inspect.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_inspect.py
@@ -83,6 +83,66 @@ _TWO_FN_SRC = dedent("""\
 _TRIPLE = "aarch64-unknown-linux-gnu"
 
 
+# A load from a global -> a machine operand that isGlobal (the @g address).
+_GLOBAL_SRC = dedent("""\
+    @g = global i32 0
+    define i32 @f() {
+      %v = load i32, ptr @g
+      ret i32 %v
+    }
+    """)
+
+# An alloca -> a stack slot, i.e. a frame-index (isFI) machine operand. The
+# accesses are volatile so they survive as real load/store machine instructions
+# (a plain alloca would be promoted away).
+_ALLOCA_SRC = dedent("""\
+    define i32 @a(i32 %x) {
+      %p = alloca i32
+      store volatile i32 %x, ptr %p
+      %v = load volatile i32, ptr %p
+      ret i32 %v
+    }
+    """)
+
+# Generic (pre-ISel) MIR parsed directly: G_CONSTANT carries a CImm operand and
+# G_FCONSTANT an FPImm operand -- the operand kinds selected MIR doesn't have.
+_GENERIC_MIR = dedent("""\
+    --- |
+      define i32 @c() { ret i32 0 }
+      define float @fc() { ret float 0.0 }
+    ...
+    ---
+    name: c
+    body: |
+      bb.0:
+        %0:_(s32) = G_CONSTANT i32 42
+        $w0 = COPY %0(s32)
+        RET_ReallyLR implicit $w0
+    ...
+    ---
+    name: fc
+    body: |
+      bb.0:
+        %0:_(s32) = G_FCONSTANT float 1.000000e+00
+        RET_ReallyLR
+    ...
+    """)
+
+# An external-symbol (isSymbol) machine operand, via an ADRP of a runtime symbol.
+_SYMBOL_MIR = dedent("""\
+    --- |
+      define void @s() { ret void }
+    ...
+    ---
+    name: s
+    body: |
+      bb.0:
+        $x0 = ADRP target-flags(aarch64-page) &__stack_chk_guard
+        RET_ReallyLR
+    ...
+    """)
+
+
 def test_run_codegen_to_mir_yields_named_machine_function():
     with ir.Context() as ctx:
         mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
@@ -250,4 +310,269 @@ def test_to_mir_emits_every_defined_function():
         text = mmi.to_mir()
         assert "name:            add" in text
         assert "name:            sub" in text
+    assert_no_leaks()
+
+
+def test_register_accessors():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        add = next(i for i in block.instructions if i.opcode_name == "ADDWrr")
+        vreg = add.operand(0).reg  # a def: virtual
+        assert vreg.is_valid
+        assert vreg.is_virtual
+        assert vreg.virt_reg_index >= 0
+        # Equality + hashing (by register id).
+        assert vreg == add.operand(0).reg
+        assert vreg != add.operand(1).reg
+        assert hash(vreg) == vreg.id
+        assert (vreg == "not a register") is False
+        # virt_reg_index is virtual-only.
+        phys = (
+            next(i for i in block.instructions if i.opcode_name == "RET_ReallyLR")
+            .operand(0)
+            .reg
+        )
+        assert phys.is_physical
+        with pytest.raises(ValueError):
+            phys.virt_reg_index
+    assert_no_leaks()
+
+
+def test_operand_kind_predicates_are_all_false_on_a_register():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        reg = next(i for i in block.instructions if i.opcode_name == "ADDWrr").operand(
+            0
+        )
+        assert reg.is_reg
+        # Every non-register kind predicate is False for a register operand
+        # (this exercises each predicate's binding line).
+        for pred in (
+            "is_cimm",
+            "is_fpimm",
+            "is_mbb",
+            "is_fi",
+            "is_cpi",
+            "is_jti",
+            "is_target_index",
+            "is_global",
+            "is_symbol",
+            "is_block_address",
+            "is_reg_mask",
+            "is_metadata",
+            "is_predicate",
+        ):
+            assert getattr(reg, pred) is False
+        # Register-flag reads + target_flags.
+        assert reg.is_debug is False
+        assert reg.is_internal_read is False
+        assert isinstance(reg.is_tied, bool)
+        assert reg.target_flags == 0
+    assert_no_leaks()
+
+
+def test_operand_getters_raise_on_wrong_kind():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        reg = next(i for i in block.instructions if i.opcode_name == "ADDWrr").operand(
+            0
+        )
+        for attr in (
+            "cimm",
+            "fpimm",
+            "mbb",
+            "index",
+            "global_value",
+            "symbol_name",
+            "offset",
+        ):
+            with pytest.raises(ValueError):
+                getattr(reg, attr)
+    assert_no_leaks()
+
+
+def test_branch_operands_expose_target_blocks():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_LOOP_SRC, ctx, "m")
+        mf = mir.run_codegen_to_mir(
+            mod, jit.TargetMachine(triple=_TRIPLE)
+        ).machine_function("count")
+        mbb_ops = [
+            i.operand(k)
+            for b in mf.blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_mbb
+        ]
+        assert mbb_ops  # the loop has conditional/unconditional branches
+        assert all(o.mbb.number >= 0 for o in mbb_ops)
+    assert_no_leaks()
+
+
+def test_constant_operands_read_their_values():
+    with ir.Context() as ctx:
+        mmi = mir.parse_mir(_GENERIC_MIR, ctx, jit.TargetMachine(triple=_TRIPLE))
+        cimm = next(
+            i.operand(k)
+            for b in mmi.machine_function("c").blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_cimm
+        )
+        assert cimm.cimm.zext_value == 42  # the G_CONSTANT's ConstantInt
+        fpimm = next(
+            i.operand(k)
+            for b in mmi.machine_function("fc").blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_fpimm
+        )
+        assert type(fpimm.fpimm).__name__ == "ConstantFP"
+    assert_no_leaks()
+
+
+def test_global_operand_reads_the_global_value():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_GLOBAL_SRC, ctx, "m")
+        mf = mir.run_codegen_to_mir(
+            mod, jit.TargetMachine(triple=_TRIPLE)
+        ).machine_function("f")
+        gop = next(
+            i.operand(k)
+            for b in mf.blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_global
+        )
+        assert gop.global_value.name == "g"
+        assert gop.offset == 0
+        assert isinstance(gop.target_flags, int)
+    assert_no_leaks()
+
+
+def test_frame_index_operand_has_an_index():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ALLOCA_SRC, ctx, "m")
+        mf = mir.run_codegen_to_mir(
+            mod, jit.TargetMachine(triple=_TRIPLE)
+        ).machine_function("a")
+        fop = next(
+            i.operand(k)
+            for b in mf.blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_fi
+        )
+        assert isinstance(fop.index, int)
+    assert_no_leaks()
+
+
+def test_external_symbol_operand_reads_its_name():
+    with ir.Context() as ctx:
+        mmi = mir.parse_mir(_SYMBOL_MIR, ctx, jit.TargetMachine(triple=_TRIPLE))
+        sop = next(
+            i.operand(k)
+            for b in mmi.machine_function("s").blocks
+            for i in b.instructions
+            for k in range(i.num_operands)
+            if i.operand(k).is_symbol
+        )
+        assert sop.symbol_name == "__stack_chk_guard"
+        assert sop.offset == 0
+    assert_no_leaks()
+
+
+def test_machine_instr_navigation_and_classification():
+    with ir.Context() as ctx:
+        mf = _add_machine_module(ctx).machine_function("add")
+        block = mf.blocks[0]
+        add = next(i for i in block.instructions if i.opcode_name == "ADDWrr")
+        # Navigation.
+        assert add.parent.number == block.number
+        assert add.num_defs == 1
+        assert add.num_explicit_operands == 3
+        # Classification on known instructions.
+        copy = next(i for i in block.instructions if i.opcode_name == "COPY")
+        ret = next(i for i in block.instructions if i.opcode_name == "RET_ReallyLR")
+        assert copy.is_copy
+        assert ret.is_return and ret.is_terminator
+        assert not add.is_terminator
+        # Exercise every remaining predicate line (values vary by instr).
+        for pred in (
+            "is_branch",
+            "is_conditional_branch",
+            "is_unconditional_branch",
+            "is_indirect_branch",
+            "is_barrier",
+            "is_call",
+            "is_phi",
+            "is_implicit_def",
+            "may_load",
+            "may_store",
+            "is_debug_instr",
+        ):
+            assert isinstance(getattr(add, pred), bool)
+    assert_no_leaks()
+
+
+def test_branch_instruction_classification():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_LOOP_SRC, ctx, "m")
+        mf = mir.run_codegen_to_mir(
+            mod, jit.TargetMachine(triple=_TRIPLE)
+        ).machine_function("count")
+        instrs = [i for b in mf.blocks for i in b.instructions]
+        assert any(i.is_branch for i in instrs)
+        assert any(i.is_conditional_branch for i in instrs)
+        assert any(i.is_phi for i in instrs)
+    assert_no_leaks()
+
+
+def test_memory_instruction_classification():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ALLOCA_SRC, ctx, "m")
+        mf = mir.run_codegen_to_mir(
+            mod, jit.TargetMachine(triple=_TRIPLE)
+        ).machine_function("a")
+        instrs = [i for b in mf.blocks for i in b.instructions]
+        assert any(i.may_load for i in instrs)
+        assert any(i.may_store for i in instrs)
+    assert_no_leaks()
+
+
+def test_machine_basic_block_cfg_accessors():
+    with ir.Context() as ctx:
+        mf = mir.run_codegen_to_mir(
+            ir.parse_assembly(_LOOP_SRC, ctx, "m"),
+            jit.TargetMachine(triple=_TRIPLE),
+        ).machine_function("count")
+        entry = mf.blocks[0]
+        assert entry.is_entry_block
+        assert entry.parent.name == "count"
+        # Some block has a successor, and some block has a predecessor.
+        assert any(b.successors for b in mf.blocks)
+        assert any(b.predecessors for b in mf.blocks)
+        # Successor/predecessor edges are consistent.
+        for b in mf.blocks:
+            for s in b.successors:
+                assert b in s.predecessors
+    assert_no_leaks()
+
+
+def test_machine_function_accessors():
+    with ir.Context() as ctx:
+        mf = _add_machine_module(ctx).machine_function("add")
+        assert mf.num_blocks == 1
+        assert mf.function.name == "add"  # the IR Function it was lowered from
+    assert_no_leaks()
+
+
+def test_machine_module_info_lists_machine_functions():
+    with ir.Context() as ctx:
+        mmi = mir.run_codegen_to_mir(
+            ir.parse_assembly(_TWO_FN_SRC, ctx, "m"),
+            jit.TargetMachine(triple=_TRIPLE),
+        )
+        names = sorted(mf.name for mf in mmi.machine_functions)
+        assert names == ["add", "sub"]
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_inspect.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_inspect.py
@@ -1,0 +1,167 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Inspecting MIR produced by the codegen pipeline.
+
+`run_codegen_to_mir` runs instruction selection on an IR module and hands back
+the MachineModuleInfo that owns the resulting MachineFunctions, so they can be
+inspected. The reference shapes asserted here were produced with
+`llc -mtriple=aarch64-unknown-linux-gnu -stop-after=finalize-isel`.
+"""
+
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# These assert AArch64 opcodes (ADDWrr, RET_ReallyLR, ...), so they need the
+# AArch64 backend, which eudsl-llvmpy only links when EUDSL_LLVMPY_TARGETS
+# includes it (the default is the native target). Skip otherwise.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_ADD_SRC = dedent("""\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """)
+
+_CONST_SRC = dedent("""\
+    define i32 @c() {
+      ret i32 42
+    }
+    """)
+
+_DECL_SRC = dedent("""\
+    declare i32 @ext()
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """)
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+
+def test_run_codegen_to_mir_yields_named_machine_function():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm)
+        assert mmi.machine_function("add").name == "add"
+    assert_no_leaks()
+
+
+def _add_machine_module(ctx):
+    """Lower @add to MIR; returns the MachineModuleInfo that owns it."""
+    mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+    tm = jit.TargetMachine(triple=_TRIPLE)
+    return mir.run_codegen_to_mir(mod, tm)
+
+
+def test_machine_function_prints_mir_text():
+    with ir.Context() as ctx:
+        text = str(_add_machine_module(ctx).machine_function("add"))
+        assert "ADDWrr" in text
+        assert "RET_ReallyLR" in text
+    assert_no_leaks()
+
+
+def test_machine_function_has_single_entry_block():
+    with ir.Context() as ctx:
+        assert len(_add_machine_module(ctx).machine_function("add").blocks) == 1
+    assert_no_leaks()
+
+
+def test_instruction_opcode_names():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        assert [i.opcode_name for i in block.instructions] == [
+            "COPY",
+            "COPY",
+            "ADDWrr",
+            "COPY",
+            "RET_ReallyLR",
+        ]
+    assert_no_leaks()
+
+
+def test_addwrr_operands_are_one_def_two_uses():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        add = next(i for i in block.instructions if i.opcode_name == "ADDWrr")
+        assert add.num_operands == 3
+        assert add.operand(0).is_reg and add.operand(0).is_def
+        assert add.operand(1).is_use
+        assert add.operand(2).is_use
+        assert add.operand(0).reg.is_virtual
+    assert_no_leaks()
+
+
+def test_object_model_accessors():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        assert block.number == 0
+        assert isinstance(block.name, str)
+        assert "ADDWrr" in str(block)
+
+        add = next(i for i in block.instructions if i.opcode_name == "ADDWrr")
+        assert isinstance(add.opcode, int) and add.opcode > 0
+        assert "ADDWrr" in str(add)
+
+        # The last COPY is `$w0 = COPY %2`: its def is a physical register.
+        last_copy = [i for i in block.instructions if i.opcode_name == "COPY"][-1]
+        phys = last_copy.operand(0)
+        assert phys.reg.is_physical
+        assert phys.reg.id > 0
+        assert "w0" in str(phys)
+    assert_no_leaks()
+
+
+def test_machine_function_missing_name_raises():
+    with ir.Context() as ctx:
+        mmi = _add_machine_module(ctx)
+        with pytest.raises(KeyError):
+            mmi.machine_function("nope")
+    assert_no_leaks()
+
+
+def test_declared_function_has_no_machine_function():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_DECL_SRC, ctx, "m")
+        mmi = mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE))
+        with pytest.raises(KeyError):
+            mmi.machine_function("ext")  # a declaration has no MachineFunction
+    assert_no_leaks()
+
+
+def test_operand_index_out_of_range_raises():
+    with ir.Context() as ctx:
+        block = _add_machine_module(ctx).machine_function("add").blocks[0]
+        add = next(i for i in block.instructions if i.opcode_name == "ADDWrr")
+        with pytest.raises(IndexError):
+            add.operand(99)
+    assert_no_leaks()
+
+
+def test_immediate_operand_and_kind_guards():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_CONST_SRC, ctx, "m")
+        mmi = mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE))
+        block = mmi.machine_function("c").blocks[0]
+        mov = next(i for i in block.instructions if i.opcode_name == "MOVi32imm")
+        assert mov.operand(1).is_imm
+        assert mov.operand(1).imm == 42
+        with pytest.raises(ValueError):
+            mov.operand(1).reg  # an immediate operand has no register
+        with pytest.raises(ValueError):
+            mov.operand(0).imm  # a register operand has no immediate
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_roundtrip.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_roundtrip.py
@@ -1,0 +1,101 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Round-tripping MIR through its textual serialization format.
+
+`to_mir()` prints a MachineModuleInfo as `.mir` text; `parse_mir` reads it back.
+The reference MIR is produced by lowering @add with run_codegen_to_mir rather
+than hand-written, so the test stays honest about the real serialization.
+"""
+
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# AArch64-specific (asserts ADDWrr/RET_ReallyLR); needs the AArch64 backend.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_ADD_SRC = dedent("""\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """)
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+_EXPECTED_OPCODES = ["COPY", "COPY", "ADDWrr", "COPY", "RET_ReallyLR"]
+
+
+def _add_mir_text(ctx):
+    mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+    return mir.run_codegen_to_mir(mod, jit.TargetMachine(triple=_TRIPLE)).to_mir()
+
+
+def test_to_mir_emits_machine_function_text():
+    with ir.Context() as ctx:
+        text = _add_mir_text(ctx)
+        assert "name:" in text and "add" in text
+        assert "ADDWrr" in text
+        assert "RET_ReallyLR" in text
+    assert_no_leaks()
+
+
+def test_parse_mir_recovers_the_machine_function():
+    with ir.Context() as ctx:
+        text = _add_mir_text(ctx)
+    with ir.Context() as ctx:
+        mmi = mir.parse_mir(text, ctx, jit.TargetMachine(triple=_TRIPLE))
+        block = mmi.machine_function("add").blocks[0]
+        assert [i.opcode_name for i in block.instructions] == _EXPECTED_OPCODES
+    assert_no_leaks()
+
+
+def test_mir_print_parse_is_idempotent():
+    with ir.Context() as ctx:
+        text1 = _add_mir_text(ctx)
+    with ir.Context() as ctx:
+        text2 = mir.parse_mir(text1, ctx, jit.TargetMachine(triple=_TRIPLE)).to_mir()
+    with ir.Context() as ctx:
+        text3 = mir.parse_mir(text2, ctx, jit.TargetMachine(triple=_TRIPLE)).to_mir()
+    assert text2 == text3
+    assert_no_leaks()
+
+
+def test_parse_mir_rejects_invalid_text():
+    with ir.Context() as ctx:
+        with pytest.raises(RuntimeError):
+            mir.parse_mir(
+                "@@@ not valid mir @@@", ctx, jit.TargetMachine(triple=_TRIPLE)
+            )
+    assert_no_leaks()
+
+
+_BAD_MF = dedent("""\
+    --- |
+      define void @f() {
+        ret void
+      }
+    ...
+    ---
+    name: f
+    body: |
+      bb.0:
+        NOT_A_REAL_OPCODE
+    ...
+    """)
+
+
+def test_parse_mir_rejects_bad_machine_function_body():
+    with ir.Context() as ctx:
+        with pytest.raises(RuntimeError):
+            mir.parse_mir(_BAD_MF, ctx, jit.TargetMachine(triple=_TRIPLE))
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_roundtrip.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_roundtrip.py
@@ -72,10 +72,13 @@ def test_mir_print_parse_is_idempotent():
 
 def test_parse_mir_rejects_invalid_text():
     with ir.Context() as ctx:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as ei:
             mir.parse_mir(
                 "@@@ not valid mir @@@", ctx, jit.TargetMachine(triple=_TRIPLE)
             )
+        # The real parser diagnostic is threaded into the message, not swallowed.
+        assert "failed to parse" in str(ei.value)
+        assert ":" in str(ei.value)
     assert_no_leaks()
 
 
@@ -96,6 +99,8 @@ _BAD_MF = dedent("""\
 
 def test_parse_mir_rejects_bad_machine_function_body():
     with ir.Context() as ctx:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as ei:
             mir.parse_mir(_BAD_MF, ctx, jit.TargetMachine(triple=_TRIPLE))
+        assert "failed to parse machine functions" in str(ei.value)
+        assert ":" in str(ei.value)
     assert_no_leaks()


### PR DESCRIPTION
run_codegen_to_mir lowers an IR module through instruction selection and hands
back a MachineModuleInfo that owns the resulting MachineFunctions (only the ISel
passes are added, so they are retained -- the state llc -stop-after=finalize-isel
produces). Bind the MIR object model on top: MachineFunction, MachineBasicBlock,
MachineInstr, MachineOperand, Register. Add .mir text round-trip via to_mir()
(MIRPrinter) and parse_mir (MIRParser).

Second PR in the MIR bindings/DSL stack; builds on the LLT foundation.