### PR TITLE
[eudsl-llvmpy] Build generic (GlobalISel) MIR with MachineIRBuilder

### DIFF
--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -23,6 +23,20 @@ for calling convention, visibility, address space, and similar. If a binding
 would silently bake in one choice from a set the LLVM API offers, surface that
 choice as an argument.
 
+## Prefer specific nanobind types over `nb::object`/`nb::handle`
+
+In binding signatures, stored state, and return types, use the most specific
+type nanobind can bind rather than a generic `nb::object`/`nb::handle`. If a
+parameter is really an `llvm::MachineIRBuilder`, bind it as
+`llvm::MachineIRBuilder *`, not `nb::object` — nanobind casts the argument, and
+pointer equality gives a precise identity check. When you need to hand the same
+Python object back (e.g. a context manager's `__enter__`, or a `current_*()`
+accessor), return the pointer with `nb::rv_policy::reference`: nanobind's
+instance registry maps it back to the same Python object, so `is` identity
+holds. Reach for `nb::object`/`nb::handle` only when the value is genuinely an
+arbitrary Python object with no more specific type — e.g. the ignored
+`exc_type`/`exc_value`/`traceback` parameters of `__exit__`.
+
 ## No forward-reference comments
 
 Do not write comments that reference future work, later PRs, or task numbers

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -5,18 +5,23 @@
 #include "IR/Common.h"
 #include "IR/Ownership.h"
 
+#include <llvm/CodeGen/GlobalISel/MachineIRBuilder.h>
 #include <llvm/CodeGen/MIRParser/MIRParser.h>
 #include <llvm/CodeGen/MIRPrinter.h>
 #include <llvm/CodeGen/MachineBasicBlock.h>
 #include <llvm/CodeGen/MachineFunction.h>
 #include <llvm/CodeGen/MachineInstr.h>
+#include <llvm/CodeGen/MachineInstrBuilder.h>
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/CodeGen/MachineOperand.h>
+#include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
+#include <llvm/CodeGenTypes/LowLevelType.h>
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/Function.h>
@@ -486,6 +491,12 @@ void populate_mir(nb::module_ &m) {
             return &self.getFunction();
           },
           nb::rv_policy::reference_internal)
+      .def(
+          "create_generic_vreg",
+          [](llvm::MachineFunction &self, llvm::LLT ty) -> llvm::Register {
+            return self.getRegInfo().createGenericVirtualRegister(ty);
+          },
+          "type"_a, "Create a new generic virtual register of the given LLT.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -617,4 +628,81 @@ void populate_mir(nb::module_ &m) {
                                      /*pm=*/nullptr, std::move(ownedMmi), mmi};
       },
       "text"_a, "context"_a, "target_machine"_a, nb::keep_alive<0, 3>());
+
+  // Create a fresh, empty MachineFunction to build into: make a void() IR
+  // Function stub named `name` (a MachineFunction must attach to one), get its
+  // MachineFunction from a freshly owned MachineModuleInfo, and give it a
+  // single empty entry block. Consumes the module into the returned wrapper
+  // (like run_codegen_to_mir), which owns everything the MachineFunction
+  // depends on.
+  m.def(
+      "create_machine_function",
+      [](eudsl::Module &mod, llvm::TargetMachine &tm, const std::string &name) {
+        std::shared_ptr<llvm::LLVMContext> ctxKeepAlive =
+            mod.context().shared();
+        std::unique_ptr<llvm::Module> module = mod.take();
+        module->setDataLayout(tm.createDataLayout());
+
+        llvm::FunctionType *fnTy =
+            llvm::FunctionType::get(llvm::Type::getVoidTy(module->getContext()),
+                                    /*isVarArg=*/false);
+        llvm::Function *f = llvm::Function::Create(
+            fnTy, llvm::GlobalValue::ExternalLinkage, name, *module);
+
+        auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
+        llvm::MachineFunction &mf = ownedMmi->getOrCreateMachineFunction(*f);
+        mf.push_back(mf.CreateMachineBasicBlock());
+
+        llvm::MachineModuleInfo *mmi = ownedMmi.get();
+        return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
+                                     /*pm=*/nullptr, std::move(ownedMmi), mmi};
+      },
+      "module"_a, "target_machine"_a, "name"_a, nb::keep_alive<0, 2>());
+
+  // llvm::MachineIRBuilder -- the GlobalISel builder for generic (G_*) MIR. The
+  // typed helpers take the result type as an LLT (a fresh generic vreg is
+  // created for it) and the operands as Registers, returning the def Register
+  // so builds chain. Construction positions the builder at the end of the
+  // function's entry block.
+  nb::class_<llvm::MachineIRBuilder>(m, "MachineIRBuilder")
+      .def(
+          "__init__",
+          [](llvm::MachineIRBuilder *self, llvm::MachineFunction &mf) {
+            new (self) llvm::MachineIRBuilder(mf);
+            self->setMBB(mf.front());
+          },
+          "machine_function"_a, nb::keep_alive<1, 2>())
+      .def(
+          "build_constant",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty,
+             int64_t value) -> llvm::Register {
+            return self.buildConstant(ty, value).getReg(0);
+          },
+          "type"_a, "value"_a)
+      .def(
+          "build_add",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
+             llvm::Register rhs) -> llvm::Register {
+            return self.buildAdd(ty, lhs, rhs).getReg(0);
+          },
+          "type"_a, "lhs"_a, "rhs"_a)
+      .def(
+          "build_sub",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
+             llvm::Register rhs) -> llvm::Register {
+            return self.buildSub(ty, lhs, rhs).getReg(0);
+          },
+          "type"_a, "lhs"_a, "rhs"_a)
+      .def(
+          "build_mul",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
+             llvm::Register rhs) -> llvm::Register {
+            return self.buildMul(ty, lhs, rhs).getReg(0);
+          },
+          "type"_a, "lhs"_a, "rhs"_a)
+      .def(
+          "build_copy",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register src)
+              -> llvm::Register { return self.buildCopy(ty, src).getReg(0); },
+          "type"_a, "src"_a);
 }

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -19,7 +19,6 @@
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
-#include <llvm/CodeGenTypes/LowLevelType.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/DiagnosticInfo.h>
@@ -76,6 +75,37 @@ std::string withDetail(llvm::StringRef base, const std::string &detail) {
   if (detail.empty())
     return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
   return (base + ": " + detail).str();
+}
+
+// GlobalISel's build helpers validate their operands only with asserts, which
+// are compiled out under NDEBUG (the shipped wheel), so bad input would emit
+// malformed MIR or fault in a later pass instead of raising. Enforce the same
+// preconditions here regardless of build mode: `reg` must be a generic virtual
+// register of `b`'s MachineFunction carrying type `ty`. MachineRegisterInfo::
+// getType returns an invalid LLT{} for a non-virtual, out-of-bounds, or
+// wrong-function register, so a single type compare rejects both a type
+// mismatch and a register minted by a different MachineFunction.
+void requireVRegOfType(llvm::MachineIRBuilder &b, llvm::Register reg,
+                       llvm::LLT ty, const char *role) {
+  if (b.getMF().getRegInfo().getType(reg) != ty)
+    throw nb::value_error((std::string(role) +
+                           " must be a virtual register of this "
+                           "MachineFunction with the result type")
+                              .c_str());
+}
+
+// The "current MachineIRBuilder" is tracked on a thread-local stack, mirroring
+// the IR builder's `with builder:` / current_builder() mechanism (see the
+// thread_local ThreadContextEntry stack in IR/Builder.cpp). `with builder:`
+// pushes the builder; current_machine_builder() returns the innermost. The
+// entries are MachineIRBuilder pointers; nanobind's instance registry maps a
+// returned pointer back to the same Python object, so current_machine_builder
+// hands back the object that was entered (identity-stable, which the DSL relies
+// on to anchor a MachineValue to its builder). A `with builder:` keeps that
+// Python object alive for the block, so the raw pointer never dangles.
+static std::vector<llvm::MachineIRBuilder *> &machineBuilderStack() {
+  static thread_local std::vector<llvm::MachineIRBuilder *> stack;
+  return stack;
 }
 
 // Owns everything the inspected MachineFunctions transitively depend on, so
@@ -492,7 +522,7 @@ void populate_mir(nb::module_ &m) {
           },
           nb::rv_policy::reference_internal)
       .def(
-          "create_generic_vreg",
+          "create_generic_virtual_register",
           [](llvm::MachineFunction &self, llvm::LLT ty) -> llvm::Register {
             return self.getRegInfo().createGenericVirtualRegister(ty);
           },
@@ -629,25 +659,39 @@ void populate_mir(nb::module_ &m) {
       },
       "text"_a, "context"_a, "target_machine"_a, nb::keep_alive<0, 3>());
 
-  // Create a fresh, empty MachineFunction to build into: make a void() IR
-  // Function stub named `name` (a MachineFunction must attach to one), get its
+  // Create a fresh, empty MachineFunction to build into: make an IR Function
+  // stub named `name` (a MachineFunction must attach to one), get its
   // MachineFunction from a freshly owned MachineModuleInfo, and give it a
-  // single empty entry block. Consumes the module into the returned wrapper
-  // (like run_codegen_to_mir), which owns everything the MachineFunction
-  // depends on.
+  // single empty entry block. The stub's signature and linkage are surfaced as
+  // arguments rather than hardcoded; `function_type` defaults to `void()` (a
+  // MachineFunction anchored purely for building generic MIR never reads the IR
+  // signature). Consumes the module into the returned wrapper (like
+  // run_codegen_to_mir), which owns everything the MachineFunction depends on.
   m.def(
       "create_machine_function",
-      [](eudsl::Module &mod, llvm::TargetMachine &tm, const std::string &name) {
+      [](eudsl::Module &mod, llvm::TargetMachine &tm, const std::string &name,
+         llvm::FunctionType *fnTy, llvm::GlobalValue::LinkageTypes linkage) {
+        // Validate before take() so a rejected call leaves the module usable.
+        // Function::Create does not fail on a name collision -- it appends a
+        // numeric suffix (`f` -> `f.1`), which would then make
+        // machine_function(name) throw a confusing "no function named" error.
+        if (name.empty())
+          throw nb::value_error("function name must not be empty");
+        if (mod.get().getFunction(name)) {
+          throw nb::value_error(
+              ("module already has a function named '" + name + "'").c_str());
+        }
+
         std::shared_ptr<llvm::LLVMContext> ctxKeepAlive =
             mod.context().shared();
         std::unique_ptr<llvm::Module> module = mod.take();
         module->setDataLayout(tm.createDataLayout());
 
-        llvm::FunctionType *fnTy =
-            llvm::FunctionType::get(llvm::Type::getVoidTy(module->getContext()),
-                                    /*isVarArg=*/false);
-        llvm::Function *f = llvm::Function::Create(
-            fnTy, llvm::GlobalValue::ExternalLinkage, name, *module);
+        if (!fnTy)
+          fnTy = llvm::FunctionType::get(
+              llvm::Type::getVoidTy(module->getContext()), /*isVarArg=*/false);
+        llvm::Function *f =
+            llvm::Function::Create(fnTy, linkage, name, *module);
 
         auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
         llvm::MachineFunction &mf = ownedMmi->getOrCreateMachineFunction(*f);
@@ -657,25 +701,60 @@ void populate_mir(nb::module_ &m) {
         return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
                                      /*pm=*/nullptr, std::move(ownedMmi), mmi};
       },
-      "module"_a, "target_machine"_a, "name"_a, nb::keep_alive<0, 2>());
+      "module"_a, "target_machine"_a, "name"_a, "function_type"_a = nullptr,
+      "linkage"_a = llvm::GlobalValue::LinkageTypes::ExternalLinkage,
+      nb::keep_alive<0, 2>());
 
   // llvm::MachineIRBuilder -- the GlobalISel builder for generic (G_*) MIR. The
   // typed helpers take the result type as an LLT (a fresh generic vreg is
   // created for it) and the operands as Registers, returning the def Register
   // so builds chain. Construction positions the builder at the end of the
-  // function's entry block.
+  // function's entry block. Entering the builder as a context manager
+  // (`with MachineIRBuilder(mf):`) makes it the current builder for the
+  // duration of the block; current_machine_builder() reads it back.
   nb::class_<llvm::MachineIRBuilder>(m, "MachineIRBuilder")
       .def(
           "__init__",
           [](llvm::MachineIRBuilder *self, llvm::MachineFunction &mf) {
+            // setMBB(mf.front()) on a block-less MachineFunction dereferences
+            // the ilist sentinel (UB, no assert). create_machine_function seeds
+            // a block, but this ctor is public and accepts any MachineFunction.
+            if (mf.empty()) {
+              throw nb::value_error(
+                  "MachineFunction has no basic block to build into");
+            }
             new (self) llvm::MachineIRBuilder(mf);
             self->setMBB(mf.front());
           },
           "machine_function"_a, nb::keep_alive<1, 2>())
       .def(
+          "__enter__",
+          [](llvm::MachineIRBuilder *self) -> llvm::MachineIRBuilder * {
+            // Make this builder the current one for current_machine_builder().
+            machineBuilderStack().push_back(self);
+            return self;
+          },
+          nb::rv_policy::reference)
+      .def(
+          "__exit__",
+          [](llvm::MachineIRBuilder *self, nb::handle, nb::handle, nb::handle) {
+            auto &stack = machineBuilderStack();
+            if (stack.empty() || stack.back() != self)
+              throw nb::value_error("unbalanced MachineIRBuilder enter/exit");
+            stack.pop_back();
+          },
+          "exc_type"_a.none(), "exc_value"_a.none(), "traceback"_a.none())
+      .def(
           "build_constant",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
              int64_t value) -> llvm::Register {
+            // buildConstant derives the width from ty's scalar size; a pointer,
+            // scalable-vector, or invalid LLT hits asserting accessors that
+            // vanish under NDEBUG and would emit a wrong-width G_CONSTANT.
+            if (!(ty.isScalar() || ty.isFixedVector())) {
+              throw nb::value_error("build_constant requires a scalar or "
+                                    "fixed-vector type");
+            }
             return self.buildConstant(ty, value).getReg(0);
           },
           "type"_a, "value"_a)
@@ -683,6 +762,8 @@ void populate_mir(nb::module_ &m) {
           "build_add",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
              llvm::Register rhs) -> llvm::Register {
+            requireVRegOfType(self, lhs, ty, "lhs");
+            requireVRegOfType(self, rhs, ty, "rhs");
             return self.buildAdd(ty, lhs, rhs).getReg(0);
           },
           "type"_a, "lhs"_a, "rhs"_a)
@@ -690,6 +771,8 @@ void populate_mir(nb::module_ &m) {
           "build_sub",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
              llvm::Register rhs) -> llvm::Register {
+            requireVRegOfType(self, lhs, ty, "lhs");
+            requireVRegOfType(self, rhs, ty, "rhs");
             return self.buildSub(ty, lhs, rhs).getReg(0);
           },
           "type"_a, "lhs"_a, "rhs"_a)
@@ -697,12 +780,33 @@ void populate_mir(nb::module_ &m) {
           "build_mul",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
              llvm::Register rhs) -> llvm::Register {
+            requireVRegOfType(self, lhs, ty, "lhs");
+            requireVRegOfType(self, rhs, ty, "rhs");
             return self.buildMul(ty, lhs, rhs).getReg(0);
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_copy",
-          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register src)
-              -> llvm::Register { return self.buildCopy(ty, src).getReg(0); },
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty,
+             llvm::Register src) -> llvm::Register {
+            requireVRegOfType(self, src, ty, "src");
+            return self.buildCopy(ty, src).getReg(0);
+          },
           "type"_a, "src"_a);
+
+  // The innermost MachineIRBuilder entered as a context manager, mirroring the
+  // IR module's current_builder(). Raises when there is none.
+  m.def(
+      "current_machine_builder",
+      []() -> llvm::MachineIRBuilder * {
+        auto &stack = machineBuilderStack();
+        if (stack.empty())
+          throw std::runtime_error(
+              "no current MachineIRBuilder; enter one with "
+              "`with MachineIRBuilder(mf):` (e.g. inside a @machine_function "
+              "body)");
+        return stack.back();
+      },
+      nb::rv_policy::reference,
+      "The innermost MachineIRBuilder on the thread-local stack.");
 }

--- a/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
@@ -5,14 +5,18 @@
 
 create_machine_function makes a fresh, empty MachineFunction to build into;
 MachineIRBuilder emits target-independent G_* instructions. The built MIR is
-inspected with the Phase 1 object model / printer.
+inspected with the MIR object model / printer.
 """
 
-from llvm import ir, jit, mir
+import gc
+
+import pytest
+
+from llvm import ir, jit, mir, types
 from llvm.testing import assert_no_leaks
 
 # Generic (G_*) MIR is target-independent, so build against the host target
-# (triple=None) -- these run on any runner, no specific backend required.
+# (triple=None) -- these run on any runner, no non-host backend required.
 _TRIPLE = None
 
 
@@ -25,6 +29,67 @@ def test_create_machine_function_is_empty_and_named():
         assert mf.name == "f"
         assert len(mf.blocks) == 1  # a single empty entry block
         assert mf.blocks[0].instructions == []
+    assert_no_leaks()
+
+
+def test_create_machine_function_defaults_to_void_external():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        f = mmi.machine_function("f").function
+        # Default stub: void() with external linkage.
+        assert f.function_type.return_type.is_void
+        assert f.function_type.num_params == 0
+        assert f.linkage == ir.Linkage.EXTERNAL
+    assert_no_leaks()
+
+
+def test_create_machine_function_honors_function_type_and_linkage():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        i32 = types.i32(ctx)
+        fnTy = types.FunctionType.get(i32, [i32, i32], context=ctx)
+        mmi = mir.create_machine_function(
+            mod, tm, "f", function_type=fnTy, linkage=ir.Linkage.INTERNAL
+        )
+        f = mmi.machine_function("f").function
+        assert f.function_type.return_type == i32
+        assert f.function_type.num_params == 2
+        assert f.linkage == ir.Linkage.INTERNAL
+    assert_no_leaks()
+
+
+def test_create_machine_function_consumes_module():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mir.create_machine_function(mod, tm, "f")
+        assert mod._is_consumed
+        with pytest.raises(RuntimeError, match="has been consumed"):
+            mod.functions  # the module moved into the wrapper; it can't be used
+    assert_no_leaks()
+
+
+def test_create_machine_function_rejects_empty_name():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        with pytest.raises(ValueError, match="must not be empty"):
+            mir.create_machine_function(mod, tm, "")
+        # A rejected call must leave the module usable (not consumed).
+        assert not mod._is_consumed
+    assert_no_leaks()
+
+
+def test_create_machine_function_rejects_duplicate_name():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly("define void @f() {\n  ret void\n}\n", ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        with pytest.raises(ValueError, match="already has a function named"):
+            mir.create_machine_function(mod, tm, "f")
+        assert not mod._is_consumed
     assert_no_leaks()
 
 
@@ -41,7 +106,8 @@ def test_build_generic_arithmetic():
         s = b.build_add(s32, a, c)
         d = b.build_sub(s32, s, a)
         p = b.build_mul(s32, d, c)
-        b.build_copy(s32, p)
+        cp = b.build_copy(s32, p)
+        assert s.is_virtual and d.is_virtual and p.is_virtual and cp.is_virtual
 
         opcodes = [
             i.opcode_name for i in mmi.machine_function("f").blocks[0].instructions
@@ -57,11 +123,143 @@ def test_build_generic_arithmetic():
     assert_no_leaks()
 
 
-def test_create_generic_vreg_has_requested_type():
+def test_build_constant_rejects_non_scalar_type():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        b = mir.MachineIRBuilder(
+            mir.create_machine_function(mod, tm, "f").machine_function("f")
+        )
+        with pytest.raises(ValueError, match="scalar or fixed-vector"):
+            b.build_constant(mir.LLT.pointer(0, 64), 0)
+    assert_no_leaks()
+
+
+def test_build_add_rejects_type_mismatch():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        b = mir.MachineIRBuilder(
+            mir.create_machine_function(mod, tm, "f").machine_function("f")
+        )
+        s32, s64 = mir.LLT.scalar(32), mir.LLT.scalar(64)
+        a = b.build_constant(s32, 1)
+        # Result type s64 disagrees with the s32 operands.
+        with pytest.raises(ValueError, match="result type"):
+            b.build_add(s64, a, a)
+    assert_no_leaks()
+
+
+def test_build_add_rejects_register_from_another_function():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        mmi_g = mir.create_machine_function(ir.Module("g", ctx), tm, "g")
+        foreign = mir.MachineIRBuilder(mmi_g.machine_function("g")).build_constant(
+            s32, 7
+        )
+
+        mmi_f = mir.create_machine_function(ir.Module("f", ctx), tm, "f")
+        bf = mir.MachineIRBuilder(mmi_f.machine_function("f"))
+        with pytest.raises(ValueError, match="virtual register of this"):
+            bf.build_add(s32, foreign, foreign)
+    assert_no_leaks()
+
+
+def test_builder_outlives_machine_function_handle():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_TRIPLE)
         mmi = mir.create_machine_function(mod, tm, "f")
-        reg = mmi.machine_function("f").create_generic_vreg(mir.LLT.scalar(64))
+        b = mir.MachineIRBuilder(mmi.machine_function("f"))
+        del mmi
+        gc.collect()
+        # keep_alive<1,2> pins the MachineFunction (and transitively its owning
+        # MachineModuleInfo) to the builder, so building still works.
+        assert b.build_constant(mir.LLT.scalar(32), 5).is_virtual
+    assert_no_leaks()
+
+
+def test_create_generic_virtual_register_is_virtual():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        s64 = mir.LLT.scalar(64)
+        reg = mf.create_generic_virtual_register(s64)
         assert reg.is_virtual
+        # The vreg carries the requested LLT: it is accepted as an s64 operand
+        # (the builder validates operand type against the result type).
+        b = mir.MachineIRBuilder(mf)
+        assert b.build_add(s64, reg, reg).is_virtual
+    assert_no_leaks()
+
+
+def test_machine_ir_builder_context_manager_tracks_current():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        outer = mir.MachineIRBuilder(
+            mir.create_machine_function(mod, tm, "f").machine_function("f")
+        )
+        inner = mir.MachineIRBuilder(
+            mir.create_machine_function(ir.Module("g", ctx), tm, "g").machine_function(
+                "g"
+            )
+        )
+        with outer as entered:
+            # __enter__ returns the builder itself, and it becomes current.
+            assert entered is outer
+            assert mir.current_machine_builder() is outer
+            with inner:
+                # Nested: the innermost builder is current.
+                assert mir.current_machine_builder() is inner
+            # Popping restores the outer builder.
+            assert mir.current_machine_builder() is outer
+        # Fully unwound: no current builder.
+        with pytest.raises(RuntimeError, match="no current MachineIRBuilder"):
+            mir.current_machine_builder()
+    assert_no_leaks()
+
+
+def test_current_machine_builder_without_context_raises():
+    with pytest.raises(RuntimeError, match="no current MachineIRBuilder"):
+        mir.current_machine_builder()
+    assert_no_leaks()
+
+
+def test_machine_ir_builder_unbalanced_exit_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        b = mir.MachineIRBuilder(
+            mir.create_machine_function(mod, tm, "f").machine_function("f")
+        )
+        # __exit__ without a matching __enter__ (empty stack) is unbalanced.
+        with pytest.raises(ValueError, match="unbalanced"):
+            b.__exit__(None, None, None)
+    assert_no_leaks()
+
+
+# A function with no `body:` parses to a MachineFunction with zero blocks.
+_BODYLESS_MIR = """\
+--- |
+  define void @f() {
+    ret void
+  }
+...
+---
+name:            f
+...
+"""
+
+
+def test_machine_ir_builder_rejects_block_less_machine_function():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mf = mir.parse_mir(_BODYLESS_MIR, ctx, tm).machine_function("f")
+        assert len(mf.blocks) == 0
+        with pytest.raises(ValueError, match="no basic block"):
+            mir.MachineIRBuilder(mf)
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
@@ -1,0 +1,67 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Building generic (GlobalISel) MIR with MachineIRBuilder.
+
+create_machine_function makes a fresh, empty MachineFunction to build into;
+MachineIRBuilder emits target-independent G_* instructions. The built MIR is
+inspected with the Phase 1 object model / printer.
+"""
+
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# Generic (G_*) MIR is target-independent, so build against the host target
+# (triple=None) -- these run on any runner, no specific backend required.
+_TRIPLE = None
+
+
+def test_create_machine_function_is_empty_and_named():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        assert mf.name == "f"
+        assert len(mf.blocks) == 1  # a single empty entry block
+        assert mf.blocks[0].instructions == []
+    assert_no_leaks()
+
+
+def test_build_generic_arithmetic():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        b = mir.MachineIRBuilder(mmi.machine_function("f"))
+        s32 = mir.LLT.scalar(32)
+        a = b.build_constant(s32, 3)
+        c = b.build_constant(s32, 4)
+        assert a.is_virtual and c.is_virtual
+        s = b.build_add(s32, a, c)
+        d = b.build_sub(s32, s, a)
+        p = b.build_mul(s32, d, c)
+        b.build_copy(s32, p)
+
+        opcodes = [
+            i.opcode_name for i in mmi.machine_function("f").blocks[0].instructions
+        ]
+        assert opcodes == [
+            "G_CONSTANT",
+            "G_CONSTANT",
+            "G_ADD",
+            "G_SUB",
+            "G_MUL",
+            "COPY",
+        ]
+    assert_no_leaks()
+
+
+def test_create_generic_vreg_has_requested_type():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        reg = mmi.machine_function("f").create_generic_vreg(mir.LLT.scalar(64))
+        assert reg.is_virtual
+    assert_no_leaks()


### PR DESCRIPTION
Add create_machine_function to make a fresh, empty MachineFunction to build
into (a void() IR stub + owned MachineModuleInfo + entry block), and bind
MachineIRBuilder with typed generic builders (build_constant/add/sub/mul/copy)
that take the result type as an LLT and return the def Register so builds chain.
MachineFunction.create_generic_vreg exposes raw vreg creation.

Third PR in the MIR bindings/DSL stack; builds on the inspection PR.