### PR TITLE
[eudsl-llvmpy] Add generic-MIR if/else control-flow runtime

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -475,6 +475,16 @@ void populate_mir(nb::module_ &m) {
                    [](llvm::MachineInstr &self) { return self.mayStore(); })
       .def_prop_ro("is_debug_instr",
                    [](llvm::MachineInstr &self) { return self.isDebugInstr(); })
+      .def(
+          "set_branch_target",
+          [](llvm::MachineInstr &self, llvm::MachineBasicBlock *mbb) {
+            if (self.getNumOperands() == 0 || !self.getOperand(0).isMBB())
+              throw nb::value_error(
+                  "instruction has no branch-target (MBB) operand");
+            self.getOperand(0).setMBB(mbb);
+          },
+          "block"_a,
+          "Repoint a branch's target block (operand 0), e.g. a G_BR.")
       .def("__str__",
            [](llvm::MachineInstr &self) { return eudsl::toString(self); });
 
@@ -530,6 +540,13 @@ void populate_mir(nb::module_ &m) {
             self.addSuccessor(succ);
           },
           "successor"_a, "Add a CFG successor edge to another block.")
+      .def(
+          "replace_successor",
+          [](llvm::MachineBasicBlock &self, llvm::MachineBasicBlock *old,
+             llvm::MachineBasicBlock *replacement) {
+            self.replaceSuccessor(old, replacement);
+          },
+          "old"_a, "new"_a, "Replace a CFG successor edge with another block.")
       .def("__str__",
            [](llvm::MachineBasicBlock &self) { return eudsl::toString(self); });
 
@@ -856,6 +873,13 @@ void populate_mir(nb::module_ &m) {
             self.setMBB(*mbb);
           },
           "block"_a, "Insert subsequent instructions at the end of `block`.")
+      .def_prop_ro(
+          "machine_function",
+          [](llvm::MachineIRBuilder &self) -> llvm::MachineFunction * {
+            return &self.getMF();
+          },
+          nb::rv_policy::reference_internal,
+          "The MachineFunction this builder inserts into.")
       .def(
           "build_icmp",
           [](llvm::MachineIRBuilder &self, llvm::CmpInst::Predicate pred,
@@ -882,11 +906,14 @@ void populate_mir(nb::module_ &m) {
           "predicate"_a, "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_br",
-          [](llvm::MachineIRBuilder &self, llvm::MachineBasicBlock *dest) {
+          [](llvm::MachineIRBuilder &self,
+             llvm::MachineBasicBlock *dest) -> llvm::MachineInstr * {
             requireSameFunction(self.getMF(), dest, "dest");
-            self.buildBr(*dest);
+            return self.buildBr(*dest).getInstr();
           },
-          "dest"_a, "Build an unconditional branch (G_BR) to `dest`.")
+          "dest"_a, nb::rv_policy::reference_internal,
+          "Build an unconditional branch (G_BR) to `dest`; returns the "
+          "instruction so its target can be repointed.")
       .def(
           "build_brcond",
           [](llvm::MachineIRBuilder &self, llvm::Register cond,

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -478,9 +478,10 @@ void populate_mir(nb::module_ &m) {
       .def(
           "set_branch_target",
           [](llvm::MachineInstr &self, llvm::MachineBasicBlock *mbb) {
-            if (self.getNumOperands() == 0 || !self.getOperand(0).isMBB())
+            if (self.getNumOperands() == 0 || !self.getOperand(0).isMBB()) {
               throw nb::value_error(
                   "instruction has no branch-target (MBB) operand");
+            }
             self.getOperand(0).setMBB(mbb);
           },
           "block"_a,
@@ -544,6 +545,13 @@ void populate_mir(nb::module_ &m) {
           "replace_successor",
           [](llvm::MachineBasicBlock &self, llvm::MachineBasicBlock *old,
              llvm::MachineBasicBlock *replacement) {
+            // replaceSuccessor only asserts `old` is a successor (gone under
+            // NDEBUG); without the check it walks past succ_end() and corrupts
+            // the CFG. Guard it, and reject a cross-function replacement.
+            if (!self.isSuccessor(old)) {
+              throw nb::value_error("`old` is not a successor of this block");
+            }
+            requireSameFunction(*self.getParent(), replacement, "new");
             self.replaceSuccessor(old, replacement);
           },
           "old"_a, "new"_a, "Replace a CFG successor edge with another block.")

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
@@ -13,6 +13,7 @@ ints coerce to a G_CONSTANT of the other operand's type.
 
 import inspect
 
+from ..eudslllvm_ext.ir import ICmpPredicate
 from ..eudslllvm_ext.mir import (
     LLT,
     MachineIRBuilder,
@@ -84,6 +85,36 @@ class MachineValue:
 
     def __rsub__(self, other):
         return self._binary(other, "build_sub", reflected=True)
+
+    def _cmp(self, other, predicate):
+        """Emit a G_ICMP, producing an i1 (LLT.scalar(1)) MachineValue.
+        Comparisons default to signed-integer predicates."""
+        other = self._coerce(other)
+        i1 = LLT.scalar(1)
+        reg = current_machine_builder().build_icmp(predicate, i1, self.reg, other.reg)
+        return MachineValue(reg, i1)
+
+    def __lt__(self, other):
+        return self._cmp(other, ICmpPredicate.SLT)
+
+    def __le__(self, other):
+        return self._cmp(other, ICmpPredicate.SLE)
+
+    def __gt__(self, other):
+        return self._cmp(other, ICmpPredicate.SGT)
+
+    def __ge__(self, other):
+        return self._cmp(other, ICmpPredicate.SGE)
+
+    # __eq__/__ne__ stay identity (so a MachineValue is hashable and usable in
+    # traversal); value equality is exposed by name, like ArithValue.
+    __hash__ = object.__hash__
+
+    def eq(self, other):
+        return self._cmp(other, ICmpPredicate.EQ)
+
+    def ne(self, other):
+        return self._cmp(other, ICmpPredicate.NE)
 
 
 class DSLMachineFunction:

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
@@ -88,8 +88,11 @@ class MachineValue:
 
     def _cmp(self, other, predicate):
         """Emit a G_ICMP, producing an i1 (LLT.scalar(1)) MachineValue.
-        Comparisons default to signed-integer predicates."""
+        Comparisons default to signed-integer predicates; the unsigned
+        ult/ule/ugt/uge methods request the unsigned ones."""
         other = self._coerce(other)
+        if self.llt != other.llt:
+            raise TypeError(f"mismatched types: {self.llt} and {other.llt}")
         i1 = LLT.scalar(1)
         reg = current_machine_builder().build_icmp(predicate, i1, self.reg, other.reg)
         return MachineValue(reg, i1)
@@ -107,7 +110,11 @@ class MachineValue:
         return self._cmp(other, ICmpPredicate.SGE)
 
     # __eq__/__ne__ stay identity (so a MachineValue is hashable and usable in
-    # traversal); value equality is exposed by name, like ArithValue.
+    # traversal); value equality is exposed by name, like ArithValue. NOTE: in a
+    # @machine_function body `if a == b:` therefore compares Python identity (a
+    # compile-time False for two distinct values), NOT a G_ICMP -- use a.eq(b) /
+    # a.ne(b) for a value comparison, and the ult/ule/ugt/uge methods for
+    # unsigned ordering (the < <= > >= operators are signed).
     __hash__ = object.__hash__
 
     def eq(self, other):
@@ -115,6 +122,18 @@ class MachineValue:
 
     def ne(self, other):
         return self._cmp(other, ICmpPredicate.NE)
+
+    def ult(self, other):
+        return self._cmp(other, ICmpPredicate.ULT)
+
+    def ule(self, other):
+        return self._cmp(other, ICmpPredicate.ULE)
+
+    def ugt(self, other):
+        return self._cmp(other, ICmpPredicate.UGT)
+
+    def uge(self, other):
+        return self._cmp(other, ICmpPredicate.UGE)
 
 
 class DSLMachineFunction:

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
@@ -21,8 +21,8 @@ cond_br.set_successor. The values passed to yield_ become the merge block's
 G_PHIs, built on the else branch (when both incoming edges are known), so
 `r = yield_(...)` binds to the phi that `return r` uses.
 
-Loops are not lowered here yet; a for/while in a @machine_function body is
-unsupported until the loop runtime lands.
+Only if/else is lowered here: a for/while in a @machine_function body is
+rejected (MIRCanonicalizer installs no loop transformers).
 """
 
 from contextlib import contextmanager
@@ -71,6 +71,14 @@ class _MIRIfOp:
         pred.add_successor(self.merge_block)
         return pred
 
+    def _repoint_false_edge(self, new_target):
+        """Atomically move the entry's false edge (CFG successor + the G_BR
+        terminator's target) from the merge block to `new_target`. MIR tracks
+        the successor list and the terminator operand separately, so both must
+        change together or the CFG and terminators silently disagree."""
+        self.entry_block.replace_successor(self.merge_block, new_target)
+        self.false_br.set_branch_target(new_target)
+
     def record_and_maybe_phi(self, values):
         """Called by yield_. Record this branch's values; on the else branch
         (both edges known) build the G_PHIs and return them."""
@@ -83,9 +91,18 @@ class _MIRIfOp:
         # else branch: both edges known, build the phis at the merge block.
         self.else_vals = list(values)
         self.else_pred = self._terminate_current()
+        if len(self.then_vals) != len(self.else_vals):
+            raise ValueError(
+                f"then/else branches yield different numbers of values "
+                f"({len(self.then_vals)} vs {len(self.else_vals)})"
+            )
         b.set_block(self.merge_block)
         phis = []
         for tv, ev in zip(self.then_vals, self.else_vals):
+            if tv.llt != ev.llt:
+                raise TypeError(
+                    f"then/else values have mismatched types: {tv.llt} and " f"{ev.llt}"
+                )
             reg = b.build_phi(
                 tv.llt, [(tv.reg, self.then_pred), (ev.reg, self.else_pred)]
             )
@@ -113,8 +130,7 @@ def else_ctx_manager(op):
     b = op.builder
     op.else_block = b.machine_function.create_block()
     # Repoint the entry's fall-through branch (and CFG edge) merge -> else.
-    op.entry_block.replace_successor(op.merge_block, op.else_block)
-    op.false_br.set_branch_target(op.else_block)
+    op._repoint_false_edge(op.else_block)
     op.active = "else"
     _if_stack.append(op)
     b.set_block(op.else_block)
@@ -126,6 +142,13 @@ def else_ctx_manager(op):
 
 
 def yield_(*values):
+    # _InjectMIRCFGlobals injects yield_ into the traced function's globals, so
+    # a stray yield_ outside an if body is reachable; fail with a clear message
+    # rather than a bare IndexError.
+    if not _if_stack:
+        raise RuntimeError(
+            "yield_ used outside a lowered if/else body (no active if op)"
+        )
     return _if_stack[-1].record_and_maybe_phi(values)
 
 
@@ -139,11 +162,29 @@ class _InjectMIRCFGlobals(FunctionPatcher):
         return f
 
 
+class _RejectLoops(_T.StrictTransformer):
+    """This runtime lowers only if/else; a for/while would otherwise fall
+    through the canonicalizer untouched and silently unroll (a Python `range`)
+    or hang the trace (a truthy MachineValue condition). Reject it loudly."""
+
+    def visit_For(self, node):
+        raise NotImplementedError(
+            "`for` loops in a @machine_function body are not supported"
+        )
+
+    def visit_While(self, node):
+        raise NotImplementedError(
+            "`while` loops in a @machine_function body are not supported"
+        )
+
+
 class MIRCanonicalizer(Canonicalizer):
-    # if/else only for now (no loop transformers); mirrors LLVMCanonicalizer's
-    # if/else passes so the rewritten AST shape is identical.
+    # if/else lowering; mirrors LLVMCanonicalizer's if/else passes so the
+    # rewritten AST shape is identical. _RejectLoops turns an unsupported
+    # for/while into a clear error instead of silently wrong MIR.
     cst_transformers = [
         _T.RejectUnsupportedJumps,
+        _RejectLoops,
         _T.CanonicalizeElIfs,
         _T.InsertEmptyYield,
         _T.ReplaceYieldWithLLVMYield,

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
@@ -1,0 +1,152 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Generic-MIR runtime for lowered if/else: MachineBasicBlocks and G_PHI.
+
+The MIR analogue of llvm.dsl.cf's if/else lowering. The same AST canonicalizer
+rewrites
+
+    if c:
+        r = yield a + 1
+    else:
+        r = yield b
+    return r
+
+into if_ctx_manager/else_ctx_manager/yield_ (see llvm.ast.cf_transformers); this
+module emits the blocks and phis. Since MIR's conditional branch (G_BRCOND) has
+a single target, the entry block gets `G_BRCOND cond -> then` plus a fall-through
+`G_BR -> false-target` whose target (initially the merge block) is repointed to
+the else block by else_ctx_manager -- the MIR equivalent of the IR builder's
+cond_br.set_successor. The values passed to yield_ become the merge block's
+G_PHIs, built on the else branch (when both incoming edges are known), so
+`r = yield_(...)` binds to the phi that `return r` uses.
+
+Loops are not lowered here yet; a for/while in a @machine_function body is
+unsupported until the loop runtime lands.
+"""
+
+from contextlib import contextmanager
+
+from ..ast import cf_transformers as _T
+from ..ast.canonicalize import Canonicalizer, FunctionPatcher
+from .machine import MachineValue, current_machine_builder
+
+
+def placeholder_opaque_t():
+    # Marks a phi-result slot in the rewritten AST; the real value is the phi
+    # built by yield_. Never inspected here.
+    return None
+
+
+class _MIRIfOp:
+    """Bookkeeping for one lowered if/else, emitting MIR blocks and G_PHIs."""
+
+    def __init__(self, cond):
+        b = current_machine_builder()
+        mf = b.machine_function
+        self.builder = b
+        self.entry_block = b.insert_block
+        self.then_block = mf.create_block()
+        self.merge_block = mf.create_block()
+        self.else_block = None
+        # G_BRCOND cond -> then, then a fall-through G_BR whose target starts at
+        # merge; else_ctx_manager repoints it to the else block.
+        b.build_brcond(cond.reg, self.then_block)
+        self.false_br = b.build_br(self.merge_block)
+        self.entry_block.add_successor(self.then_block)
+        self.entry_block.add_successor(self.merge_block)
+        self.then_vals = None
+        self.else_vals = None
+        self.then_pred = None
+        self.else_pred = None
+        self.active = "then"
+
+    def _terminate_current(self):
+        # A branch body never self-terminates (its trailing yield_ calls this),
+        # so the current block always branches to merge. Capture the real
+        # predecessor (b.insert_block), which nested control flow may have moved.
+        b = self.builder
+        pred = b.insert_block
+        b.build_br(self.merge_block)
+        pred.add_successor(self.merge_block)
+        return pred
+
+    def record_and_maybe_phi(self, values):
+        """Called by yield_. Record this branch's values; on the else branch
+        (both edges known) build the G_PHIs and return them."""
+        b = self.builder
+        if self.active == "then":
+            self.then_vals = list(values)
+            self.then_pred = self._terminate_current()
+            vals = list(values)
+            return vals[0] if len(vals) == 1 else tuple(vals)
+        # else branch: both edges known, build the phis at the merge block.
+        self.else_vals = list(values)
+        self.else_pred = self._terminate_current()
+        b.set_block(self.merge_block)
+        phis = []
+        for tv, ev in zip(self.then_vals, self.else_vals):
+            reg = b.build_phi(
+                tv.llt, [(tv.reg, self.then_pred), (ev.reg, self.else_pred)]
+            )
+            phis.append(MachineValue(reg, tv.llt))
+        return phis[0] if len(phis) == 1 else tuple(phis)
+
+
+_if_stack = []
+
+
+@contextmanager
+def if_ctx_manager(cond, results=()):
+    op = _MIRIfOp(cond)
+    _if_stack.append(op)
+    op.builder.set_block(op.then_block)
+    try:
+        yield op
+    finally:
+        _if_stack.pop()
+        op.builder.set_block(op.merge_block)
+
+
+@contextmanager
+def else_ctx_manager(op):
+    b = op.builder
+    op.else_block = b.machine_function.create_block()
+    # Repoint the entry's fall-through branch (and CFG edge) merge -> else.
+    op.entry_block.replace_successor(op.merge_block, op.else_block)
+    op.false_br.set_branch_target(op.else_block)
+    op.active = "else"
+    _if_stack.append(op)
+    b.set_block(op.else_block)
+    try:
+        yield op
+    finally:
+        _if_stack.pop()
+        b.set_block(op.merge_block)
+
+
+def yield_(*values):
+    return _if_stack[-1].record_and_maybe_phi(values)
+
+
+class _InjectMIRCFGlobals(FunctionPatcher):
+    def patch_function(self, f):
+        g = f.__globals__
+        g["yield_"] = yield_
+        g["if_ctx_manager"] = if_ctx_manager
+        g["else_ctx_manager"] = else_ctx_manager
+        g["placeholder_opaque_t"] = placeholder_opaque_t
+        return f
+
+
+class MIRCanonicalizer(Canonicalizer):
+    # if/else only for now (no loop transformers); mirrors LLVMCanonicalizer's
+    # if/else passes so the rewritten AST shape is identical.
+    cst_transformers = [
+        _T.RejectUnsupportedJumps,
+        _T.CanonicalizeElIfs,
+        _T.InsertEmptyYield,
+        _T.ReplaceYieldWithLLVMYield,
+        _T.ReplaceIfWithWith,
+    ]
+    function_patchers = [_InjectMIRCFGlobals]

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -197,3 +197,32 @@ def test_set_branch_target_on_non_branch_raises():
         with pytest.raises(ValueError):
             const_mi.set_branch_target(mf.create_block())
     assert_no_leaks()
+
+
+def test_replace_successor_requires_an_existing_successor():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        entry = mf.blocks[0]
+        a = mf.create_block()
+        b = mf.create_block()
+        # `a` is not a successor of entry yet -- replacing it is a no-op in
+        # LLVM's assert-only path (UB in release); guarded to raise.
+        with pytest.raises(ValueError, match="not a successor"):
+            entry.replace_successor(a, b)
+        # After adding the edge, the replacement succeeds.
+        entry.add_successor(a)
+        entry.replace_successor(a, b)
+    assert_no_leaks()
+
+
+def test_replace_successor_rejects_cross_function_block():
+    with ir.Context() as ctx:
+        mmi_f, mf = _new_function(ctx, "f")
+        mmi_g, mg = _new_function(ctx, "g")
+        entry = mf.blocks[0]
+        a = mf.create_block()
+        entry.add_successor(a)
+        foreign = mg.create_block()  # belongs to g
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            entry.replace_successor(a, foreign)
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -186,3 +186,14 @@ def test_cross_function_register_rejected():
         with pytest.raises(ValueError):
             bf.build_brcond(foreign, mf.blocks[0])
     assert_no_leaks()
+
+
+def test_set_branch_target_on_non_branch_raises():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        b = mir.MachineIRBuilder(mf)
+        b.build_constant(mir.LLT.scalar(32), 7)
+        const_mi = mf.blocks[0].instructions[0]
+        with pytest.raises(ValueError):
+            const_mi.set_branch_target(mf.create_block())
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
@@ -14,7 +14,12 @@ import pytest
 from llvm import ir, jit, mir
 from llvm.ast.canonicalize import canonicalize
 from llvm.dsl import machine_function
-from llvm.dsl.machine_cf import MIRCanonicalizer
+from llvm.dsl.machine_cf import (
+    MIRCanonicalizer,
+    if_ctx_manager,
+    else_ctx_manager,
+    yield_,
+)
 from llvm.testing import assert_no_leaks
 
 # Generic (G_*) control-flow MIR is target-independent; host target.
@@ -120,4 +125,210 @@ def test_if_else_with_two_carried_values_builds_two_phis():
             return x + y
 
         assert f.to_mir().count("G_PHI") == 2
+
+        # The branches yield (a, b) then (b, a) -- a classic swap. The two phis
+        # must route the values in that swapped order: whatever is phi0's
+        # then-value (operand 1) must be phi1's else-value (operand 3), and vice
+        # versa. A then/else swap or wrong-predecessor bug breaks this.
+        phis = [
+            i
+            for blk in f.machine_function.blocks
+            for i in blk.instructions
+            if i.opcode_name == "G_PHI"
+        ]
+        assert len(phis) == 2
+        p0, p1 = phis
+        assert p0.operand(1).reg.id == p1.operand(3).reg.id
+        assert p0.operand(3).reg.id == p1.operand(1).reg.id
+    assert_no_leaks()
+
+
+def test_nested_if_else_captures_moved_predecessor():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def f(a: s32, b: s32):
+            if a < b:
+                if b < a:
+                    r = yield a
+                else:
+                    r = yield b
+                s = yield r + a
+            else:
+                s = yield b
+            return s
+
+        # Outer + inner diamonds each build a phi; the outer phi's then-edge
+        # predecessor is the inner merge block (the builder moved), so this
+        # exercises the moved-predecessor capture.
+        assert f.to_mir().count("G_PHI") == 2
+        # entry + (inner then/else/merge) + (outer then-tail already = inner
+        # merge) + outer else + outer merge.
+        assert len(f.machine_function.blocks) >= 6
+    assert_no_leaks()
+
+
+def test_for_loop_in_body_is_rejected():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(NotImplementedError, match="`for` loops"):
+
+            @machine_function(module=mod, target=tm)
+            @canonicalize(using=MIRCanonicalizer())
+            def f(a: s32):
+                for _ in range(3):
+                    r = yield a + 1
+                return r
+
+    assert_no_leaks()
+
+
+def test_while_loop_in_body_is_rejected():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(NotImplementedError, match="`while` loops"):
+
+            @machine_function(module=mod, target=tm)
+            @canonicalize(using=MIRCanonicalizer())
+            def f(a: s32, b: s32):
+                while a < b:
+                    r = yield a + 1
+                return r
+
+    assert_no_leaks()
+
+
+def test_equality_is_python_identity_not_icmp():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            # `==`/`!=` are Python identity (documented), NOT a G_ICMP: two
+            # distinct MachineValues compare unequal, and no instruction is
+            # emitted. Value comparison is a.eq(b) / a.ne(b).
+            captured["eq"] = a == b
+            captured["ne"] = a != b
+
+        assert captured["eq"] is False
+        assert captured["ne"] is True
+        opcodes = [i.opcode_name for i in f.machine_function.blocks[0].instructions]
+        assert "G_ICMP" not in opcodes
+    assert_no_leaks()
+
+
+def test_unsigned_comparisons_build_g_icmp():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        i1 = mir.LLT.scalar(1)
+        cmps = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            cmps["ult"] = a.ult(b)
+            cmps["ule"] = a.ule(b)
+            cmps["ugt"] = a.ugt(b)
+            cmps["uge"] = a.uge(b)
+
+        assert all(v.llt == i1 for v in cmps.values())
+        opcodes = [i.opcode_name for i in f.machine_function.blocks[0].instructions]
+        assert opcodes.count("G_ICMP") == 4
+    assert_no_leaks()
+
+
+def test_reflected_comparison_produces_i1():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32):
+            captured["c"] = 1 < a  # int.__lt__ defers -> a.__gt__(1) -> SGT
+
+        assert captured["c"].llt == mir.LLT.scalar(1)
+    assert_no_leaks()
+
+
+def test_mismatched_comparison_types_raise():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32, s64 = mir.LLT.scalar(32), mir.LLT.scalar(64)
+
+        with pytest.raises(TypeError, match="mismatched types"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32, b: s64):
+                return a < b
+
+    assert_no_leaks()
+
+
+def test_mismatched_branch_arity_raises():
+    # Drive the if/else runtime directly (bypassing the canonicalizer) to feed
+    # branches that yield different numbers of values.
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(ValueError, match="different numbers of values"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32, b: s32):
+                with if_ctx_manager(a < b) as op:
+                    yield_(a, b)  # two values
+                with else_ctx_manager(op):
+                    yield_(b)  # one value
+
+    assert_no_leaks()
+
+
+def test_mismatched_branch_types_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32, s64 = mir.LLT.scalar(32), mir.LLT.scalar(64)
+
+        with pytest.raises(TypeError, match="mismatched types"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32, c: s64):
+                with if_ctx_manager(a < a) as op:
+                    yield_(a)  # s32
+                with else_ctx_manager(op):
+                    yield_(c)  # s64 -> phi type mismatch
+
+    assert_no_leaks()
+
+
+def test_yield_outside_if_body_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(RuntimeError, match="outside a lowered if/else"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                yield_(a)  # no active if op
+
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
@@ -1,0 +1,123 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""The generic-MIR if/else control-flow runtime.
+
+Mirrors the IR DSL's if/else lowering (llvm.dsl.cf) but emits MachineBasicBlocks
+and G_PHI through MachineIRBuilder. The same AST canonicalizer rewrites `if/else`
++ `yield` into if_ctx_manager/else_ctx_manager/yield_; only the injected runtime
+differs (MIRCanonicalizer).
+"""
+
+import pytest
+
+from llvm import ir, jit, mir
+from llvm.ast.canonicalize import canonicalize
+from llvm.dsl import machine_function
+from llvm.dsl.machine_cf import MIRCanonicalizer
+from llvm.testing import assert_no_leaks
+
+# Generic (G_*) control-flow MIR is target-independent; host target.
+_TRIPLE = None
+
+
+def test_if_else_builds_a_phi_diamond():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def f(a: s32, b: s32):
+            if a < b:
+                r = yield a + 1
+            else:
+                r = yield b
+            return r
+
+        text = f.to_mir()
+        assert "G_ICMP" in text
+        assert "G_BRCOND" in text
+        assert "G_PHI" in text
+        # entry, if.then, if.else, if.end
+        assert len(f.machine_function.blocks) == 4
+    assert_no_leaks()
+
+
+def test_if_without_else_has_no_phi():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def f(a: s32, b: s32):
+            if a < b:
+                r = yield a * b
+            return r
+
+        text = f.to_mir()
+        assert "G_BRCOND" in text
+        assert "G_PHI" not in text
+        # entry, if.then, if.end
+        assert len(f.machine_function.blocks) == 3
+    assert_no_leaks()
+
+
+def test_comparison_produces_i1():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            captured["c"] = a < b
+
+        assert captured["c"].llt == mir.LLT.scalar(1)
+    assert_no_leaks()
+
+
+def test_all_comparison_predicates_build_g_icmp():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        i1 = mir.LLT.scalar(1)
+        cmps = {}
+
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            cmps["lt"] = a < b
+            cmps["le"] = a <= b
+            cmps["gt"] = a > b
+            cmps["ge"] = a >= b
+            cmps["eq"] = a.eq(b)
+            cmps["ne"] = a.ne(b)
+
+        assert all(v.llt == i1 for v in cmps.values())
+        opcodes = [i.opcode_name for i in f.machine_function.blocks[0].instructions]
+        assert opcodes.count("G_ICMP") == 6
+    assert_no_leaks()
+
+
+def test_if_else_with_two_carried_values_builds_two_phis():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def f(a: s32, b: s32):
+            if a < b:
+                x, y = yield a, b
+            else:
+                x, y = yield b, a
+            return x + y
+
+        assert f.to_mir().count("G_PHI") == 2
+    assert_no_leaks()


### PR DESCRIPTION
Lower Python if/else in a @machine_function body to MachineBasicBlocks + G_PHI,
reusing the existing AST canonicalizer (llvm.ast) unchanged -- only the injected
runtime differs (MIRCanonicalizer). The MIR runtime (machine_cf._MIRIfOp) mirrors
the IR cf runtime: G_BRCOND cond->then plus a fall-through G_BR whose target is
repointed merge->else by else_ctx_manager (the MIR analogue of cond_br
set_successor), with yielded values becoming merge-block G_PHIs. Adds MachineValue
comparison operators (G_ICMP -> i1) and the supporting primitives (build_br
returns its instr, MachineInstr.set_branch_target, MachineBasicBlock.
replace_successor, MachineIRBuilder.machine_function).

Loops remain for a follow-up. Sixth PR in the MIR bindings/DSL stack.