### PR TITLE
[eudsl-llvmpy] Build already-selected target MIR by hand (Route B foundation)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -142,6 +142,46 @@ void requireValidOpcode(const llvm::TargetInstrInfo &tii, unsigned opcode) {
     throw nb::index_error("opcode number out of range");
 }
 
+// getRegisterInfo() can be null for a target without one; real backends always
+// have it (these MachineFunctions come from create_machine_function/codegen
+// with a real subtarget), so this is purely defensive (mirrors requireTII).
+const llvm::TargetRegisterInfo &requireTRI(const llvm::MachineFunction &mf) {
+  const llvm::TargetRegisterInfo *tri = mf.getSubtarget().getRegisterInfo();
+  if (!tri)
+    throw nb::value_error("target has no TargetRegisterInfo"); // LCOV_EXCL_LINE
+  return *tri;
+}
+
+// Shared register-operand construction for add_def/add_use/add_reg, so the
+// "same operation with defaults" invariant lives in one place rather than in
+// three parallel CreateReg calls. Rejects flags that LLVM only permits on the
+// opposite operand kind (kill on a use, dead on a def) and out-of-range
+// subregister indices -- all guarded by asserts in LLVM that vanish under
+// NDEBUG, so an otherwise-silent corrupt operand would result.
+void addRegOperand(llvm::MachineInstr &mi, llvm::Register reg, bool isDef,
+                   bool isImp, bool isKill, bool isDead, bool isUndef,
+                   bool isEarlyClobber, unsigned subReg, bool isDebug,
+                   bool isInternalRead, bool isRenamable) {
+  if (isKill && isDef)
+    throw nb::value_error(
+        "is_kill is only valid on a use operand (is_def=False)");
+  if (isDead && !isDef)
+    throw nb::value_error(
+        "is_dead is only valid on a def operand (is_def=True)");
+  if (isRenamable && !reg.isPhysical())
+    throw nb::value_error("is_renamable is only valid on a physical register");
+  llvm::MachineFunction &mf = *mi.getMF();
+  if (subReg) {
+    const llvm::TargetRegisterInfo &tri = requireTRI(mf);
+    if (subReg >= tri.getNumSubRegIndices())
+      throw nb::index_error("sub_reg index out of range");
+  }
+  mi.addOperand(mf,
+                llvm::MachineOperand::CreateReg(
+                    reg, isDef, isImp, isKill, isDead, isUndef, isEarlyClobber,
+                    subReg, isDebug, isInternalRead, isRenamable));
+}
+
 // The "current MachineIRBuilder" is tracked on a thread-local stack, mirroring
 // the IR builder's `with builder:` / current_builder() mechanism (see the
 // thread_local ThreadContextEntry stack in IR/Builder.cpp). `with builder:`
@@ -287,10 +327,12 @@ void populate_mir(nb::module_ &m) {
   // already-selected MIR.
   nb::class_<llvm::TargetRegisterClass>(m, "TargetRegisterClass");
 
-  // MachineFunctionProperties::Property -- the pipeline-stage flags a
-  // MachineFunction carries (set with MachineFunction.set_property). Building
-  // already-selected MIR by hand means setting these to match what the
-  // corresponding codegen stage would have produced (e.g. IsSSA).
+  // MachineFunctionProperties::Property -- the flags a MachineFunction carries
+  // (set with MachineFunction.set_property). Some mark progress through the
+  // codegen pipeline (Legalized, RegBankSelected, Selected) and some are
+  // descriptive invariants of the current body (IsSSA, NoPHIs, TracksLiveness,
+  // NoVRegs). Building already-selected MIR by hand means setting these to
+  // match what the corresponding codegen stage would have produced.
   nb::enum_<llvm::MachineFunctionProperties::Property>(
       m, "MachineFunctionProperty")
       .value("IsSSA", llvm::MachineFunctionProperties::Property::IsSSA)
@@ -318,6 +360,37 @@ void populate_mir(nb::module_ &m) {
       .def_prop_ro("is_use",
                    [](llvm::MachineOperand &self) {
                      return self.isReg() && self.isUse();
+                   })
+      .def_prop_ro("is_implicit",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isImplicit();
+                   })
+      .def_prop_ro("is_kill",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isKill();
+                   })
+      .def_prop_ro("is_dead",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isDead();
+                   })
+      .def_prop_ro("is_undef",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isUndef();
+                   })
+      .def_prop_ro("is_early_clobber",
+                   [](llvm::MachineOperand &self) {
+                     return self.isReg() && self.isEarlyClobber();
+                   })
+      .def_prop_ro("is_renamable",
+                   [](llvm::MachineOperand &self) {
+                     // isRenamable() asserts a physical register (renamable is
+                     // a post-RA physreg concept), so guard on that too.
+                     return self.isReg() && self.getReg().isPhysical() &&
+                            self.isRenamable();
+                   })
+      .def_prop_ro("sub_reg",
+                   [](llvm::MachineOperand &self) -> unsigned {
+                     return self.isReg() ? self.getSubReg() : 0;
                    })
       .def_prop_ro("reg",
                    [](llvm::MachineOperand &self) -> llvm::Register {
@@ -549,36 +622,43 @@ void populate_mir(nb::module_ &m) {
       .def(
           "add_def",
           [](llvm::MachineInstr &self, llvm::Register reg) {
-            self.addOperand(*self.getMF(), llvm::MachineOperand::CreateReg(
-                                               reg, /*isDef=*/true));
+            addRegOperand(self, reg, /*isDef=*/true, /*isImp=*/false,
+                          /*isKill=*/false, /*isDead=*/false, /*isUndef=*/false,
+                          /*isEarlyClobber=*/false, /*subReg=*/0,
+                          /*isDebug=*/false, /*isInternalRead=*/false,
+                          /*isRenamable=*/false);
           },
           "reg"_a, "Append a register def operand.")
       .def(
           "add_use",
           [](llvm::MachineInstr &self, llvm::Register reg, bool implicit) {
-            self.addOperand(*self.getMF(), llvm::MachineOperand::CreateReg(
-                                               reg, /*isDef=*/false, implicit));
+            addRegOperand(self, reg, /*isDef=*/false, /*isImp=*/implicit,
+                          /*isKill=*/false, /*isDead=*/false, /*isUndef=*/false,
+                          /*isEarlyClobber=*/false, /*subReg=*/0,
+                          /*isDebug=*/false, /*isInternalRead=*/false,
+                          /*isRenamable=*/false);
           },
-          "reg"_a, "implicit"_a = false, "Append a register use operand.")
+          "reg"_a, "implicit"_a = false,
+          "Append a register use operand (implicit=True for an implicit use).")
       .def(
           "add_reg",
           [](llvm::MachineInstr &self, llvm::Register reg, bool isDef,
              bool isImp, bool isKill, bool isDead, bool isUndef,
-             bool isEarlyClobber, unsigned subReg, bool isRenamable) {
-            self.addOperand(*self.getMF(),
-                            llvm::MachineOperand::CreateReg(
-                                reg, isDef, isImp, isKill, isDead, isUndef,
-                                isEarlyClobber, subReg, /*isDebug=*/false,
-                                /*isInternalRead=*/false, isRenamable));
+             bool isEarlyClobber, unsigned subReg, bool isDebug,
+             bool isInternalRead, bool isRenamable) {
+            addRegOperand(self, reg, isDef, isImp, isKill, isDead, isUndef,
+                          isEarlyClobber, subReg, isDebug, isInternalRead,
+                          isRenamable);
           },
           "reg"_a, "is_def"_a = false, "implicit"_a = false,
           "is_kill"_a = false, "is_dead"_a = false, "is_undef"_a = false,
-          "is_early_clobber"_a = false, "sub_reg"_a = 0,
-          "is_renamable"_a = false,
+          "is_early_clobber"_a = false, "sub_reg"_a = 0, "is_debug"_a = false,
+          "is_internal_read"_a = false, "is_renamable"_a = false,
           "Append a register operand, exposing the full MachineOperand "
-          "register "
-          "flag set (def/use, implicit, kill, dead, undef, early-clobber, "
-          "sub-register, renamable).")
+          "register flag set (def/use, implicit, kill, dead, undef, "
+          "early-clobber, sub-register, debug, internal-read, renamable). "
+          "is_kill is only valid on a use, is_dead only on a def, and "
+          "is_renamable only on a physical register.")
       .def(
           "add_imm",
           [](llvm::MachineInstr &self, int64_t value) {
@@ -665,6 +745,11 @@ void populate_mir(nb::module_ &m) {
       .def(
           "add_livein",
           [](llvm::MachineBasicBlock &self, llvm::Register reg) {
+            // asMCReg() only asserts physicality (compiled out under NDEBUG),
+            // so a virtual register would be truncated into a garbage
+            // MCRegister and recorded as a bogus livein. Reject it here.
+            if (!reg.isPhysical())
+              throw nb::value_error("add_livein requires a physical register");
             self.addLiveIn(reg.asMCReg());
           },
           "reg"_a, "Declare a physical register live-in to this block.")
@@ -706,27 +791,26 @@ void populate_mir(nb::module_ &m) {
           "reg_class",
           [](llvm::MachineFunction &self,
              const std::string &name) -> const llvm::TargetRegisterClass * {
-            const llvm::TargetRegisterInfo *tri =
-                self.getSubtarget().getRegisterInfo();
-            for (unsigned i = 0, e = tri->getNumRegClasses(); i < e; ++i) {
-              const llvm::TargetRegisterClass *rc = tri->getRegClass(i);
-              if (name == tri->getRegClassName(
-                              &tri->MCRegisterInfo::getRegClass(rc->getID())))
+            const llvm::TargetRegisterInfo &tri = requireTRI(self);
+            for (unsigned i = 0, e = tri.getNumRegClasses(); i < e; ++i) {
+              const llvm::TargetRegisterClass *rc = tri.getRegClass(i);
+              if (name == tri.getRegClassName(
+                              &tri.MCRegisterInfo::getRegClass(rc->getID()))) {
                 return rc;
+              }
             }
             throw nb::key_error(
                 ("no target register class named '" + name + "'").c_str());
           },
-          "name"_a, nb::rv_policy::reference_internal,
+          "name"_a, nb::rv_policy::reference,
           "Look up a target register class by name (e.g. \"GPR32\").")
       .def(
           "physreg",
           [](llvm::MachineFunction &self,
              const std::string &name) -> llvm::Register {
-            const llvm::TargetRegisterInfo *tri =
-                self.getSubtarget().getRegisterInfo();
-            for (unsigned i = 1, e = tri->getNumRegs(); i < e; ++i) {
-              if (name == tri->getName(i))
+            const llvm::TargetRegisterInfo &tri = requireTRI(self);
+            for (unsigned i = 1, e = tri.getNumRegs(); i < e; ++i) {
+              if (name == tri.getName(i))
                 return llvm::Register(i);
             }
             throw nb::key_error(
@@ -747,7 +831,22 @@ void populate_mir(nb::module_ &m) {
              llvm::MachineFunctionProperties::Property prop) {
             self.getProperties().set(prop);
           },
-          "property"_a, "Set a MachineFunctionProperties flag.")
+          "property"_a,
+          "Set a MachineFunctionProperties flag. Warning: this asserts, it "
+          "does "
+          "not request -- the machine verifier trusts these flags and chooses "
+          "which invariant classes to enforce from them (e.g. liveness is only "
+          "checked when TracksLiveness is set), so setting a flag the MIR does "
+          "not actually satisfy can make verify() pass on malformed MIR.")
+      .def(
+          "has_property",
+          [](llvm::MachineFunction &self,
+             llvm::MachineFunctionProperties::Property prop) {
+            return self.getProperties().hasProperty(prop);
+          },
+          "property"_a,
+          "Whether a MachineFunctionProperties flag is set (read side of "
+          "set_property).")
       .def(
           "create_block",
           [](llvm::MachineFunction &self,

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -18,6 +18,7 @@
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
+#include <llvm/CodeGen/TargetRegisterInfo.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
 #include <llvm/IR/BasicBlock.h>
@@ -281,6 +282,27 @@ void populate_mir(nb::module_ &m) {
         return static_cast<Py_ssize_t>(self.id());
       });
 
+  // A target register class (e.g. AArch64 GPR32), looked up by name via
+  // MachineFunction.reg_class. Opaque handle used when creating typed vregs for
+  // already-selected MIR.
+  nb::class_<llvm::TargetRegisterClass>(m, "TargetRegisterClass");
+
+  // MachineFunctionProperties::Property -- the pipeline-stage flags a
+  // MachineFunction carries (set with MachineFunction.set_property). Building
+  // already-selected MIR by hand means setting these to match what the
+  // corresponding codegen stage would have produced (e.g. IsSSA).
+  nb::enum_<llvm::MachineFunctionProperties::Property>(
+      m, "MachineFunctionProperty")
+      .value("IsSSA", llvm::MachineFunctionProperties::Property::IsSSA)
+      .value("NoPHIs", llvm::MachineFunctionProperties::Property::NoPHIs)
+      .value("TracksLiveness",
+             llvm::MachineFunctionProperties::Property::TracksLiveness)
+      .value("NoVRegs", llvm::MachineFunctionProperties::Property::NoVRegs)
+      .value("Legalized", llvm::MachineFunctionProperties::Property::Legalized)
+      .value("RegBankSelected",
+             llvm::MachineFunctionProperties::Property::RegBankSelected)
+      .value("Selected", llvm::MachineFunctionProperties::Property::Selected);
+
   // llvm::MachineOperand -- one operand of a MachineInstr. is_def/is_use are
   // register-only in LLVM (they assert otherwise), so they are guarded to
   // report false for non-register operands rather than crash.
@@ -533,11 +555,30 @@ void populate_mir(nb::module_ &m) {
           "reg"_a, "Append a register def operand.")
       .def(
           "add_use",
-          [](llvm::MachineInstr &self, llvm::Register reg) {
+          [](llvm::MachineInstr &self, llvm::Register reg, bool implicit) {
             self.addOperand(*self.getMF(), llvm::MachineOperand::CreateReg(
-                                               reg, /*isDef=*/false));
+                                               reg, /*isDef=*/false, implicit));
           },
-          "reg"_a, "Append a register use operand.")
+          "reg"_a, "implicit"_a = false, "Append a register use operand.")
+      .def(
+          "add_reg",
+          [](llvm::MachineInstr &self, llvm::Register reg, bool isDef,
+             bool isImp, bool isKill, bool isDead, bool isUndef,
+             bool isEarlyClobber, unsigned subReg, bool isRenamable) {
+            self.addOperand(*self.getMF(),
+                            llvm::MachineOperand::CreateReg(
+                                reg, isDef, isImp, isKill, isDead, isUndef,
+                                isEarlyClobber, subReg, /*isDebug=*/false,
+                                /*isInternalRead=*/false, isRenamable));
+          },
+          "reg"_a, "is_def"_a = false, "implicit"_a = false,
+          "is_kill"_a = false, "is_dead"_a = false, "is_undef"_a = false,
+          "is_early_clobber"_a = false, "sub_reg"_a = 0,
+          "is_renamable"_a = false,
+          "Append a register operand, exposing the full MachineOperand "
+          "register "
+          "flag set (def/use, implicit, kill, dead, undef, early-clobber, "
+          "sub-register, renamable).")
       .def(
           "add_imm",
           [](llvm::MachineInstr &self, int64_t value) {
@@ -621,6 +662,12 @@ void populate_mir(nb::module_ &m) {
             self.replaceSuccessor(old, replacement);
           },
           "old"_a, "new"_a, "Replace a CFG successor edge with another block.")
+      .def(
+          "add_livein",
+          [](llvm::MachineBasicBlock &self, llvm::Register reg) {
+            self.addLiveIn(reg.asMCReg());
+          },
+          "reg"_a, "Declare a physical register live-in to this block.")
       .def("__str__",
            [](llvm::MachineBasicBlock &self) { return eudsl::toString(self); });
 
@@ -655,6 +702,52 @@ void populate_mir(nb::module_ &m) {
             return self.getRegInfo().createGenericVirtualRegister(ty);
           },
           "type"_a, "Create a new generic virtual register of the given LLT.")
+      .def(
+          "reg_class",
+          [](llvm::MachineFunction &self,
+             const std::string &name) -> const llvm::TargetRegisterClass * {
+            const llvm::TargetRegisterInfo *tri =
+                self.getSubtarget().getRegisterInfo();
+            for (unsigned i = 0, e = tri->getNumRegClasses(); i < e; ++i) {
+              const llvm::TargetRegisterClass *rc = tri->getRegClass(i);
+              if (name == tri->getRegClassName(
+                              &tri->MCRegisterInfo::getRegClass(rc->getID())))
+                return rc;
+            }
+            throw nb::key_error(
+                ("no target register class named '" + name + "'").c_str());
+          },
+          "name"_a, nb::rv_policy::reference_internal,
+          "Look up a target register class by name (e.g. \"GPR32\").")
+      .def(
+          "physreg",
+          [](llvm::MachineFunction &self,
+             const std::string &name) -> llvm::Register {
+            const llvm::TargetRegisterInfo *tri =
+                self.getSubtarget().getRegisterInfo();
+            for (unsigned i = 1, e = tri->getNumRegs(); i < e; ++i) {
+              if (name == tri->getName(i))
+                return llvm::Register(i);
+            }
+            throw nb::key_error(
+                ("no physical register named '" + name + "'").c_str());
+          },
+          "name"_a, "Look up a physical register by name (e.g. \"W0\").")
+      .def(
+          "create_vreg",
+          [](llvm::MachineFunction &self,
+             const llvm::TargetRegisterClass *rc) -> llvm::Register {
+            return self.getRegInfo().createVirtualRegister(rc);
+          },
+          "reg_class"_a,
+          "Create a new virtual register constrained to a register class.")
+      .def(
+          "set_property",
+          [](llvm::MachineFunction &self,
+             llvm::MachineFunctionProperties::Property prop) {
+            self.getProperties().set(prop);
+          },
+          "property"_a, "Set a MachineFunctionProperties flag.")
       .def(
           "create_block",
           [](llvm::MachineFunction &self,

--- a/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
@@ -1,0 +1,107 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Building already-selected target MIR by hand (Route B).
+
+Rather than build generic G_* MIR and rely on GlobalISel selection (which falls
+back to SelectionDAG -- and thus to IR -- when the target can't select it), the
+DSL can emit fully-selected target instructions directly. This is the substrate
+for lowering to machine code without instruction selection: the resulting MIR is
+well-formed (verify() is True), unlike an incomplete generic function.
+
+The reference shape is `llc -stop-after=finalize-isel` for a 32-bit add on
+AArch64: liveins $w0/$w1, two COPYs in, ADDWrr, a COPY to $w0, RET_ReallyLR.
+"""
+
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+import pytest
+import llvm
+
+# Target-specific (AArch64 GPR32/ADDWrr/RET_ReallyLR); needs the AArch64 backend.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 `add(i32,i32)->i32` MachineFunction."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    w1 = mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+
+    v0 = mf.create_vreg(gpr32)
+    v1 = mf.create_vreg(gpr32)
+    v2 = mf.create_vreg(gpr32)
+    copy = mf.opcode("COPY")
+
+    c0 = b.build_instr(copy)
+    c0.add_reg(v0, is_def=True)
+    c0.add_reg(w0)
+    c1 = b.build_instr(copy)
+    c1.add_reg(v1, is_def=True)
+    c1.add_reg(w1)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    c2 = b.build_instr(copy)
+    c2.add_reg(w0, is_def=True)
+    c2.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+
+    mf.set_property(mir.MachineFunctionProperty.IsSSA)
+    mf.set_property(mir.MachineFunctionProperty.TracksLiveness)
+    mf.set_property(mir.MachineFunctionProperty.NoPHIs)
+    return mf
+
+
+def test_reg_class_and_physreg_lookup():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        mf = mmi.machine_function("add")
+        assert mf.reg_class("GPR32") is not None
+        assert mf.create_vreg(mf.reg_class("GPR32")).is_virtual
+        assert mf.physreg("W0").is_physical
+    assert_no_leaks()
+
+
+def test_unknown_reg_class_and_physreg_raise():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mf = mir.create_machine_function(mod, tm, "add").machine_function("add")
+        import pytest
+
+        with pytest.raises(KeyError):
+            mf.reg_class("NOPE")
+        with pytest.raises(KeyError):
+            mf.physreg("NOPE")
+    assert_no_leaks()
+
+
+def test_hand_built_selected_add_verifies():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        mf = _build_selected_add(mmi)
+
+        opcodes = [i.opcode_name for i in mf.blocks[0].instructions]
+        assert opcodes == ["COPY", "COPY", "ADDWrr", "COPY", "RET_ReallyLR"]
+        # A well-formed, fully-selected function -- unlike incomplete generic MIR.
+        assert mf.verify() is True
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
@@ -5,9 +5,9 @@
 
 Rather than build generic G_* MIR and rely on GlobalISel selection (which falls
 back to SelectionDAG -- and thus to IR -- when the target can't select it), the
-DSL can emit fully-selected target instructions directly. This is the substrate
-for lowering to machine code without instruction selection: the resulting MIR is
-well-formed (verify() is True), unlike an incomplete generic function.
+DSL can emit fully-selected target instructions directly. The resulting MIR is
+well-formed target MIR (verify() is True), unlike an incomplete generic
+function that never went through instruction selection.
 
 The reference shape is `llc -stop-after=finalize-isel` for a 32-bit add on
 AArch64: liveins $w0/$w1, two COPYs in, ADDWrr, a COPY to $w0, RET_ReallyLR.
@@ -28,8 +28,13 @@ pytestmark = pytest.mark.skipif(
 _TRIPLE = "aarch64-unknown-linux-gnu"
 
 
-def _build_selected_add(mmi):
-    """Hand-build a fully-selected AArch64 `add(i32,i32)->i32` MachineFunction."""
+def _build_selected_add(mmi, declare_liveins=True):
+    """Hand-build a fully-selected AArch64 `add(i32,i32)->i32` MachineFunction.
+
+    Returns (mf, {"v0", "v1", "v2", "w0"} register ids) so callers can assert on
+    the operand wiring. With declare_liveins=False the live-ins are omitted,
+    which (given TracksLiveness) makes the same MIR fail verify().
+    """
     mf = mmi.machine_function("add")
     b = mir.MachineIRBuilder(mf)
     entry = mf.blocks[0]
@@ -37,8 +42,9 @@ def _build_selected_add(mmi):
     gpr32 = mf.reg_class("GPR32")
     w0 = mf.physreg("W0")
     w1 = mf.physreg("W1")
-    entry.add_livein(w0)
-    entry.add_livein(w1)
+    if declare_liveins:
+        entry.add_livein(w0)
+        entry.add_livein(w1)
 
     v0 = mf.create_vreg(gpr32)
     v1 = mf.create_vreg(gpr32)
@@ -64,7 +70,7 @@ def _build_selected_add(mmi):
     mf.set_property(mir.MachineFunctionProperty.IsSSA)
     mf.set_property(mir.MachineFunctionProperty.TracksLiveness)
     mf.set_property(mir.MachineFunctionProperty.NoPHIs)
-    return mf
+    return mf, {"v0": v0.id, "v1": v1.id, "v2": v2.id, "w0": w0.id}
 
 
 def test_reg_class_and_physreg_lookup():
@@ -84,8 +90,6 @@ def test_unknown_reg_class_and_physreg_raise():
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_TRIPLE)
         mf = mir.create_machine_function(mod, tm, "add").machine_function("add")
-        import pytest
-
         with pytest.raises(KeyError):
             mf.reg_class("NOPE")
         with pytest.raises(KeyError):
@@ -98,10 +102,82 @@ def test_hand_built_selected_add_verifies():
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_TRIPLE)
         mmi = mir.create_machine_function(mod, tm, "add")
-        mf = _build_selected_add(mmi)
+        mf, regs = _build_selected_add(mmi)
 
-        opcodes = [i.opcode_name for i in mf.blocks[0].instructions]
+        instrs = list(mf.blocks[0].instructions)
+        opcodes = [i.opcode_name for i in instrs]
         assert opcodes == ["COPY", "COPY", "ADDWrr", "COPY", "RET_ReallyLR"]
+        # Operand wiring: ADDWrr defs v2 and uses v0, v1.
+        addwrr = instrs[2]
+        assert addwrr.operand(0).is_def and addwrr.operand(0).reg.id == regs["v2"]
+        assert addwrr.operand(1).is_use and addwrr.operand(1).reg.id == regs["v0"]
+        assert addwrr.operand(2).is_use and addwrr.operand(2).reg.id == regs["v1"]
+        # The terminal RET reads $w0 as an implicit use.
+        ret = instrs[4]
+        assert ret.operand(0).is_implicit and ret.operand(0).reg.id == regs["w0"]
         # A well-formed, fully-selected function -- unlike incomplete generic MIR.
         assert mf.verify() is True
+    assert_no_leaks()
+
+
+def test_hand_built_add_without_liveins_fails_verify():
+    """Dropping the live-in declarations makes the same MIR fail verify(),
+    showing add_livein is load-bearing (the verifier checks physreg liveness
+    because TracksLiveness is set)."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        mf, _ = _build_selected_add(mmi, declare_liveins=False)
+        assert mf.verify() is False
+        assert mf.verify_diagnostic() != ""
+    assert_no_leaks()
+
+
+def test_add_reg_flag_matrix_roundtrips():
+    """Every add_reg flag is set and read back, so an argument-position
+    mis-wiring in the 11-arg operand builder would be caught. Uses physical
+    registers because is_renamable is a physreg-only flag (the target-neutral
+    virtual-register subset is covered in test_build_selected_generic.py)."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mf = mir.create_machine_function(mod, tm, "add").machine_function("add")
+        b = mir.MachineIRBuilder(mf)
+        w0 = mf.physreg("W0")
+        w1 = mf.physreg("W1")
+
+        instr = b.build_instr(mf.opcode("COPY"))
+        instr.add_reg(
+            w0,
+            is_def=True,
+            is_dead=True,
+            is_early_clobber=True,
+            is_renamable=True,
+            sub_reg=1,
+        )
+        instr.add_reg(w1, implicit=True, is_kill=True, is_undef=True)
+
+        defop = instr.operand(0)
+        assert defop.is_def and defop.is_dead and defop.is_early_clobber
+        assert defop.is_renamable and defop.sub_reg == 1
+        assert not defop.is_kill
+
+        useop = instr.operand(1)
+        assert useop.is_use and useop.is_implicit
+        assert useop.is_kill and useop.is_undef
+        assert not useop.is_dead and not useop.is_renamable
+    assert_no_leaks()
+
+
+def test_selected_add_survives_mir_roundtrip():
+    """The hand-built selected MIR prints to .mir and parses back well-formed."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        text = mmi.to_mir()
+        mmi2 = mir.parse_mir(text, ctx, jit.TargetMachine(triple=_TRIPLE))
+        assert mmi2.machine_function("add").verify() is True
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_build_selected_generic.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_selected_generic.py
@@ -1,0 +1,90 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Target-neutral coverage for the Route-B operand/property primitives.
+
+test_build_selected.py exercises the real AArch64 shape but skips entirely on
+non-AArch64 legs, leaving the target-agnostic guards -- add_reg's flag matrix
+and validation, set_property/has_property, and add_livein's physical-register
+check -- uncovered there. These use only target-independent opcodes (COPY) and
+registers, so they run on every runner (triple=None builds against the host).
+"""
+
+import pytest
+
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+
+def test_add_reg_flag_matrix_roundtrips():
+    """Every virtual-register-legal add_reg flag is set and read back, catching
+    a mis-wired arg. (is_renamable is physreg-only -- see test_build_selected.py
+    for the physical-register variant.)"""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=None)
+        mf = mir.create_machine_function(mod, tm, "f").machine_function("f")
+        b = mir.MachineIRBuilder(mf)
+        d = mf.create_generic_virtual_register(mir.LLT.scalar(32))
+        u = mf.create_generic_virtual_register(mir.LLT.scalar(32))
+
+        instr = b.build_instr(mf.opcode("COPY"))
+        instr.add_reg(d, is_def=True, is_dead=True, is_early_clobber=True, sub_reg=1)
+        instr.add_reg(u, implicit=True, is_kill=True, is_undef=True)
+
+        defop = instr.operand(0)
+        assert defop.is_def and defop.is_dead and defop.is_early_clobber
+        assert defop.sub_reg == 1
+        assert not defop.is_kill and not defop.is_renamable
+
+        useop = instr.operand(1)
+        assert useop.is_use and useop.is_implicit
+        assert useop.is_kill and useop.is_undef
+        assert not useop.is_dead
+    assert_no_leaks()
+
+
+def test_add_reg_rejects_contradictory_flags():
+    """kill is use-only, dead is def-only, is_renamable is physreg-only, and
+    sub_reg is bounds-checked -- LLVM asserts these, compiled out under NDEBUG
+    in the release wheel."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=None)
+        mf = mir.create_machine_function(mod, tm, "f").machine_function("f")
+        b = mir.MachineIRBuilder(mf)
+        v = mf.create_generic_virtual_register(mir.LLT.scalar(32))
+        instr = b.build_instr(mf.opcode("COPY"))
+        with pytest.raises(ValueError):
+            instr.add_reg(v, is_def=True, is_kill=True)
+        with pytest.raises(ValueError):
+            instr.add_reg(v, is_def=False, is_dead=True)
+        with pytest.raises(ValueError):
+            instr.add_reg(v, is_renamable=True)  # virtual register
+        with pytest.raises(IndexError):
+            instr.add_reg(v, sub_reg=1_000_000_000)
+    assert_no_leaks()
+
+
+def test_add_livein_rejects_virtual_register():
+    """add_livein truncates via asMCReg() (assert-only), so a virtual register
+    would silently corrupt the livein list -- reject it instead."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=None)
+        mf = mir.create_machine_function(mod, tm, "f").machine_function("f")
+        v = mf.create_generic_virtual_register(mir.LLT.scalar(32))
+        with pytest.raises(ValueError):
+            mf.blocks[0].add_livein(v)
+    assert_no_leaks()
+
+
+def test_has_property_reads_back_set_property():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=None)
+        mf = mir.create_machine_function(mod, tm, "f").machine_function("f")
+        assert mf.has_property(mir.MachineFunctionProperty.Selected) is False
+        mf.set_property(mir.MachineFunctionProperty.Selected)
+        assert mf.has_property(mir.MachineFunctionProperty.Selected) is True
+    assert_no_leaks()


### PR DESCRIPTION
Add the primitives to construct fully-selected target MIR directly, sidestepping
GlobalISel (whose selection failure falls back to SelectionDAG, i.e. to the IR,
which hand-built MIR lacks): MachineFunction.reg_class / physreg (by-name lookup
via TargetRegisterInfo, like the opcode lookup), create_vreg(reg_class),
MachineBasicBlock.add_livein, MachineInstr.add_reg (exposing the full
MachineOperand register flag set -- def/use, implicit, kill, dead, undef,
early-clobber, sub-register, renamable), and MachineFunction.set_property over a
MachineFunctionProperty enum. A hand-built, fully-selected AArch64 add verifies()
True -- unlike incomplete generic MIR.

Tenth PR in the MIR stack; foundation for lowering hand-built MIR to machine code
without instruction selection (emit + JIT to follow).