### PR TITLE
[eudsl-llvmpy] Add generic-MIR control-flow primitives (blocks, branches, G_PHI)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -20,6 +20,7 @@
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
+#include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/DiagnosticInfo.h>
@@ -97,6 +98,28 @@ void requireVRegOfType(llvm::MachineIRBuilder &b, llvm::Register reg,
                            " must be a virtual register of this "
                            "MachineFunction with the result type")
                               .c_str());
+}
+
+// A MachineBasicBlock / Register crosses the Python boundary as a bare handle
+// with no back-link to its function; passing one from a different function
+// builds corrupt MIR (cross-linked CFGs, out-of-bounds vreg indexes) that the
+// verifier -- gone under NDEBUG -- would otherwise catch. Guard provenance
+// against the builder's (or another block's) function.
+void requireSameFunction(const llvm::MachineFunction &mf,
+                         const llvm::MachineBasicBlock *mbb, const char *role) {
+  if (mbb->getParent() != &mf)
+    throw nb::value_error(
+        (std::string(role) + " belongs to a different MachineFunction")
+            .c_str());
+}
+
+void requireVReg(llvm::MachineIRBuilder &b, llvm::Register reg,
+                 const char *role) {
+  if (!b.getMF().getRegInfo().getType(reg).isValid())
+    throw nb::value_error(
+        (std::string(role) +
+         " must be a generic virtual register of this MachineFunction")
+            .c_str());
 }
 
 // The "current MachineIRBuilder" is tracked on a thread-local stack, mirroring
@@ -501,6 +524,9 @@ void populate_mir(nb::module_ &m) {
       .def(
           "add_successor",
           [](llvm::MachineBasicBlock &self, llvm::MachineBasicBlock *succ) {
+            // addSuccessor also calls succ->addPredecessor(this), so a
+            // cross-function successor would corrupt two functions' CFGs.
+            requireSameFunction(*self.getParent(), succ, "successor");
             self.addSuccessor(succ);
           },
           "successor"_a, "Add a CFG successor edge to another block.")
@@ -540,13 +566,16 @@ void populate_mir(nb::module_ &m) {
           "type"_a, "Create a new generic virtual register of the given LLT.")
       .def(
           "create_block",
-          [](llvm::MachineFunction &self) -> llvm::MachineBasicBlock * {
-            llvm::MachineBasicBlock *mbb = self.CreateMachineBasicBlock();
+          [](llvm::MachineFunction &self,
+             const llvm::BasicBlock *bb) -> llvm::MachineBasicBlock * {
+            llvm::MachineBasicBlock *mbb = self.CreateMachineBasicBlock(bb);
             self.push_back(mbb);
             return mbb;
           },
+          "basic_block"_a.none() = nb::none(),
           nb::rv_policy::reference_internal,
-          "Append a new, empty MachineBasicBlock to the function.")
+          "Append a new, empty MachineBasicBlock to the function, optionally "
+          "linked to an IR BasicBlock for debug info/naming.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -823,6 +852,7 @@ void populate_mir(nb::module_ &m) {
       .def(
           "set_block",
           [](llvm::MachineIRBuilder &self, llvm::MachineBasicBlock *mbb) {
+            requireSameFunction(self.getMF(), mbb, "block");
             self.setMBB(*mbb);
           },
           "block"_a, "Insert subsequent instructions at the end of `block`.")
@@ -831,19 +861,40 @@ void populate_mir(nb::module_ &m) {
           [](llvm::MachineIRBuilder &self, llvm::CmpInst::Predicate pred,
              llvm::LLT ty, llvm::Register lhs,
              llvm::Register rhs) -> llvm::Register {
+            // buildICmp only asserts these (gone under NDEBUG): an integer
+            // predicate, an s1 (or vector-of-s1) result, and same-typed operand
+            // vregs of this function.
+            if (!llvm::CmpInst::isIntPredicate(pred))
+              throw nb::value_error(
+                  "build_icmp requires an integer comparison predicate");
+            llvm::LLT s1 = llvm::LLT::scalar(1);
+            if (ty != s1 && !(ty.isFixedVector() && ty.getElementType() == s1))
+              throw nb::value_error(
+                  "build_icmp result type must be s1 or a fixed vector of s1");
+            requireVReg(self, lhs, "lhs");
+            requireVReg(self, rhs, "rhs");
+            const llvm::MachineRegisterInfo &mri = self.getMF().getRegInfo();
+            if (mri.getType(lhs) != mri.getType(rhs))
+              throw nb::value_error("build_icmp operands must have the same "
+                                    "type");
             return self.buildICmp(pred, ty, lhs, rhs).getReg(0);
           },
           "predicate"_a, "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_br",
           [](llvm::MachineIRBuilder &self, llvm::MachineBasicBlock *dest) {
+            requireSameFunction(self.getMF(), dest, "dest");
             self.buildBr(*dest);
           },
           "dest"_a, "Build an unconditional branch (G_BR) to `dest`.")
       .def(
           "build_brcond",
           [](llvm::MachineIRBuilder &self, llvm::Register cond,
-             llvm::MachineBasicBlock *dest) { self.buildBrCond(cond, *dest); },
+             llvm::MachineBasicBlock *dest) {
+            requireVReg(self, cond, "cond");
+            requireSameFunction(self.getMF(), dest, "dest");
+            self.buildBrCond(cond, *dest);
+          },
           "cond"_a, "dest"_a,
           "Build a conditional branch (G_BRCOND) on `cond` to `dest`.")
       .def(
@@ -851,6 +902,16 @@ void populate_mir(nb::module_ &m) {
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
              std::vector<std::pair<llvm::Register, llvm::MachineBasicBlock *>>
                  incomings) -> llvm::Register {
+            // A G_PHI with no operands is structurally invalid; each incoming
+            // value must be a vreg of this function with the phi's type, and
+            // each predecessor block must belong to this function.
+            if (incomings.empty())
+              throw nb::value_error("build_phi requires at least one "
+                                    "(value, predecessor-block) pair");
+            for (auto &[reg, mbb] : incomings) {
+              requireVRegOfType(self, reg, ty, "incoming value");
+              requireSameFunction(self.getMF(), mbb, "predecessor block");
+            }
             llvm::Register res =
                 self.getMRI()->createGenericVirtualRegister(ty);
             llvm::MachineInstrBuilder phi =

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -16,6 +16,7 @@
 #include <llvm/CodeGen/MachineOperand.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
+#include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
@@ -25,13 +26,17 @@
 #include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/GlobalValue.h>
+#include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Target/TargetMachine.h>
 
+#include <nanobind/stl/pair.h>
+
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -493,6 +498,12 @@ void populate_mir(nb::module_ &m) {
             return preds;
           },
           nb::rv_policy::reference_internal)
+      .def(
+          "add_successor",
+          [](llvm::MachineBasicBlock &self, llvm::MachineBasicBlock *succ) {
+            self.addSuccessor(succ);
+          },
+          "successor"_a, "Add a CFG successor edge to another block.")
       .def("__str__",
            [](llvm::MachineBasicBlock &self) { return eudsl::toString(self); });
 
@@ -527,6 +538,15 @@ void populate_mir(nb::module_ &m) {
             return self.getRegInfo().createGenericVirtualRegister(ty);
           },
           "type"_a, "Create a new generic virtual register of the given LLT.")
+      .def(
+          "create_block",
+          [](llvm::MachineFunction &self) -> llvm::MachineBasicBlock * {
+            llvm::MachineBasicBlock *mbb = self.CreateMachineBasicBlock();
+            self.push_back(mbb);
+            return mbb;
+          },
+          nb::rv_policy::reference_internal,
+          "Append a new, empty MachineBasicBlock to the function.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -792,7 +812,58 @@ void populate_mir(nb::module_ &m) {
             requireVRegOfType(self, src, ty, "src");
             return self.buildCopy(ty, src).getReg(0);
           },
-          "type"_a, "src"_a);
+          "type"_a, "src"_a)
+      .def_prop_ro(
+          "insert_block",
+          [](llvm::MachineIRBuilder &self) -> llvm::MachineBasicBlock * {
+            return &self.getMBB();
+          },
+          nb::rv_policy::reference_internal,
+          "The block new instructions are appended to.")
+      .def(
+          "set_block",
+          [](llvm::MachineIRBuilder &self, llvm::MachineBasicBlock *mbb) {
+            self.setMBB(*mbb);
+          },
+          "block"_a, "Insert subsequent instructions at the end of `block`.")
+      .def(
+          "build_icmp",
+          [](llvm::MachineIRBuilder &self, llvm::CmpInst::Predicate pred,
+             llvm::LLT ty, llvm::Register lhs,
+             llvm::Register rhs) -> llvm::Register {
+            return self.buildICmp(pred, ty, lhs, rhs).getReg(0);
+          },
+          "predicate"_a, "type"_a, "lhs"_a, "rhs"_a)
+      .def(
+          "build_br",
+          [](llvm::MachineIRBuilder &self, llvm::MachineBasicBlock *dest) {
+            self.buildBr(*dest);
+          },
+          "dest"_a, "Build an unconditional branch (G_BR) to `dest`.")
+      .def(
+          "build_brcond",
+          [](llvm::MachineIRBuilder &self, llvm::Register cond,
+             llvm::MachineBasicBlock *dest) { self.buildBrCond(cond, *dest); },
+          "cond"_a, "dest"_a,
+          "Build a conditional branch (G_BRCOND) on `cond` to `dest`.")
+      .def(
+          "build_phi",
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty,
+             std::vector<std::pair<llvm::Register, llvm::MachineBasicBlock *>>
+                 incomings) -> llvm::Register {
+            llvm::Register res =
+                self.getMRI()->createGenericVirtualRegister(ty);
+            llvm::MachineInstrBuilder phi =
+                self.buildInstr(llvm::TargetOpcode::G_PHI);
+            phi.addDef(res);
+            for (auto &[reg, mbb] : incomings) {
+              phi.addUse(reg);
+              phi.addMBB(mbb);
+            }
+            return res;
+          },
+          "type"_a, "incomings"_a,
+          "Build a G_PHI from (value, predecessor-block) pairs.");
 
   // The innermost MachineIRBuilder entered as a context manager, mirroring the
   // IR module's current_builder(). Raises when there is none.

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -2,9 +2,10 @@
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Control-flow primitives for generic MIR: extra blocks, branches, compares,
-and G_PHI. These are the pieces the @machine_function control-flow runtime is
-built on; here they are driven directly to hand-build an if-diamond.
+and G_PHI. Here they are driven directly to hand-build an if-diamond.
 """
+
+import pytest
 
 from llvm import ir, jit, mir
 from llvm.testing import assert_no_leaks
@@ -13,11 +14,11 @@ from llvm.testing import assert_no_leaks
 _TRIPLE = None
 
 
-def _new_function(ctx):
+def _new_function(ctx, name="f"):
     mod = ir.Module("m", ctx)
     tm = jit.TargetMachine(triple=_TRIPLE)
-    mmi = mir.create_machine_function(mod, tm, "f")
-    return mmi, mmi.machine_function("f")
+    mmi = mir.create_machine_function(mod, tm, name)
+    return mmi, mmi.machine_function(name)
 
 
 def test_create_block_and_set_block():
@@ -67,8 +68,121 @@ def test_build_if_diamond_with_phi():
         r = b.build_phi(s32, [(tv, then_bb), (ev, else_bb)])
         assert r.is_virtual
 
-        text = str(mf)
         assert len(mf.blocks) == 4
-        for opc in ("G_ICMP", "G_BRCOND", "G_BR", "G_PHI"):
-            assert opc in text
+
+        # Structural check of the G_ICMP: def is `cond`, operands (after the
+        # predicate operand) are x and one, in order. build_* return a raw
+        # Register, so compare .id directly.
+        icmp = next(i for i in entry.instructions if i.opcode_name == "G_ICMP")
+        assert icmp.operand(0).reg.id == cond.id
+        assert icmp.operand(2).reg.id == x.id
+        assert icmp.operand(3).reg.id == one.id
+
+        # Structural check of the G_PHI: def is `r`, and the value operands are
+        # tv then ev in that order (register operands are 1 and 3; 2 and 4 are
+        # the predecessor blocks). Swapping the pair order would fail here.
+        phi = next(i for i in join_bb.instructions if i.opcode_name == "G_PHI")
+        assert phi.num_operands == 5
+        assert phi.operand(0).reg.id == r.id
+        assert phi.operand(1).reg.id == tv.id
+        assert phi.operand(3).reg.id == ev.id
+    assert_no_leaks()
+
+
+def test_create_block_accepts_ir_basic_block():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        # Passing an IR BasicBlock links the MBB to it (debug info/naming); the
+        # default (None) is used everywhere else. Just exercise the arg path.
+        fn = ir.parse_assembly(
+            "define void @g() {\nentry:\n  ret void\n}\n", ctx, "g2"
+        ).functions[0]
+        bb = fn.entry_block
+        before = len(mf.blocks)
+        mbb = mf.create_block(bb)
+        assert len(mf.blocks) == before + 1
+        assert mbb.number == before
+    assert_no_leaks()
+
+
+def test_build_icmp_rejects_float_predicate():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32, s1 = mir.LLT.scalar(32), mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        x = b.build_constant(s32, 1)
+        with pytest.raises(ValueError, match="integer comparison predicate"):
+            b.build_icmp(ir.FCmpPredicate.OLT, s1, x, x)
+    assert_no_leaks()
+
+
+def test_build_icmp_rejects_non_s1_result():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        x = b.build_constant(s32, 1)
+        with pytest.raises(ValueError, match="s1"):
+            b.build_icmp(ir.ICmpPredicate.SLT, s32, x, x)  # result must be s1
+    assert_no_leaks()
+
+
+def test_build_icmp_rejects_mismatched_operands():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32, s64, s1 = mir.LLT.scalar(32), mir.LLT.scalar(64), mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        a = b.build_constant(s32, 1)
+        c = b.build_constant(s64, 1)
+        with pytest.raises(ValueError, match="same type"):
+            b.build_icmp(ir.ICmpPredicate.SLT, s1, a, c)
+    assert_no_leaks()
+
+
+def test_build_phi_rejects_empty_incomings():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        b = mir.MachineIRBuilder(mf)
+        with pytest.raises(ValueError, match="at least one"):
+            b.build_phi(mir.LLT.scalar(32), [])
+    assert_no_leaks()
+
+
+def test_build_phi_rejects_mistyped_incoming():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32, s64 = mir.LLT.scalar(32), mir.LLT.scalar(64)
+        b = mir.MachineIRBuilder(mf)
+        wrong = b.build_constant(s64, 1)  # not s32
+        entry = mf.blocks[0]
+        with pytest.raises(ValueError, match="incoming value"):
+            b.build_phi(s32, [(wrong, entry)])
+    assert_no_leaks()
+
+
+def test_cross_function_block_rejected():
+    with ir.Context() as ctx:
+        mmi_f, mf = _new_function(ctx, "f")
+        mmi_g, mg = _new_function(ctx, "g")
+        foreign = mg.create_block()  # a block owned by g
+        b = mir.MachineIRBuilder(mf)
+        entry = mf.blocks[0]
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            b.set_block(foreign)
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            b.build_br(foreign)
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            entry.add_successor(foreign)
+    assert_no_leaks()
+
+
+def test_cross_function_register_rejected():
+    with ir.Context() as ctx:
+        mmi_f, mf = _new_function(ctx, "f")
+        mmi_g, mg = _new_function(ctx, "g")
+        s32, s1 = mir.LLT.scalar(32), mir.LLT.scalar(1)
+        foreign = mir.MachineIRBuilder(mg).build_constant(s32, 1)  # g's vreg
+        bf = mir.MachineIRBuilder(mf)
+        with pytest.raises(ValueError):
+            bf.build_brcond(foreign, mf.blocks[0])
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -1,0 +1,74 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Control-flow primitives for generic MIR: extra blocks, branches, compares,
+and G_PHI. These are the pieces the @machine_function control-flow runtime is
+built on; here they are driven directly to hand-build an if-diamond.
+"""
+
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# Generic (G_*) control-flow MIR is target-independent; host target.
+_TRIPLE = None
+
+
+def _new_function(ctx):
+    mod = ir.Module("m", ctx)
+    tm = jit.TargetMachine(triple=_TRIPLE)
+    mmi = mir.create_machine_function(mod, tm, "f")
+    return mmi, mmi.machine_function("f")
+
+
+def test_create_block_and_set_block():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        b = mir.MachineIRBuilder(mf)
+        assert b.insert_block.number == mf.blocks[0].number
+        bb1 = mf.create_block()
+        assert len(mf.blocks) == 2
+        b.set_block(bb1)
+        assert b.insert_block.number == bb1.number
+    assert_no_leaks()
+
+
+def test_build_if_diamond_with_phi():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        entry = mf.blocks[0]
+
+        x = mf.create_generic_virtual_register(s32)
+        one = b.build_constant(s32, 1)
+        two = b.build_constant(s32, 2)
+        cond = b.build_icmp(ir.ICmpPredicate.SLT, s1, x, one)  # x < 1
+
+        then_bb = mf.create_block()
+        else_bb = mf.create_block()
+        join_bb = mf.create_block()
+        entry.add_successor(then_bb)
+        entry.add_successor(else_bb)
+        b.build_brcond(cond, then_bb)
+        b.build_br(else_bb)
+
+        b.set_block(then_bb)
+        tv = b.build_add(s32, x, one)
+        b.build_br(join_bb)
+        then_bb.add_successor(join_bb)
+
+        b.set_block(else_bb)
+        ev = b.build_sub(s32, x, two)
+        b.build_br(join_bb)
+        else_bb.add_successor(join_bb)
+
+        b.set_block(join_bb)
+        r = b.build_phi(s32, [(tv, then_bb), (ev, else_bb)])
+        assert r.is_virtual
+
+        text = str(mf)
+        assert len(mf.blocks) == 4
+        for opc in ("G_ICMP", "G_BRCOND", "G_BR", "G_PHI"):
+            assert opc in text
+    assert_no_leaks()


### PR DESCRIPTION
Extend the MIR object model and MachineIRBuilder with the pieces control flow
needs: MachineFunction.create_block, MachineBasicBlock.add_successor, and the
builder's insert_block/set_block, build_icmp (G_ICMP, reusing ir.CmpPredicate),
build_br/build_brcond (G_BR/G_BRCOND), and build_phi (G_PHI from
(value, predecessor) pairs). Tested by hand-building an if-diamond CFG.

Fifth PR in the MIR bindings/DSL stack; the substrate for the control-flow DSL.