### PR TITLE
[eudsl-llvmpy] Extract shared PassPipelineEnv scaffold in Passes.cpp

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -10,6 +10,37 @@
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/StandardInstrumentations.h>
 
+namespace {
+// Bundles the PassBuilder with the four analysis managers and instrumentation,
+// with the lifetimes ModulePassManager::run requires: the managers and the
+// StandardInstrumentations must outlive the run that references them, and the
+// PassBuilder holds a pointer to `pic`. run_passes and run_default_pipeline
+// build this identically, so keeping it in one place stops the two copies from
+// drifting. Member declaration order is the construction order: `pic` before
+// `pb` (which captures &pic), `si` before its registerCallbacks(pic).
+struct PassPipelineEnv {
+  llvm::PassInstrumentationCallbacks pic;
+  llvm::StandardInstrumentations si;
+  llvm::PassBuilder pb;
+  llvm::LoopAnalysisManager lam;
+  llvm::FunctionAnalysisManager fam;
+  llvm::CGSCCAnalysisManager cgam;
+  llvm::ModuleAnalysisManager mam;
+
+  PassPipelineEnv(llvm::LLVMContext &ctx,
+                  const llvm::PipelineTuningOptions &opts, bool debug,
+                  bool verifyEach)
+      : si(ctx, debug, verifyEach), pb(nullptr, opts, std::nullopt, &pic) {
+    si.registerCallbacks(pic);
+    pb.registerModuleAnalyses(mam);
+    pb.registerCGSCCAnalyses(cgam);
+    pb.registerFunctionAnalyses(fam);
+    pb.registerLoopAnalyses(lam);
+    pb.crossRegisterProxies(lam, fam, cgam, mam);
+  }
+};
+} // namespace
+
 void populate_passes(nb::module_ &m) {
   nb::enum_<llvm::OptimizationLevel>(m, "OptLevel")
       .value("O0", llvm::OptimizationLevel::O0)
@@ -35,25 +66,12 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        llvm::PassInstrumentationCallbacks pic;
-        llvm::StandardInstrumentations si(mod.get().getContext(), debug,
-                                          verifyEach);
-        si.registerCallbacks(pic);
-        llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
-        llvm::LoopAnalysisManager lam;
-        llvm::FunctionAnalysisManager fam;
-        llvm::CGSCCAnalysisManager cgam;
-        llvm::ModuleAnalysisManager mam;
-        pb.registerModuleAnalyses(mam);
-        pb.registerCGSCCAnalyses(cgam);
-        pb.registerFunctionAnalyses(fam);
-        pb.registerLoopAnalyses(lam);
-        pb.crossRegisterProxies(lam, fam, cgam, mam);
+        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
 
         llvm::ModulePassManager mpm;
-        if (llvm::Error err = pb.parsePassPipeline(mpm, pipeline))
+        if (llvm::Error err = env.pb.parsePassPipeline(mpm, pipeline))
           throw std::runtime_error(llvm::toString(std::move(err)));
-        mpm.run(mod.get(), mam);
+        mpm.run(mod.get(), env.mam);
       },
       "module"_a, "pipeline"_a, "tuning"_a = nb::none(), "debug"_a = false,
       "verify_each"_a = false,
@@ -66,26 +84,13 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        llvm::PassInstrumentationCallbacks pic;
-        llvm::StandardInstrumentations si(mod.get().getContext(), debug,
-                                          verifyEach);
-        si.registerCallbacks(pic);
-        llvm::PassBuilder pb(nullptr, opts, std::nullopt, &pic);
-        llvm::LoopAnalysisManager lam;
-        llvm::FunctionAnalysisManager fam;
-        llvm::CGSCCAnalysisManager cgam;
-        llvm::ModuleAnalysisManager mam;
-        pb.registerModuleAnalyses(mam);
-        pb.registerCGSCCAnalyses(cgam);
-        pb.registerFunctionAnalyses(fam);
-        pb.registerLoopAnalyses(lam);
-        pb.crossRegisterProxies(lam, fam, cgam, mam);
+        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
 
         llvm::ModulePassManager mpm =
             (level == llvm::OptimizationLevel::O0)
-                ? pb.buildO0DefaultPipeline(level)
-                : pb.buildPerModuleDefaultPipeline(level);
-        mpm.run(mod.get(), mam);
+                ? env.pb.buildO0DefaultPipeline(level)
+                : env.pb.buildPerModuleDefaultPipeline(level);
+        mpm.run(mod.get(), env.mam);
       },
       "module"_a, "level"_a, "tuning"_a = nb::none(), "debug"_a = false,
       "verify_each"_a = false,


### PR DESCRIPTION
run_passes and run_default_pipeline built the PassBuilder + the four
analysis managers + StandardInstrumentations identically. Pull that setup
into a PassPipelineEnv struct (declared so member construction order gives
the lifetimes ModulePassManager::run needs) so the two copies cannot drift
and later Python-pass entry points can reuse it. Pure refactor.