### PR TITLE
[eudsl-llvmpy] Run the GlobalISel pipeline + expose the machine verifier

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Target.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Target.cpp
@@ -76,6 +76,12 @@ void populate_target(nb::module_ &m) {
                    [](llvm::TargetMachine &self) {
                      return self.createDataLayout().getStringRepresentation();
                    })
+      .def_prop_ro(
+          "global_isel",
+          [](llvm::TargetMachine &self) -> bool {
+            return self.Options.EnableGlobalISel;
+          },
+          "Whether instruction selection uses GlobalISel (vs SelectionDAG).")
       .def(
           "emit_assembly",
           [](llvm::TargetMachine &self, eudsl::Module &mod) {

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -32,6 +32,7 @@
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
 
 #include <nanobind/stl/pair.h>
 
@@ -687,6 +688,15 @@ void populate_mir(nb::module_ &m) {
             return tii.getName(opcode).str();
           },
           "opcode"_a, "The mnemonic for a target opcode number.")
+      .def(
+          "verify",
+          [](llvm::MachineFunction &self) {
+            std::string buf;
+            llvm::raw_string_ostream os(buf);
+            return self.verify(/*p=*/nullptr, /*Banner=*/nullptr, &os,
+                               /*AbortOnError=*/false);
+          },
+          "Run the machine verifier; returns True if no problems were found.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -736,14 +746,22 @@ void populate_mir(nb::module_ &m) {
   // passes are added -- not the object-emission pipeline (addPassesToEmitFile),
   // which would append FreeMachineFunctionPass -- so the MachineFunctions are
   // retained for inspection, the state `llc -stop-after=finalize-isel`
-  // produces.
+  // produces. With global_isel=True the ISel passes are the GlobalISel pipeline
+  // (IRTranslator -> Legalizer -> RegBankSelect -> InstructionSelect), so the
+  // retained MIR is fully selected target MIR rather than SelectionDAG output;
+  // DisableWithDiag keeps a legalization failure from aborting the process.
   m.def(
       "run_codegen_to_mir",
-      [](eudsl::Module &mod, llvm::TargetMachine &tm) {
+      [](eudsl::Module &mod, llvm::TargetMachine &tm, bool globalISel) {
         std::shared_ptr<llvm::LLVMContext> ctxKeepAlive =
             mod.context().shared();
         std::unique_ptr<llvm::Module> module = mod.take();
         module->setDataLayout(tm.createDataLayout());
+
+        if (globalISel) {
+          tm.setGlobalISel(true);
+          tm.setGlobalISelAbort(llvm::GlobalISelAbortMode::DisableWithDiag);
+        }
 
         auto pm = std::make_unique<llvm::legacy::PassManager>();
         llvm::TargetPassConfig *tpc = tm.createPassConfig(*pm);
@@ -778,7 +796,8 @@ void populate_mir(nb::module_ &m) {
                                      std::move(pm), /*ownedMmi=*/nullptr,
                                      &mmiwp->getMMI()};
       },
-      "module"_a, "target_machine"_a, nb::keep_alive<0, 2>());
+      "module"_a, "target_machine"_a, "global_isel"_a = false,
+      nb::keep_alive<0, 2>());
 
   // Parse .mir text into a MachineModuleInfo. Mirrors run_codegen_to_mir's
   // result but builds the MachineFunctions by deserialization rather than

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -691,12 +691,21 @@ void populate_mir(nb::module_ &m) {
       .def(
           "verify",
           [](llvm::MachineFunction &self) {
-            std::string buf;
-            llvm::raw_string_ostream os(buf);
-            return self.verify(/*p=*/nullptr, /*Banner=*/nullptr, &os,
-                               /*AbortOnError=*/false);
+            return self.verify(/*p=*/nullptr, /*Banner=*/nullptr,
+                               /*OS=*/nullptr, /*AbortOnError=*/false);
           },
           "Run the machine verifier; returns True if no problems were found.")
+      .def(
+          "verify_diagnostic",
+          [](llvm::MachineFunction &self) {
+            std::string buf;
+            llvm::raw_string_ostream os(buf);
+            self.verify(/*p=*/nullptr, /*Banner=*/nullptr, &os,
+                        /*AbortOnError=*/false);
+            return buf;
+          },
+          "Run the machine verifier and return its report -- an empty string "
+          "if the MIR is well-formed, else the verifier's explanation.")
       .def("__str__",
            [](llvm::MachineFunction &self) { return eudsl::toString(self); });
 
@@ -748,8 +757,9 @@ void populate_mir(nb::module_ &m) {
   // retained for inspection, the state `llc -stop-after=finalize-isel`
   // produces. With global_isel=True the ISel passes are the GlobalISel pipeline
   // (IRTranslator -> Legalizer -> RegBankSelect -> InstructionSelect), so the
-  // retained MIR is fully selected target MIR rather than SelectionDAG output;
-  // DisableWithDiag keeps a legalization failure from aborting the process.
+  // retained MIR is fully target-selected when selection succeeds;
+  // DisableWithDiag keeps a legalization failure from aborting the process, and
+  // a post-run scan turns a resulting residual generic op into an exception.
   m.def(
       "run_codegen_to_mir",
       [](eudsl::Module &mod, llvm::TargetMachine &tm, bool globalISel) {
@@ -758,10 +768,13 @@ void populate_mir(nb::module_ &m) {
         std::unique_ptr<llvm::Module> module = mod.take();
         module->setDataLayout(tm.createDataLayout());
 
-        if (globalISel) {
-          tm.setGlobalISel(true);
-          tm.setGlobalISelAbort(llvm::GlobalISelAbortMode::DisableWithDiag);
-        }
+        // Set both flags on every call (the tm is caller-owned and reused), so
+        // the selection mode is a pure function of `globalISel` and doesn't
+        // stick from a prior global_isel=True call.
+        tm.setGlobalISel(globalISel);
+        tm.setGlobalISelAbort(globalISel
+                                  ? llvm::GlobalISelAbortMode::DisableWithDiag
+                                  : llvm::GlobalISelAbortMode::Enable);
 
         auto pm = std::make_unique<llvm::legacy::PassManager>();
         llvm::TargetPassConfig *tpc = tm.createPassConfig(*pm);
@@ -791,6 +804,29 @@ void populate_mir(nb::module_ &m) {
               withDetail("instruction selection failed", diag));
         }
         // LCOV_EXCL_STOP
+
+        // GlobalISel with DisableWithDiag emits its fallback diagnostic as a
+        // warning (not captured above) and leaves residual generic (G_*) ops
+        // rather than aborting. Scan for them so an incompletely-selected
+        // function is reported instead of returned as if fully selected.
+        if (globalISel) {
+          for (llvm::Function &f : *module) {
+            llvm::MachineFunction *mf = mmiwp->getMMI().getMachineFunction(f);
+            if (!mf)
+              continue;
+            for (llvm::MachineBasicBlock &mbb : *mf) {
+              for (llvm::MachineInstr &mi : mbb) {
+                // LCOV_EXCL_START -- needs an un-selectable input to trigger
+                if (llvm::isPreISelGenericOpcode(mi.getOpcode())) {
+                  throw std::runtime_error(
+                      "GlobalISel did not fully select the module (a generic "
+                      "G_* instruction remains)");
+                }
+                // LCOV_EXCL_STOP
+              }
+            }
+          }
+        }
 
         return new MachineModuleInfo{std::move(ctxKeepAlive), std::move(module),
                                      std::move(pm), /*ownedMmi=*/nullptr,

--- a/projects/eudsl-llvmpy/tests/mir/test_mir_passes.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_mir_passes.py
@@ -40,6 +40,27 @@ _ADD_SRC = dedent("""\
 _TRIPLE = "aarch64-unknown-linux-gnu"
 
 
+def test_global_isel_skips_declared_functions():
+    with ir.Context() as ctx:
+        # A declaration has no body -> no MachineFunction; the post-run
+        # residual-generic scan must skip it and still select the definition.
+        src = dedent("""\
+            declare i32 @ext()
+            define i32 @add(i32 %a, i32 %b) {
+              %s = add i32 %a, %b
+              ret i32 %s
+            }
+            """)
+        mod = ir.parse_assembly(src, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm, global_isel=True)
+        opcodes = [
+            i.opcode_name for i in mmi.machine_function("add").blocks[0].instructions
+        ]
+        assert "ADDWrr" in opcodes
+    assert_no_leaks()
+
+
 def test_global_isel_selects_target_instructions():
     with ir.Context() as ctx:
         mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
@@ -82,5 +103,52 @@ def test_incomplete_generic_function_does_not_verify():
         def f(a: s32, b: s32):
             return a + b
 
-        assert f.machine_function.verify() is False
+        mf = f.machine_function
+        assert mf.verify() is False
+        # verify_diagnostic surfaces *why* (the detail verify() throws away).
+        diag = mf.verify_diagnostic()
+        assert diag != ""
+        assert "Bad machine code" in diag or "not defined" in diag.lower()
+    assert_no_leaks()
+
+
+def test_verify_diagnostic_empty_when_well_formed():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm)
+        mf = mmi.machine_function("add")
+        assert mf.verify() is True
+        assert mf.verify_diagnostic() == ""
+    assert_no_leaks()
+
+
+def test_global_isel_flag_is_not_sticky_on_reused_target_machine():
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        # global_isel is a pure function of the argument on each call, so a
+        # global_isel=True run does not leave the shared TargetMachine in
+        # GlobalISel mode for a subsequent default (SelectionDAG) run.
+        mir.run_codegen_to_mir(
+            ir.parse_assembly(_ADD_SRC, ctx, "m1"), tm, global_isel=True
+        )
+        assert tm.global_isel is True
+        mir.run_codegen_to_mir(
+            ir.parse_assembly(_ADD_SRC, ctx, "m2"), tm, global_isel=False
+        )
+        assert tm.global_isel is False
+        mir.run_codegen_to_mir(ir.parse_assembly(_ADD_SRC, ctx, "m3"), tm)  # default
+        assert tm.global_isel is False
+    assert_no_leaks()
+
+
+def test_global_isel_verified_mir_survives_mir_roundtrip():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        text = mir.run_codegen_to_mir(mod, tm, global_isel=True).to_mir()
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.parse_mir(text, ctx, tm)
+        assert mmi.machine_function("add").verify() is True
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_mir_passes.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_mir_passes.py
@@ -1,0 +1,86 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Running MIR passes: the GlobalISel lowering pipeline and the verifier.
+
+run_codegen_to_mir(global_isel=True) runs the GlobalISel pipeline (IRTranslator
+-> Legalizer -> RegBankSelect -> InstructionSelect) instead of SelectionDAG ISel,
+so the retained MIR is fully selected target MIR. MachineFunction.verify runs the
+machine verifier on any MIR, returning whether it is well-formed.
+
+(Running individual GlobalISel passes on DSL-built generic MIR is not exposed:
+the pass factories and an MMI-injecting pass ctor are not in the installed LLVM
+headers, so lowering hand-built MIR would need those. Lowering from IR via the
+pipeline above is the supported route.)
+"""
+
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.dsl import machine_function
+from llvm.testing import assert_no_leaks
+
+# Target-specific (AArch64 GISel selection to ADDWrr, etc.); needs the backend.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_ADD_SRC = dedent("""\
+    define i32 @add(i32 %a, i32 %b) {
+    entry:
+      %s = add i32 %a, %b
+      ret i32 %s
+    }
+    """)
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+
+def test_global_isel_selects_target_instructions():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm, global_isel=True)
+        opcodes = [
+            i.opcode_name for i in mmi.machine_function("add").blocks[0].instructions
+        ]
+        assert "ADDWrr" in opcodes
+        assert "RET_ReallyLR" in opcodes
+    assert_no_leaks()
+
+
+def test_globally_selected_mir_verifies():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm, global_isel=True)
+        assert mmi.machine_function("add").verify() is True
+    assert_no_leaks()
+
+
+def test_selection_dag_selected_mir_verifies():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_SRC, ctx, "m")
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.run_codegen_to_mir(mod, tm)  # default SelectionDAG ISel
+        assert mmi.machine_function("add").verify() is True
+    assert_no_leaks()
+
+
+def test_incomplete_generic_function_does_not_verify():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+
+        # Uses of the parameter vregs that are never defined -> not well-formed.
+        @machine_function(module=mod, target=tm)
+        def f(a: s32, b: s32):
+            return a + b
+
+        assert f.machine_function.verify() is False
+    assert_no_leaks()


### PR DESCRIPTION
run_codegen_to_mir gains global_isel=: when set it runs the GlobalISel lowering
pipeline (IRTranslator -> Legalizer -> RegBankSelect -> InstructionSelect) rather
than SelectionDAG ISel, so the retained MIR is fully selected target MIR
(DisableWithDiag keeps a legalization fallback from aborting). MachineFunction.
verify runs the machine verifier (non-aborting), returning whether the MIR is
well-formed.

Running individual GlobalISel passes on DSL-built generic MIR is intentionally
not exposed: the pass factories and an MMI-injecting pass ctor are absent from
the installed LLVM headers, so lowering from IR via the pipeline is the route.

Ninth PR in the MIR bindings/DSL stack; completes Phase 3.