### PR TITLE
[eudsl-llvmpy] Add target-specific MIR construction (BuildMI + opcode lookup)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -122,6 +122,24 @@ void requireVReg(llvm::MachineIRBuilder &b, llvm::Register reg,
             .c_str());
 }
 
+// getInstrInfo() can be null for a target without one; real backends always
+// have it (these MachineFunctions come from create_machine_function/codegen
+// with a real subtarget), so this is purely defensive.
+const llvm::TargetInstrInfo &requireTII(const llvm::MachineFunction &mf) {
+  const llvm::TargetInstrInfo *tii = mf.getSubtarget().getInstrInfo();
+  if (!tii)
+    throw nb::value_error("target has no TargetInstrInfo"); // LCOV_EXCL_LINE
+  return *tii;
+}
+
+// MCInstrInfo::get/getName index an array bounded only by an assert (compiled
+// out under NDEBUG), so an out-of-range opcode would read out of bounds -- a
+// segfault or, worse, a silently-wrong name. Validate before indexing.
+void requireValidOpcode(const llvm::TargetInstrInfo &tii, unsigned opcode) {
+  if (opcode >= tii.getNumOpcodes())
+    throw nb::index_error("opcode number out of range");
+}
+
 // The "current MachineIRBuilder" is tracked on a thread-local stack, mirroring
 // the IR builder's `with builder:` / current_builder() mechanism (see the
 // thread_local ThreadContextEntry stack in IR/Builder.cpp). `with builder:`
@@ -651,10 +669,9 @@ void populate_mir(nb::module_ &m) {
       .def(
           "opcode",
           [](llvm::MachineFunction &self, const std::string &name) -> unsigned {
-            const llvm::TargetInstrInfo *tii =
-                self.getSubtarget().getInstrInfo();
-            for (unsigned i = 0, e = tii->getNumOpcodes(); i < e; ++i) {
-              if (tii->getName(i) == name)
+            const llvm::TargetInstrInfo &tii = requireTII(self);
+            for (unsigned i = 0, e = tii.getNumOpcodes(); i < e; ++i) {
+              if (tii.getName(i) == name)
                 return i;
             }
             throw nb::key_error(
@@ -665,7 +682,9 @@ void populate_mir(nb::module_ &m) {
       .def(
           "opcode_name",
           [](llvm::MachineFunction &self, unsigned opcode) {
-            return self.getSubtarget().getInstrInfo()->getName(opcode).str();
+            const llvm::TargetInstrInfo &tii = requireTII(self);
+            requireValidOpcode(tii, opcode);
+            return tii.getName(opcode).str();
           },
           "opcode"_a, "The mnemonic for a target opcode number.")
       .def("__str__",
@@ -1046,12 +1065,16 @@ void populate_mir(nb::module_ &m) {
           "build_instr",
           [](llvm::MachineIRBuilder &self,
              unsigned opcode) -> llvm::MachineInstr * {
+            requireValidOpcode(requireTII(self.getMF()), opcode);
             return self.buildInstr(opcode).getInstr();
           },
           "opcode"_a, nb::rv_policy::reference_internal,
           "Build and insert an empty instruction of the given opcode; append "
           "operands with MachineInstr.add_def/add_use/add_imm/add_mbb. The "
-          "BuildMI analogue for target-specific opcodes.");
+          "BuildMI analogue for target-specific opcodes. Like BuildMI, the "
+          "appended operands are not validated against the opcode's "
+          "MCInstrDesc (arity/kind/def-first order are the caller's "
+          "responsibility).");
 
   // The innermost MachineIRBuilder entered as a context manager, mirroring the
   // IR module's current_builder(). Raises when there is none.

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -505,6 +505,34 @@ void populate_mir(nb::module_ &m) {
           },
           "value"_a, "block"_a,
           "Append a (value, predecessor-block) incoming pair to a G_PHI.")
+      .def(
+          "add_def",
+          [](llvm::MachineInstr &self, llvm::Register reg) {
+            self.addOperand(*self.getMF(), llvm::MachineOperand::CreateReg(
+                                               reg, /*isDef=*/true));
+          },
+          "reg"_a, "Append a register def operand.")
+      .def(
+          "add_use",
+          [](llvm::MachineInstr &self, llvm::Register reg) {
+            self.addOperand(*self.getMF(), llvm::MachineOperand::CreateReg(
+                                               reg, /*isDef=*/false));
+          },
+          "reg"_a, "Append a register use operand.")
+      .def(
+          "add_imm",
+          [](llvm::MachineInstr &self, int64_t value) {
+            self.addOperand(*self.getMF(),
+                            llvm::MachineOperand::CreateImm(value));
+          },
+          "value"_a, "Append an immediate operand.")
+      .def(
+          "add_mbb",
+          [](llvm::MachineInstr &self, llvm::MachineBasicBlock *mbb) {
+            self.addOperand(*self.getMF(),
+                            llvm::MachineOperand::CreateMBB(mbb));
+          },
+          "block"_a, "Append a machine-basic-block operand.")
       .def("__str__",
            [](llvm::MachineInstr &self) { return eudsl::toString(self); });
 
@@ -620,6 +648,26 @@ void populate_mir(nb::module_ &m) {
           nb::rv_policy::reference_internal,
           "Append a new, empty MachineBasicBlock to the function, optionally "
           "linked to an IR BasicBlock for debug info/naming.")
+      .def(
+          "opcode",
+          [](llvm::MachineFunction &self, const std::string &name) -> unsigned {
+            const llvm::TargetInstrInfo *tii =
+                self.getSubtarget().getInstrInfo();
+            for (unsigned i = 0, e = tii->getNumOpcodes(); i < e; ++i) {
+              if (tii->getName(i) == name)
+                return i;
+            }
+            throw nb::key_error(
+                ("no target opcode named '" + name + "'").c_str());
+          },
+          "name"_a,
+          "Look up a target opcode number by mnemonic (e.g. \"ADDWrr\").")
+      .def(
+          "opcode_name",
+          [](llvm::MachineFunction &self, unsigned opcode) {
+            return self.getSubtarget().getInstrInfo()->getName(opcode).str();
+          },
+          "opcode"_a, "The mnemonic for a target opcode number.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -993,7 +1041,17 @@ void populate_mir(nb::module_ &m) {
           "type"_a, nb::rv_policy::reference_internal,
           "Build a G_PHI with only its def (of type `type`); add incomings "
           "later "
-          "with MachineInstr.add_phi_incoming. Its def is operand 0.");
+          "with MachineInstr.add_phi_incoming. Its def is operand 0.")
+      .def(
+          "build_instr",
+          [](llvm::MachineIRBuilder &self,
+             unsigned opcode) -> llvm::MachineInstr * {
+            return self.buildInstr(opcode).getInstr();
+          },
+          "opcode"_a, nb::rv_policy::reference_internal,
+          "Build and insert an empty instruction of the given opcode; append "
+          "operands with MachineInstr.add_def/add_use/add_imm/add_mbb. The "
+          "BuildMI analogue for target-specific opcodes.");
 
   // The innermost MachineIRBuilder entered as a context manager, mirroring the
   // IR module's current_builder(). Raises when there is none.

--- a/projects/eudsl-llvmpy/tests/mir/test_build_target.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_target.py
@@ -48,6 +48,25 @@ def test_unknown_opcode_name_raises():
     assert_no_leaks()
 
 
+def test_opcode_name_out_of_range_raises():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        # The number->name direction must validate like name->number does, not
+        # index out of bounds into an assert-only (NDEBUG) table.
+        with pytest.raises(IndexError):
+            mf.opcode_name(999999)
+    assert_no_leaks()
+
+
+def test_build_instr_out_of_range_opcode_raises():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        b = mir.MachineIRBuilder(mf)
+        with pytest.raises(IndexError):
+            b.build_instr(999999)
+    assert_no_leaks()
+
+
 def test_build_target_register_instruction():
     with ir.Context() as ctx:
         _, mf = _new_function(ctx)
@@ -62,8 +81,11 @@ def test_build_target_register_instruction():
         mi.add_use(y)
         assert mi.opcode_name == "ADDWrr"
         assert mi.num_operands == 3
-        assert mi.operand(0).is_def
-        assert mi.operand(1).is_use
+        # Operand identity and order: def d, then uses x, y in that order.
+        assert mi.operand(0).is_def and mi.operand(0).reg.id == d.id
+        assert mi.operand(1).is_use and mi.operand(1).reg.id == x.id
+        assert mi.operand(2).is_use and mi.operand(2).reg.id == y.id
+        assert "ADDWrr" in str(mi)
     assert_no_leaks()
 
 
@@ -77,6 +99,7 @@ def test_build_instruction_with_immediate():
         mi.add_def(d)
         mi.add_imm(42)
         assert mi.opcode_name == "MOVi32imm"
+        assert mi.operand(0).is_def and mi.operand(0).reg.id == d.id
         assert mi.operand(1).imm == 42
     assert_no_leaks()
 
@@ -88,6 +111,8 @@ def test_build_branch_with_mbb_operand():
         target = mf.create_block()
         mi = b.build_instr(mf.opcode("B"))  # AArch64 unconditional branch
         mi.add_mbb(target)
+        # Keep the CFG consistent with the terminator so the function verifies.
+        mf.blocks[0].add_successor(target)
         assert mi.opcode_name == "B"
         assert mi.num_operands == 1
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_build_target.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_target.py
@@ -1,0 +1,93 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Target-specific MIR: build real target opcodes via runtime name lookup.
+
+Target opcode enums (e.g. AArch64 ADDWrr) live in generated headers that are not
+installed with LLVM, so opcodes are resolved by name at runtime through the
+function's TargetInstrInfo. build_instr + the operand appenders are the BuildMI
+analogue for constructing an arbitrary target instruction.
+"""
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# Target-specific (AArch64 opcodes ADDWrr/MOVi32imm/B); needs the AArch64 backend.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+
+def _new_function(ctx):
+    mod = ir.Module("m", ctx)
+    tm = jit.TargetMachine(triple=_TRIPLE)
+    mmi = mir.create_machine_function(mod, tm, "f")
+    return mmi, mmi.machine_function("f")
+
+
+def test_opcode_name_round_trips():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        addwrr = mf.opcode("ADDWrr")
+        assert isinstance(addwrr, int) and addwrr > 0
+        assert mf.opcode_name(addwrr) == "ADDWrr"
+    assert_no_leaks()
+
+
+def test_unknown_opcode_name_raises():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        with pytest.raises(KeyError):
+            mf.opcode("NOT_A_REAL_OPCODE_XYZ")
+    assert_no_leaks()
+
+
+def test_build_target_register_instruction():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        d = mf.create_generic_virtual_register(s32)
+        x = mf.create_generic_virtual_register(s32)
+        y = mf.create_generic_virtual_register(s32)
+        mi = b.build_instr(mf.opcode("ADDWrr"))
+        mi.add_def(d)
+        mi.add_use(x)
+        mi.add_use(y)
+        assert mi.opcode_name == "ADDWrr"
+        assert mi.num_operands == 3
+        assert mi.operand(0).is_def
+        assert mi.operand(1).is_use
+    assert_no_leaks()
+
+
+def test_build_instruction_with_immediate():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        d = mf.create_generic_virtual_register(s32)
+        mi = b.build_instr(mf.opcode("MOVi32imm"))
+        mi.add_def(d)
+        mi.add_imm(42)
+        assert mi.opcode_name == "MOVi32imm"
+        assert mi.operand(1).imm == 42
+    assert_no_leaks()
+
+
+def test_build_branch_with_mbb_operand():
+    with ir.Context() as ctx:
+        _, mf = _new_function(ctx)
+        b = mir.MachineIRBuilder(mf)
+        target = mf.create_block()
+        mi = b.build_instr(mf.opcode("B"))  # AArch64 unconditional branch
+        mi.add_mbb(target)
+        assert mi.opcode_name == "B"
+        assert mi.num_operands == 1
+    assert_no_leaks()


### PR DESCRIPTION
Build real target instructions (e.g. AArch64 ADDWrr) without the generated
target opcode enums, which are not installed with LLVM: MachineFunction.opcode
resolves an opcode number by mnemonic through the function's TargetInstrInfo
(and opcode_name inverts it). MachineIRBuilder.build_instr(opcode) is the
BuildMI analogue -- it inserts an empty instruction whose operands are then
appended with MachineInstr.add_def/add_use/add_imm/add_mbb.

Eighth PR in the MIR bindings/DSL stack; first half of Phase 3.