### PR TITLE
[eudsl-llvmpy] Add generic-MIR for/while loop lowering

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -490,6 +490,13 @@ void populate_mir(nb::module_ &m) {
           "add_phi_incoming",
           [](llvm::MachineInstr &self, llvm::Register reg,
              llvm::MachineBasicBlock *mbb) {
+            // Appending (value, block) operands only makes sense for a G_PHI;
+            // on any other instruction it silently grows it with junk operands
+            // (malformed MIR, no verifier under NDEBUG).
+            if (self.getOpcode() != llvm::TargetOpcode::G_PHI) {
+              throw nb::value_error(
+                  "add_phi_incoming requires a G_PHI instruction");
+            }
             llvm::MachineFunction &mf = *self.getMF();
             self.addOperand(mf,
                             llvm::MachineOperand::CreateReg(reg,

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -486,6 +486,18 @@ void populate_mir(nb::module_ &m) {
           },
           "block"_a,
           "Repoint a branch's target block (operand 0), e.g. a G_BR.")
+      .def(
+          "add_phi_incoming",
+          [](llvm::MachineInstr &self, llvm::Register reg,
+             llvm::MachineBasicBlock *mbb) {
+            llvm::MachineFunction &mf = *self.getMF();
+            self.addOperand(mf,
+                            llvm::MachineOperand::CreateReg(reg,
+                                                            /*isDef=*/false));
+            self.addOperand(mf, llvm::MachineOperand::CreateMBB(mbb));
+          },
+          "value"_a, "block"_a,
+          "Append a (value, predecessor-block) incoming pair to a G_PHI.")
       .def("__str__",
            [](llvm::MachineInstr &self) { return eudsl::toString(self); });
 
@@ -959,7 +971,22 @@ void populate_mir(nb::module_ &m) {
             return res;
           },
           "type"_a, "incomings"_a,
-          "Build a G_PHI from (value, predecessor-block) pairs.");
+          "Build a G_PHI from (value, predecessor-block) pairs.")
+      .def(
+          "build_empty_phi",
+          [](llvm::MachineIRBuilder &self,
+             llvm::LLT ty) -> llvm::MachineInstr * {
+            llvm::Register res =
+                self.getMRI()->createGenericVirtualRegister(ty);
+            llvm::MachineInstrBuilder phi =
+                self.buildInstr(llvm::TargetOpcode::G_PHI);
+            phi.addDef(res);
+            return phi.getInstr();
+          },
+          "type"_a, nb::rv_policy::reference_internal,
+          "Build a G_PHI with only its def (of type `type`); add incomings "
+          "later "
+          "with MachineInstr.add_phi_incoming. Its def is operand 0.");
 
   // The innermost MachineIRBuilder entered as a context manager, mirroring the
   // IR module's current_builder(). Raises when there is none.

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
@@ -21,8 +21,9 @@ cond_br.set_successor. The values passed to yield_ become the merge block's
 G_PHIs, built on the else branch (when both incoming edges are known), so
 `r = yield_(...)` binds to the phi that `return r` uses.
 
-Only if/else is lowered here: a for/while in a @machine_function body is
-rejected (MIRCanonicalizer installs no loop transformers).
+Loops (for/while) lower the same way as llvm.dsl.cf._Loop: an inline
+preheader -> header(phis) -> body -> exit shape whose header G_PHIs carry the
+induction variable and loop-carried values.
 """
 
 from contextlib import contextmanager
@@ -152,6 +153,149 @@ def yield_(*values):
     return _if_stack[-1].record_and_maybe_phi(values)
 
 
+def _as_mv(x, witness):
+    """Coerce a Python int to a G_CONSTANT MachineValue of `witness`'s type;
+    pass a MachineValue through."""
+    if isinstance(x, MachineValue):
+        return x
+    reg = current_machine_builder().build_constant(witness.llt, int(x))
+    return MachineValue(reg, witness.llt)
+
+
+_loop_stack = []
+
+
+class _MIRLoop:
+    """A lowered for/while loop: preheader -> header(phis) -> body -> exit.
+
+    Mirrors llvm.dsl.cf._Loop with MIR blocks. The header's induction-variable
+    and loop-carried G_PHIs are built empty at the header top on __enter__ (so
+    they precede the loop condition) and seeded with the preheader incoming;
+    __exit__ adds their back-edge incoming from whatever block the body ended in
+    (nested control flow may have moved the builder) and parks the builder at the
+    exit block. The header phis are the loop-carried live-outs, exposed as
+    `.results`. The body stays inline, so control flow nested in it lowers
+    normally.
+    """
+
+    def __init__(
+        self, kind, *, start=None, stop=None, step=None, cond_fn=None, iter_args=()
+    ):
+        self.kind = kind
+        self.start = start
+        self.stop = stop
+        self.step = step
+        self.cond_fn = cond_fn
+        self.iter_args = list(iter_args)
+        self.next_carried = []
+        self.results = ()
+
+    def __enter__(self):
+        b = current_machine_builder()
+        mf = b.machine_function
+        self.builder = b
+        preheader = b.insert_block
+        self.header = mf.create_block()
+        body = mf.create_block()
+        self.exit_block = mf.create_block()
+        b.build_br(self.header)
+        preheader.add_successor(self.header)
+
+        b.set_block(self.header)
+        # The type witness is the first MachineValue among the bounds/carried
+        # inits; a loop with an int to coerce but no MachineValue has no LLT.
+        witness_candidates = list(self.iter_args)
+        if self.kind == "for":
+            witness_candidates = [self.start, self.stop] + witness_candidates
+        witness = next(
+            (c for c in witness_candidates if isinstance(c, MachineValue)), None
+        )
+
+        def coerce(x):
+            if witness is None and not isinstance(x, MachineValue):
+                raise NotImplementedError(
+                    "a DSL loop needs at least one MachineValue bound or "
+                    "loop-carried value to infer the LLT"
+                )
+            return _as_mv(x, witness)
+
+        self.iter_args = [coerce(a) for a in self.iter_args]
+
+        self.iv_phi = None
+        iv_val = None
+        if self.kind == "for":
+            start = coerce(self.start)
+            self.stop = coerce(self.stop)
+            self.iv_phi = b.build_empty_phi(start.llt)
+            self.iv_phi.add_phi_incoming(start.reg, preheader)
+            iv_val = MachineValue(self.iv_phi.operand(0).reg, start.llt)
+        self.carried_phis = []
+        carried_typed = []
+        for a in self.iter_args:
+            phi = b.build_empty_phi(a.llt)
+            phi.add_phi_incoming(a.reg, preheader)
+            self.carried_phis.append(phi)
+            carried_typed.append(MachineValue(phi.operand(0).reg, a.llt))
+        carried_typed = tuple(carried_typed)
+        self._iv_val = iv_val
+
+        if self.kind == "for":
+            descending = isinstance(self.step, int) and self.step < 0
+            cond = iv_val > self.stop if descending else iv_val < self.stop
+        else:
+            cond = self.cond_fn(*carried_typed)
+        b.build_brcond(cond.reg, body)
+        b.build_br(self.exit_block)
+        self.header.add_successor(body)
+        self.header.add_successor(self.exit_block)
+
+        b.set_block(body)
+        _loop_stack.append(self)
+        if self.kind == "for":
+            return (iv_val, carried_typed) if carried_typed else iv_val
+        return carried_typed
+
+    def __exit__(self, exc_type, exc, tb):
+        _loop_stack.pop()
+        if exc_type is not None:
+            return False
+        b = self.builder
+        body_end = b.insert_block  # nested control flow may have moved us
+        next_iv = self._iv_val + self.step if self.kind == "for" else None
+        b.build_br(self.header)
+        body_end.add_successor(self.header)
+        if self.kind == "for":
+            self.iv_phi.add_phi_incoming(next_iv.reg, body_end)
+        for phi, nxt in zip(self.carried_phis, self.next_carried):
+            phi.add_phi_incoming(nxt.reg, body_end)
+        b.set_block(self.exit_block)
+        self.results = tuple(
+            MachineValue(phi.operand(0).reg, arg.llt)
+            for phi, arg in zip(self.carried_phis, self.iter_args)
+        )
+        return False
+
+
+def loop_yield(*values):
+    """Record this iteration's updated carried values (the loop analogue of
+    yield_), read by _MIRLoop.__exit__ to wire the back-edge phi incomings."""
+    _loop_stack[-1].next_carried = list(values)
+
+
+def range_(start, stop=None, step=1, *, iter_args=()):
+    """`for i in range_(...)` loop builder; the AST transform supplies iter_args
+    and drives this via `with`."""
+    if stop is None:
+        start, stop = 0, start
+    return _MIRLoop("for", start=start, stop=stop, step=step, iter_args=iter_args)
+
+
+def while_(cond_fn, *, iter_args=()):
+    """`while COND` loop builder; the AST transform lifts COND into cond_fn
+    (evaluated in the header against the carried phis)."""
+    return _MIRLoop("while", cond_fn=cond_fn, iter_args=iter_args)
+
+
 class _InjectMIRCFGlobals(FunctionPatcher):
     def patch_function(self, f):
         g = f.__globals__
@@ -159,32 +303,20 @@ class _InjectMIRCFGlobals(FunctionPatcher):
         g["if_ctx_manager"] = if_ctx_manager
         g["else_ctx_manager"] = else_ctx_manager
         g["placeholder_opaque_t"] = placeholder_opaque_t
+        g["loop_yield"] = loop_yield
+        g["range_"] = range_
+        g["while_"] = while_
         return f
 
 
-class _RejectLoops(_T.StrictTransformer):
-    """This runtime lowers only if/else; a for/while would otherwise fall
-    through the canonicalizer untouched and silently unroll (a Python `range`)
-    or hang the trace (a truthy MachineValue condition). Reject it loudly."""
-
-    def visit_For(self, node):
-        raise NotImplementedError(
-            "`for` loops in a @machine_function body are not supported"
-        )
-
-    def visit_While(self, node):
-        raise NotImplementedError(
-            "`while` loops in a @machine_function body are not supported"
-        )
-
-
 class MIRCanonicalizer(Canonicalizer):
-    # if/else lowering; mirrors LLVMCanonicalizer's if/else passes so the
-    # rewritten AST shape is identical. _RejectLoops turns an unsupported
-    # for/while into a clear error instead of silently wrong MIR.
+    # Mirrors LLVMCanonicalizer's pass order: loops first (a loop's trailing
+    # yield becomes its carried values before the if/else passes turn remaining
+    # yields into yield_()), then the if/else lowering.
     cst_transformers = [
         _T.RejectUnsupportedJumps,
-        _RejectLoops,
+        _T.ForToInline,
+        _T.WhileToInline,
         _T.CanonicalizeElIfs,
         _T.InsertEmptyYield,
         _T.ReplaceYieldWithLLVMYield,

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 
 from ..ast import cf_transformers as _T
 from ..ast.canonicalize import Canonicalizer, FunctionPatcher
+from ..eudslllvm_ext.mir import LLT
 from .machine import MachineValue, current_machine_builder
 
 
@@ -173,9 +174,9 @@ class _MIRLoop:
     they precede the loop condition) and seeded with the preheader incoming;
     __exit__ adds their back-edge incoming from whatever block the body ended in
     (nested control flow may have moved the builder) and parks the builder at the
-    exit block. The header phis are the loop-carried live-outs, exposed as
-    `.results`. The body stays inline, so control flow nested in it lowers
-    normally.
+    exit block. The loop-carried phis (not the induction phi) are the live-outs,
+    exposed as `.results`. The body stays inline, so control flow nested in it
+    lowers normally.
     """
 
     def __init__(
@@ -240,10 +241,17 @@ class _MIRLoop:
         self._iv_val = iv_val
 
         if self.kind == "for":
-            descending = isinstance(self.step, int) and self.step < 0
+            # step is validated to be a nonzero int by range_(), so its sign
+            # reliably selects the compare direction.
+            descending = self.step < 0
             cond = iv_val > self.stop if descending else iv_val < self.stop
         else:
             cond = self.cond_fn(*carried_typed)
+            if not isinstance(cond, MachineValue) or cond.llt != LLT.scalar(1):
+                raise TypeError(
+                    "while condition must evaluate to an i1 MachineValue "
+                    "(e.g. a comparison like `a < b`)"
+                )
         b.build_brcond(cond.reg, body)
         b.build_br(self.exit_block)
         self.header.add_successor(body)
@@ -266,6 +274,11 @@ class _MIRLoop:
         body_end.add_successor(self.header)
         if self.kind == "for":
             self.iv_phi.add_phi_incoming(next_iv.reg, body_end)
+        if len(self.next_carried) != len(self.carried_phis):
+            raise ValueError(
+                f"loop body yielded {len(self.next_carried)} carried value(s) "
+                f"but the loop carries {len(self.carried_phis)}"
+            )
         for phi, nxt in zip(self.carried_phis, self.next_carried):
             phi.add_phi_incoming(nxt.reg, body_end)
         b.set_block(self.exit_block)
@@ -279,6 +292,8 @@ class _MIRLoop:
 def loop_yield(*values):
     """Record this iteration's updated carried values (the loop analogue of
     yield_), read by _MIRLoop.__exit__ to wire the back-edge phi incomings."""
+    if not _loop_stack:
+        raise RuntimeError("loop_yield used outside a loop body (no active loop)")
     _loop_stack[-1].next_carried = list(values)
 
 
@@ -287,6 +302,13 @@ def range_(start, stop=None, step=1, *, iter_args=()):
     and drives this via `with`."""
     if stop is None:
         start, stop = 0, start
+    # The step's sign selects the compare direction at trace time, so it must be
+    # a known int -- a MachineValue/float step can't pick a direction (and a
+    # float would silently truncate). A zero step never advances (infinite loop).
+    if not isinstance(step, int):
+        raise TypeError("range_ step must be an int")
+    if step == 0:
+        raise ValueError("range_ step must not be zero")
     return _MIRLoop("for", start=start, stop=stop, step=step, iter_args=iter_args)
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -226,3 +226,33 @@ def test_replace_successor_rejects_cross_function_block():
         with pytest.raises(ValueError, match="different MachineFunction"):
             entry.replace_successor(a, foreign)
     assert_no_leaks()
+
+
+def test_add_phi_incoming_requires_a_phi():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        b.build_constant(s32, 1)
+        const_mi = mf.blocks[0].instructions[0]  # a G_CONSTANT, not a G_PHI
+        with pytest.raises(ValueError, match="requires a G_PHI"):
+            const_mi.add_phi_incoming(
+                mf.create_generic_virtual_register(s32), mf.blocks[0]
+            )
+    assert_no_leaks()
+
+
+def test_build_empty_phi_then_add_incomings():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        pred = mf.blocks[0]
+        v = b.build_constant(s32, 1)
+        phi = b.build_empty_phi(s32)  # def-only
+        assert phi.opcode_name == "G_PHI"
+        assert phi.num_operands == 1  # just the def
+        phi.add_phi_incoming(v, pred)
+        assert phi.num_operands == 3  # def + (value, block)
+        assert phi.operand(1).reg.id == v.id
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_cf.py
@@ -172,42 +172,6 @@ def test_nested_if_else_captures_moved_predecessor():
     assert_no_leaks()
 
 
-def test_for_loop_in_body_is_rejected():
-    with ir.Context() as ctx:
-        mod = ir.Module("m", ctx)
-        tm = jit.TargetMachine(triple=_TRIPLE)
-        s32 = mir.LLT.scalar(32)
-
-        with pytest.raises(NotImplementedError, match="`for` loops"):
-
-            @machine_function(module=mod, target=tm)
-            @canonicalize(using=MIRCanonicalizer())
-            def f(a: s32):
-                for _ in range(3):
-                    r = yield a + 1
-                return r
-
-    assert_no_leaks()
-
-
-def test_while_loop_in_body_is_rejected():
-    with ir.Context() as ctx:
-        mod = ir.Module("m", ctx)
-        tm = jit.TargetMachine(triple=_TRIPLE)
-        s32 = mir.LLT.scalar(32)
-
-        with pytest.raises(NotImplementedError, match="`while` loops"):
-
-            @machine_function(module=mod, target=tm)
-            @canonicalize(using=MIRCanonicalizer())
-            def f(a: s32, b: s32):
-                while a < b:
-                    r = yield a + 1
-                return r
-
-    assert_no_leaks()
-
-
 def test_equality_is_python_identity_not_icmp():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_loops.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_loops.py
@@ -1,0 +1,101 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Generic-MIR loop lowering: for/while -> header G_PHIs.
+
+A `for i in range_(...)` / `while COND` in a @machine_function body lowers to a
+preheader -> header(phis) -> body -> exit shape, mirroring the IR DSL. Asserted
+on the printed MIR structure. The loop body's trailing `yield` is rewritten to
+the loop-carried update by the AST transformer.
+"""
+
+from llvm import ir, jit, mir
+from llvm.ast.canonicalize import canonicalize
+from llvm.dsl import machine_function
+from llvm.dsl.machine_cf import MIRCanonicalizer
+from llvm.testing import assert_no_leaks
+
+# Generic (G_*) MIR is target-independent; host target.
+_TRIPLE = None
+
+
+def test_for_loop_lowers_to_header_body_exit_with_phis():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def total(n: s32, acc: s32):
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            return acc
+
+        # entry (preheader), for.header, for.body, for.end
+        assert len(total.machine_function.blocks) == 4
+        text = total.to_mir()
+        assert "G_PHI" in text
+        assert "G_BRCOND" in text
+    assert_no_leaks()
+
+
+def test_while_loop_lowers_with_carried_phi():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def countdown(n: s32):
+            while n > 0:
+                n = n - 1
+                yield n
+            return n
+
+        assert len(countdown.machine_function.blocks) == 4
+        text = countdown.to_mir()
+        assert "G_PHI" in text
+        assert "G_ICMP" in text  # the while condition
+    assert_no_leaks()
+
+
+def test_for_loop_single_arg_range():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def total(n: s32, acc: s32):
+            for i in range_(n):  # single-arg form: 0..n
+                acc = acc + i
+                yield acc
+            return acc
+
+        assert len(total.machine_function.blocks) == 4
+        # 0..n ascending -> signed-less-than induction compare
+        assert "intpred(slt)" in total.to_mir()
+    assert_no_leaks()
+
+
+def test_for_loop_descending_step_compares_sgt():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def total(n: s32, acc: s32):
+            for i in range_(n, 0, -1):
+                acc = acc + i
+                yield acc
+            return acc
+
+        # A negative step makes the induction compare signed-greater-than.
+        assert "intpred(sgt)" in total.to_mir()
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_loops.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine_loops.py
@@ -12,11 +12,20 @@ the loop-carried update by the AST transformer.
 from llvm import ir, jit, mir
 from llvm.ast.canonicalize import canonicalize
 from llvm.dsl import machine_function
-from llvm.dsl.machine_cf import MIRCanonicalizer
+from llvm.dsl.machine_cf import MIRCanonicalizer, range_, while_, loop_yield
 from llvm.testing import assert_no_leaks
+
+import pytest
 
 # Generic (G_*) MIR is target-independent; host target.
 _TRIPLE = None
+
+
+def _header_phis(mf):
+    """The G_PHIs of the loop header (the block that has them)."""
+    return [
+        i for blk in mf.blocks for i in blk.instructions if i.opcode_name == "G_PHI"
+    ]
 
 
 def test_for_loop_lowers_to_header_body_exit_with_phis():
@@ -98,4 +107,207 @@ def test_for_loop_descending_step_compares_sgt():
 
         # A negative step makes the induction compare signed-greater-than.
         assert "intpred(sgt)" in total.to_mir()
+    assert_no_leaks()
+
+
+def test_induction_phi_has_two_incomings():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def total(n: s32, acc: s32):
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            return acc
+
+        # An induction phi and a carried (acc) phi, each with exactly two
+        # incomings: def + (preheader value, block) + (back-edge value, block).
+        phis = _header_phis(total.machine_function)
+        assert len(phis) == 2
+        for phi in phis:
+            assert phi.num_operands == 5  # def, v0, bb0, v1, bb1
+    assert_no_leaks()
+
+
+def test_loop_carried_result_is_the_header_phi():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        captured = {}
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def total(n: s32, acc: s32):
+            for i in range_(0, n):
+                acc = acc + i
+                yield acc
+            captured["acc_out"] = acc  # the loop's live-out carried value
+            return acc
+
+        # The value used after the loop is a carried header phi's def, so its
+        # register is one of the header phi defs (the back-edge was wired).
+        phi_defs = {p.operand(0).reg.id for p in _header_phis(total.machine_function)}
+        assert captured["acc_out"].reg.id in phi_defs
+    assert_no_leaks()
+
+
+def test_if_in_loop_body_wires_back_edge_from_moved_block():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        @machine_function(module=mod, target=tm)
+        @canonicalize(using=MIRCanonicalizer())
+        def f(n: s32, acc: s32):
+            for i in range_(0, n):
+                if i < n:
+                    acc = yield acc + i
+                else:
+                    acc = yield acc
+                yield acc
+            return acc
+
+        # The if inside the loop body moves the builder, so the back-edge
+        # predecessor is the if's merge block, not the loop body entry. It must
+        # still build valid MIR with the loop's carried phi present.
+        mf = f.machine_function
+        assert len(_header_phis(mf)) >= 1
+        assert len(mf.blocks) >= 6  # preheader, header, body+if diamond, exit
+    assert_no_leaks()
+
+
+def test_range_step_zero_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(ValueError, match="must not be zero"):
+
+            @machine_function(module=mod, target=tm)
+            @canonicalize(using=MIRCanonicalizer())
+            def f(n: s32, acc: s32):
+                for i in range_(0, n, 0):
+                    acc = acc + i
+                    yield acc
+                return acc
+
+    assert_no_leaks()
+
+
+def test_range_non_int_step_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(TypeError, match="step must be an int"):
+
+            @machine_function(module=mod, target=tm)
+            @canonicalize(using=MIRCanonicalizer())
+            def f(n: s32, acc: s32):
+                for i in range_(0, n, 1.5):
+                    acc = acc + i
+                    yield acc
+                return acc
+
+    assert_no_leaks()
+
+
+def test_loop_needs_a_machinevalue_for_llt():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        # All-int bounds and no carried MachineValue -> no LLT to infer from.
+        with pytest.raises(NotImplementedError, match="at least one MachineValue"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                with range_(0, 10):
+                    loop_yield()
+
+    assert_no_leaks()
+
+
+def test_while_condition_must_be_i1_machinevalue():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        # Drive while_ directly with a cond_fn that returns a non-MachineValue.
+        with pytest.raises(TypeError, match="i1 MachineValue"):
+
+            @machine_function(module=ir.Module("m1", ctx), target=tm)
+            def f(a: s32):
+                with while_(lambda c: 5, iter_args=(a,)):
+                    loop_yield(a)
+
+        # ...and one that returns a MachineValue of the wrong (non-i1) type.
+        with pytest.raises(TypeError, match="i1 MachineValue"):
+
+            @machine_function(module=ir.Module("m2", ctx), target=tm)
+            def g(a: s32):
+                with while_(lambda c: c, iter_args=(a,)):  # returns s32, not i1
+                    loop_yield(a)
+
+    assert_no_leaks()
+
+
+def test_loop_yield_outside_loop_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(RuntimeError, match="outside a loop body"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                loop_yield(a)
+
+    assert_no_leaks()
+
+
+def test_loop_carried_arity_mismatch_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        # Drive a loop directly, yielding fewer carried values than iter_args.
+        with pytest.raises(ValueError, match="carries 1"):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                with range_(0, a, iter_args=(a,)):
+                    loop_yield()  # zero carried values, but the loop carries 1
+
+    assert_no_leaks()
+
+
+def test_loop_body_exception_propagates_and_pops_stack():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        with pytest.raises(ZeroDivisionError):
+
+            @machine_function(module=mod, target=tm)
+            def f(a: s32):
+                with range_(0, a, iter_args=(a,)):
+                    raise ZeroDivisionError("boom")
+
+        # __exit__ popped the loop stack even though the body raised, so a
+        # later loop_yield reports "outside a loop body" rather than mis-firing.
+        with pytest.raises(RuntimeError, match="outside a loop body"):
+            loop_yield()
     assert_no_leaks()


### PR DESCRIPTION
Lower Python for/while in a @machine_function body to a preheader -> header
(phis) -> body -> exit MIR shape, mirroring llvm.dsl.cf._Loop with the same AST
transformers (ForToInline/WhileToInline, now enabled in MIRCanonicalizer). The
header's induction-variable and loop-carried G_PHIs are built empty at the block
top (build_empty_phi) so they precede the loop condition, seeded with the
preheader incoming, then given their back-edge incoming from the body's end
(MachineInstr.add_phi_incoming) -- the incremental-phi analogue of the IR
builder's phi + add_incoming. range_ (incl. single-arg and negative step) and
while_ factories + loop_yield complete the surface.

Seventh PR in the MIR bindings/DSL stack; completes Phase 2's control flow.