### PR TITLE
[eudsl-llvmpy] Add @machine_function DSL + MachineValue for generic MIR

### DIFF
--- a/projects/eudsl-llvmpy/src/llvm/dsl/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/__init__.py
@@ -3,3 +3,4 @@
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 from .func import function  # noqa: F401
 from .cf import yield_, range_  # noqa: F401
+from .machine import machine_function  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
@@ -4,27 +4,21 @@
 """The @machine_function decorator and MachineValue: a Pythonic front end for
 building generic (GlobalISel) MIR, mirroring the IR DSL's @function/ArithValue.
 
-Unlike the IR builder, MachineIRBuilder is not wired into the C++ InsertPoint
-stack, so the "current builder" is tracked here with a plain stack pushed for
-the duration of tracing a @machine_function body. A MachineValue wraps a
-Register plus its LLT and overloads `+ - *` onto build_add/build_sub/build_mul;
-Python ints coerce to a G_CONSTANT of the other operand's type.
+The "current builder" is tracked in C++ on a thread-local stack (the same
+mechanism the IR builder uses): `with MachineIRBuilder(mf):` makes it current
+and current_machine_builder() reads it back. A MachineValue wraps a Register
+plus its LLT and overloads `+ - *` onto build_add/build_sub/build_mul; Python
+ints coerce to a G_CONSTANT of the other operand's type.
 """
 
 import inspect
 
-from ..eudslllvm_ext.mir import LLT, MachineIRBuilder, create_machine_function
-
-_builder_stack = []
-
-
-def current_machine_builder():
-    """The MachineIRBuilder for the @machine_function body being traced."""
-    if not _builder_stack:
-        raise RuntimeError(
-            "no current MachineIRBuilder; use this only inside a @machine_function body"
-        )
-    return _builder_stack[-1]
+from ..eudslllvm_ext.mir import (
+    LLT,
+    MachineIRBuilder,
+    create_machine_function,
+    current_machine_builder,
+)
 
 
 class MachineValue:
@@ -33,16 +27,41 @@ class MachineValue:
     def __init__(self, reg, llt):
         self.reg = reg
         self.llt = llt
+        # Anchor to the builder tracing this value's MachineFunction. A
+        # MachineValue carries a bare reg + llt, so a value that escapes its
+        # @machine_function body could otherwise emit into a different (e.g.
+        # nested) function's builder, referencing vregs it doesn't own. A
+        # MachineValue is only ever constructed while a builder is current.
+        self._builder = current_machine_builder()
+
+    def _require_current(self):
+        if self._builder is not current_machine_builder():
+            raise RuntimeError(
+                "MachineValue used outside the @machine_function body that "
+                "created it (it belongs to a different MachineFunction)"
+            )
 
     def _coerce(self, other):
-        """A MachineValue passes through; a Python int becomes a G_CONSTANT."""
+        """A MachineValue passes through; a Python int becomes a G_CONSTANT of
+        this value's LLT. Only an exact int (not bool, not float) is accepted --
+        int(other) would silently truncate a float or parse a str into a
+        wrong-typed constant that survives into the release wheel."""
+        self._require_current()
         if isinstance(other, MachineValue):
+            other._require_current()
             return other
-        reg = current_machine_builder().build_constant(self.llt, int(other))
+        if type(other) is not int:
+            raise TypeError(
+                f"cannot coerce {other!r} to a {self.llt} constant; "
+                "expected a MachineValue or an int"
+            )
+        reg = current_machine_builder().build_constant(self.llt, other)
         return MachineValue(reg, self.llt)
 
     def _binary(self, other, method, *, reflected=False):
         other = self._coerce(other)
+        if self.llt != other.llt:
+            raise TypeError(f"mismatched types: {self.llt} and {other.llt}")
         b = current_machine_builder()
         lhs, rhs = (other, self) if reflected else (self, other)
         reg = getattr(b, method)(self.llt, lhs.reg, rhs.reg)
@@ -71,13 +90,14 @@ class DSLMachineFunction:
     """The result of @machine_function: the built MachineFunction plus the
     MachineModuleInfo that owns it."""
 
-    def __init__(self, mmi, name):
+    def __init__(self, mmi, name, machine_function):
         self.mmi = mmi
         self.name = name
+        self._machine_function = machine_function
 
     @property
     def machine_function(self):
-        return self.mmi.machine_function(self.name)
+        return self._machine_function
 
     def to_mir(self):
         return self.mmi.to_mir()
@@ -94,26 +114,38 @@ def _resolve_llt(annotation):
 def machine_function(*, module, target, name=None):
     """Build a generic-MIR MachineFunction by tracing `f`. Each parameter is
     annotated with an LLT and arrives as a MachineValue over a fresh generic
-    vreg; the body emits instructions through the contextual builder."""
+    vreg; the body emits instructions through the contextual builder.
+
+    The body's return value is not turned into a terminator -- this traces a
+    straight-line generic-MIR fragment, so `return a + b` just ends tracing.
+    If the body raises, the partially-built MachineFunction is left in `mmi`
+    (there is no rollback), but the exception propagates unchanged.
+    """
 
     def decorator(f):
-        sig = inspect.signature(f)
-        param_llts = [_resolve_llt(p.annotation) for p in sig.parameters.values()]
+        params = list(inspect.signature(f).parameters.values())
+        for p in params:
+            if p.kind not in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD):
+                raise TypeError(
+                    f"@machine_function parameter {p.name!r} must be positional; "
+                    "*args, **kwargs, and keyword-only parameters are not supported"
+                )
+            if p.annotation is inspect.Parameter.empty:
+                raise TypeError(
+                    f"@machine_function parameter {p.name!r} is missing an LLT "
+                    "annotation"
+                )
+        param_llts = [_resolve_llt(p.annotation) for p in params]
         fn_name = name or f.__name__
 
         mmi = create_machine_function(module, target, fn_name)
         mf = mmi.machine_function(fn_name)
-        builder = MachineIRBuilder(mf)
-
-        _builder_stack.append(builder)
-        try:
+        with MachineIRBuilder(mf):
             args = [
                 MachineValue(mf.create_generic_virtual_register(llt), llt)
                 for llt in param_llts
             ]
             f(*args)
-        finally:
-            _builder_stack.pop()
-        return DSLMachineFunction(mmi, fn_name)
+        return DSLMachineFunction(mmi, fn_name, mf)
 
     return decorator

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
@@ -1,0 +1,119 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The @machine_function decorator and MachineValue: a Pythonic front end for
+building generic (GlobalISel) MIR, mirroring the IR DSL's @function/ArithValue.
+
+Unlike the IR builder, MachineIRBuilder is not wired into the C++ InsertPoint
+stack, so the "current builder" is tracked here with a plain stack pushed for
+the duration of tracing a @machine_function body. A MachineValue wraps a
+Register plus its LLT and overloads `+ - *` onto build_add/build_sub/build_mul;
+Python ints coerce to a G_CONSTANT of the other operand's type.
+"""
+
+import inspect
+
+from ..eudslllvm_ext.mir import LLT, MachineIRBuilder, create_machine_function
+
+_builder_stack = []
+
+
+def current_machine_builder():
+    """The MachineIRBuilder for the @machine_function body being traced."""
+    if not _builder_stack:
+        raise RuntimeError(
+            "no current MachineIRBuilder; use this only inside a @machine_function body"
+        )
+    return _builder_stack[-1]
+
+
+class MachineValue:
+    """A generic-MIR value: a Register plus its LLT, with operator overloads."""
+
+    def __init__(self, reg, llt):
+        self.reg = reg
+        self.llt = llt
+
+    def _coerce(self, other):
+        """A MachineValue passes through; a Python int becomes a G_CONSTANT."""
+        if isinstance(other, MachineValue):
+            return other
+        reg = current_machine_builder().build_constant(self.llt, int(other))
+        return MachineValue(reg, self.llt)
+
+    def _binary(self, other, method, *, reflected=False):
+        other = self._coerce(other)
+        b = current_machine_builder()
+        lhs, rhs = (other, self) if reflected else (self, other)
+        reg = getattr(b, method)(self.llt, lhs.reg, rhs.reg)
+        return MachineValue(reg, self.llt)
+
+    def __add__(self, other):
+        return self._binary(other, "build_add")
+
+    def __sub__(self, other):
+        return self._binary(other, "build_sub")
+
+    def __mul__(self, other):
+        return self._binary(other, "build_mul")
+
+    def __radd__(self, other):
+        return self._binary(other, "build_add", reflected=True)
+
+    def __rmul__(self, other):
+        return self._binary(other, "build_mul", reflected=True)
+
+    def __rsub__(self, other):
+        return self._binary(other, "build_sub", reflected=True)
+
+
+class DSLMachineFunction:
+    """The result of @machine_function: the built MachineFunction plus the
+    MachineModuleInfo that owns it."""
+
+    def __init__(self, mmi, name):
+        self.mmi = mmi
+        self.name = name
+
+    @property
+    def machine_function(self):
+        return self.mmi.machine_function(self.name)
+
+    def to_mir(self):
+        return self.mmi.to_mir()
+
+
+def _resolve_llt(annotation):
+    if isinstance(annotation, LLT):
+        return annotation
+    raise TypeError(
+        f"@machine_function parameters must be annotated with an LLT, got {annotation!r}"
+    )
+
+
+def machine_function(*, module, target, name=None):
+    """Build a generic-MIR MachineFunction by tracing `f`. Each parameter is
+    annotated with an LLT and arrives as a MachineValue over a fresh generic
+    vreg; the body emits instructions through the contextual builder."""
+
+    def decorator(f):
+        sig = inspect.signature(f)
+        param_llts = [_resolve_llt(p.annotation) for p in sig.parameters.values()]
+        fn_name = name or f.__name__
+
+        mmi = create_machine_function(module, target, fn_name)
+        mf = mmi.machine_function(fn_name)
+        builder = MachineIRBuilder(mf)
+
+        _builder_stack.append(builder)
+        try:
+            args = [
+                MachineValue(mf.create_generic_virtual_register(llt), llt)
+                for llt in param_llts
+            ]
+            f(*args)
+        finally:
+            _builder_stack.pop()
+        return DSLMachineFunction(mmi, fn_name)
+
+    return decorator

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
@@ -1,0 +1,119 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The @machine_function DSL: build generic MIR with Pythonic operators.
+
+Mirrors the IR DSL's @function/ArithValue: parameters annotated with an LLT
+become MachineValues over fresh generic vregs, and `+ - *` emit G_ADD/G_SUB/
+G_MUL through a contextual MachineIRBuilder.
+"""
+
+import pytest
+
+from llvm import ir, jit, mir
+from llvm.dsl import machine_function
+from llvm.dsl.machine import MachineValue, current_machine_builder
+from llvm.testing import assert_no_leaks
+
+# Generic (G_*) MIR is target-independent; build against the host
+# target so these run on any runner.
+_TRIPLE = None
+
+
+def test_machine_function_builds_generic_add():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            return a + b
+
+        assert f.name == "f"
+        opcodes = [i.opcode_name for i in f.machine_function.blocks[0].instructions]
+        assert opcodes == ["G_ADD"]
+    assert_no_leaks()
+
+
+def test_operators_and_int_coercion():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        def g(a: s32):
+            return (a + 1) * a - a
+
+        ops = [i.opcode_name for i in g.machine_function.blocks[0].instructions]
+        assert ops == ["G_CONSTANT", "G_ADD", "G_MUL", "G_SUB"]
+    assert_no_leaks()
+
+
+def test_reflected_operators():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        def g(a: s32):
+            return 1 + a, 2 * a, 10 - a
+
+        ops = [i.opcode_name for i in g.machine_function.blocks[0].instructions]
+        # three constants (1, 2, 10) and one each of add/mul/sub
+        assert ops.count("G_CONSTANT") == 3
+        assert "G_ADD" in ops and "G_MUL" in ops and "G_SUB" in ops
+    assert_no_leaks()
+
+
+def test_to_mir_from_dsl():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            return a * b
+
+        assert "G_MUL" in f.to_mir()
+    assert_no_leaks()
+
+
+def test_unannotated_parameter_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+
+        with pytest.raises(TypeError):
+
+            @machine_function(module=mod, target=tm)
+            def f(a):  # no LLT annotation
+                return a
+
+    assert_no_leaks()
+
+
+def test_current_machine_builder_outside_function_raises():
+    with pytest.raises(RuntimeError):
+        current_machine_builder()
+
+
+def test_machine_value_holds_register_and_type():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32):
+            captured["a"] = a
+            return a
+
+        assert isinstance(captured["a"], MachineValue)
+        assert captured["a"].reg.is_virtual
+        assert captured["a"].llt == s32
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
@@ -68,6 +68,149 @@ def test_reflected_operators():
     assert_no_leaks()
 
 
+def test_reflected_subtraction_operand_order():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def g(a: s32):
+            captured["a"] = a.reg.id
+            return 10 - a
+
+        instrs = g.machine_function.blocks[0].instructions
+        const = next(i for i in instrs if i.opcode_name == "G_CONSTANT")
+        sub = next(i for i in instrs if i.opcode_name == "G_SUB")
+        # `10 - a` must emit G_SUB(const, a): lhs (operand 1) is the constant,
+        # rhs (operand 2) is a. operand(0) is the def. If the reflected flag were
+        # dropped, these two would be swapped.
+        assert sub.operand(1).reg.id == const.operand(0).reg.id
+        assert sub.operand(2).reg.id == captured["a"]
+    assert_no_leaks()
+
+
+def test_forward_subtraction_operand_order():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def g(a: s32):
+            captured["a"] = a.reg.id
+            return a - 10
+
+        instrs = g.machine_function.blocks[0].instructions
+        const = next(i for i in instrs if i.opcode_name == "G_CONSTANT")
+        sub = next(i for i in instrs if i.opcode_name == "G_SUB")
+        # `a - 10` -> G_SUB(a, const): a is the lhs, the constant is the rhs.
+        assert sub.operand(1).reg.id == captured["a"]
+        assert sub.operand(2).reg.id == const.operand(0).reg.id
+    assert_no_leaks()
+
+
+def test_explicit_name_override():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm, name="custom")
+        def f(a: s32):
+            return a + a
+
+        assert f.name == "custom"
+        assert f.machine_function.name == "custom"
+    assert_no_leaks()
+
+
+def test_mismatched_operand_types_raise():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32, s64 = mir.LLT.scalar(32), mir.LLT.scalar(64)
+
+        with pytest.raises(TypeError, match="mismatched types"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32, b: s64):
+                return a + b
+
+    assert_no_leaks()
+
+
+def test_non_int_coercion_raises():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        for bad in (3.7, True, "5"):
+            with pytest.raises(TypeError, match="cannot coerce"):
+
+                @machine_function(module=ir.Module("m", ctx), target=tm)
+                def f(a: s32):
+                    return a + bad  # noqa: B023 (traced eagerly in this loop)
+
+    assert_no_leaks()
+
+
+def test_value_from_other_function_raises():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        leaked = {}
+
+        @machine_function(module=ir.Module("g", ctx), target=tm)
+        def g(a: s32):
+            leaked["a"] = a
+            return a
+
+        with pytest.raises(RuntimeError, match="different MachineFunction"):
+
+            @machine_function(module=ir.Module("f", ctx), target=tm)
+            def f(b: s32):
+                return b + leaked["a"]
+
+    assert_no_leaks()
+
+
+def test_builder_stack_cleared_when_body_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(ZeroDivisionError):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                raise ZeroDivisionError("boom")
+
+        # The `with MachineIRBuilder(mf):` __exit__ popped the builder even
+        # though the body raised.
+        with pytest.raises(RuntimeError):
+            current_machine_builder()
+    assert_no_leaks()
+
+
+def test_keyword_only_parameter_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(TypeError, match="must be positional"):
+
+            @machine_function(module=mod, target=tm)
+            def f(*, a: s32):
+                return a
+
+    assert_no_leaks()
+
+
 def test_to_mir_from_dsl():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
@@ -87,10 +230,24 @@ def test_unannotated_parameter_raises():
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_TRIPLE)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="missing an LLT annotation"):
 
             @machine_function(module=mod, target=tm)
             def f(a):  # no LLT annotation
+                return a
+
+    assert_no_leaks()
+
+
+def test_non_llt_annotation_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+
+        with pytest.raises(TypeError, match="must be annotated with an LLT"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: int):  # annotated, but not an LLT
                 return a
 
     assert_no_leaks()


### PR DESCRIPTION
A Pythonic front end for building generic (GlobalISel) MIR, mirroring the IR
DSL's @function/ArithValue. Parameters annotated with an LLT arrive as
MachineValues over fresh generic vregs; `+ - *` emit G_ADD/G_SUB/G_MUL through
a contextual MachineIRBuilder, and Python ints coerce to G_CONSTANTs. Returns a
DSLMachineFunction exposing the built MachineFunction and its .to_mir().

Fourth PR in the MIR bindings/DSL stack; builds on the MachineIRBuilder PR.