### PR TITLE
[eudsl] Cap nanobind to <3.0 (keep nanobind 3.0.0 out of the builds)

### DIFF
--- a/projects/eudsl-tblgen/pyproject.toml
+++ b/projects/eudsl-tblgen/pyproject.toml
@@ -13,7 +13,7 @@ Homepage = "https://github.com/llvm/eudsl"
 
 [build-system]
 requires = [
-    "nanobind>=2.9.2",
+    "nanobind>=2.9.2, <3.0",
     "scikit-build-core>=0.10.7",
     "typing_extensions>=4.12.2"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-nanobind>=2.9.2
+nanobind>=2.9.2,<3.0
 numpy>=2.0.2
 scikit-build-core==0.10.7
 pytest


### PR DESCRIPTION
## Why

`nanobind` **3.0.0** was just released. It dropped Python < 3.10 support **and** changed C++ internals (`nanobind::detail::keep_alive` removed), so it broke the shared **Build eudsl** job two different ways:

1. **eudsl-tblgen** (built via cibuildwheel, isolated): its own `nanobind>=2.9.2` resolved to 3.0.0 in a **cp39** build env →
   ```
   ImportError: nanobind does not support Python < 3.10.
   ```
2. **eudsl-llvmpy / eudsl-nbgen** (built with `--no-build-isolation` on regular PRs): their pyproject `nanobind==...` pins are bypassed, so they compiled against the **host** nanobind installed from `requirements-dev.txt`, which resolved to 3.0.0 →
   ```
   error: no member named 'keep_alive' in namespace 'nanobind::detail'
   error: too few arguments to function call, expected 2, have 1
   ```

## What

Cap nanobind to `<3.0` in the two uncapped specs — the only places 3.0.0 could sneak in:

- **`requirements-dev.txt`** → `nanobind>=2.9.2,<3.0` (the host env used by the `--no-build-isolation` builds: eudsl-llvmpy, eudsl-nbgen)
- **`eudsl-tblgen/pyproject.toml`** → `nanobind>=2.9.2, <3.0` (its isolated cibuildwheel build)

Every other project already pins an exact 2.x nanobind (`==2.4.0`, `==2.12.0`) or caps it (`<3.0` / `<=2.9.2`), so nothing can pull 3.0.0 anymore. Python 3.9 support is unchanged.

Lifting the cap for a nanobind 3.x migration is a separate, intentional follow-up.