### PR TITLE
[eudsl-llvmpy] Add module-level Python passes (run_python_pass)

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -5,12 +5,36 @@
 #include "IR/Common.h"
 #include "IR/Ownership.h"
 
+#include <llvm/ADT/Any.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/OptimizationLevel.h>
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Passes/StandardInstrumentations.h>
 
+#include <exception>
+
 namespace {
+// A Python exception raised inside a pass callback is stashed here instead of
+// thrown across llvm::ModulePassManager::run, which libLLVMCore compiles with
+// -fno-exceptions (LLVM_ENABLE_EH OFF): unwinding through those frames skips
+// their destructors (e.g. leaves the thread-local PrettyStackTraceHead dangling
+// and leaks the run's PreservedAnalyses) and std::terminates on targets built
+// without asynchronous unwind tables. runPipeline resets the slot, runs the
+// pipeline, and re-raises afterward, so the throw only crosses our own
+// -fexceptions frames. Thread-local so concurrent pipelines don't clobber it.
+thread_local std::exception_ptr pendingPassError;
+
+void runPipeline(llvm::ModulePassManager &mpm, llvm::Module &m,
+                 llvm::ModuleAnalysisManager &mam) {
+  pendingPassError = nullptr;
+  mpm.run(m, mam);
+  if (pendingPassError) {
+    std::exception_ptr err = pendingPassError;
+    pendingPassError = nullptr;
+    std::rethrow_exception(err);
+  }
+}
+
 // Bundles the PassBuilder with the four analysis managers and instrumentation,
 // with the lifetimes ModulePassManager::run requires: the managers and the
 // StandardInstrumentations must outlive the run that references them, and the
@@ -37,6 +61,49 @@ struct PassPipelineEnv {
     pb.registerFunctionAnalyses(fam);
     pb.registerLoopAnalyses(lam);
     pb.crossRegisterProxies(lam, fam, cgam, mam);
+    // Once a pass callback has stashed an error, skip every subsequent optional
+    // pass so the pipeline winds down to runPipeline's re-raise instead of
+    // running builtins on IR the failed pass may have left half-mutated. (The
+    // manager still runs any isRequired() pass -- those cannot be skipped.)
+    pic.registerShouldRunOptionalPassCallback(
+        [](llvm::StringRef, llvm::Any) { return !pendingPassError; });
+  }
+};
+
+// A new-PM module pass whose body is a Python callable. The new PassManager is
+// concept-based, so a pass needs no LLVM base class beyond the PassInfoMixin
+// that supplies name()/isRequired()/printPipeline -- any movable type with a
+// run(Module&, ModuleAnalysisManager&) qualifies. We hold the owning
+// eudsl::Module so the callback receives the same Python wrapper the caller
+// passed (rv_policy::reference maps the pointer back through nanobind's
+// instance registry), and the nb::callable so the callback outlives the move
+// into PassModel. Everything runs synchronously on the calling (Python) thread,
+// so the callable's refcounting stays correct; we still take the GIL in run()
+// to stay correct under a free-threaded interpreter.
+struct PyModulePass : llvm::PassInfoMixin<PyModulePass> {
+  eudsl::Module *mod;
+  nb::callable callback;
+
+  PyModulePass(eudsl::Module *mod, nb::callable callback)
+      : mod(mod), callback(std::move(callback)) {}
+
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &) {
+    nb::gil_scoped_acquire gil;
+    try {
+      nb::object res = callback(nb::cast(mod, nb::rv_policy::reference));
+      // Convention: None or any falsy return means "IR unchanged" (preserve all
+      // analyses); any truthy return means the pass mutated the IR.
+      int truthy = PyObject_IsTrue(res.ptr());
+      if (truthy < 0)
+        throw nb::python_error();
+      return truthy ? llvm::PreservedAnalyses::none()
+                    : llvm::PreservedAnalyses::all();
+    } catch (...) {
+      // Do not let the exception unwind through LLVM's -fno-exceptions frames;
+      // stash it and report "nothing changed" so the pipeline winds down.
+      pendingPassError = std::current_exception();
+      return llvm::PreservedAnalyses::all();
+    }
   }
 };
 } // namespace
@@ -71,7 +138,7 @@ void populate_passes(nb::module_ &m) {
         llvm::ModulePassManager mpm;
         if (llvm::Error err = env.pb.parsePassPipeline(mpm, pipeline))
           throw std::runtime_error(llvm::toString(std::move(err)));
-        mpm.run(mod.get(), env.mam);
+        runPipeline(mpm, mod.get(), env.mam);
       },
       "module"_a, "pipeline"_a, "tuning"_a = nb::none(), "debug"_a = false,
       "verify_each"_a = false,
@@ -90,9 +157,24 @@ void populate_passes(nb::module_ &m) {
             (level == llvm::OptimizationLevel::O0)
                 ? env.pb.buildO0DefaultPipeline(level)
                 : env.pb.buildPerModuleDefaultPipeline(level);
-        mpm.run(mod.get(), env.mam);
+        runPipeline(mpm, mod.get(), env.mam);
       },
       "module"_a, "level"_a, "tuning"_a = nb::none(), "debug"_a = false,
       "verify_each"_a = false,
       "Run the default optimization pipeline at the given level.");
+
+  m.def(
+      "run_python_pass_on_module",
+      [](eudsl::Module &mod, nb::callable callback) {
+        PassPipelineEnv env(mod.get().getContext(),
+                            llvm::PipelineTuningOptions(), /*debug=*/false,
+                            /*verifyEach=*/false);
+        llvm::ModulePassManager mpm;
+        mpm.addPass(PyModulePass(&mod, std::move(callback)));
+        runPipeline(mpm, mod.get(), env.mam);
+      },
+      "module"_a, "callback"_a,
+      "Run a Python callable as a module pass over the module in place. The "
+      "callable receives the Module; return a truthy value if it mutated the "
+      "IR (so analyses are invalidated), None/falsy otherwise.");
 }

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -88,6 +88,11 @@ struct PyModulePass : llvm::PassInfoMixin<PyModulePass> {
       : mod(mod), callback(std::move(callback)) {}
 
   llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &) {
+    // The GIL guard is intentionally outside the try: the catch stashes the
+    // exception with std::current_exception(), which for an nb::python_error
+    // touches Python refcounts and so must run while the GIL is held. Its
+    // construction (PyGILState_Ensure) does not raise, so nothing is lost by
+    // leaving it uncaught here.
     nb::gil_scoped_acquire gil;
     try {
       nb::object res = callback(nb::cast(mod, nb::rv_policy::reference));

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -94,8 +94,16 @@ struct PyModulePass : llvm::PassInfoMixin<PyModulePass> {
       // Convention: None or any falsy return means "IR unchanged" (preserve all
       // analyses); any truthy return means the pass mutated the IR.
       int truthy = PyObject_IsTrue(res.ptr());
-      if (truthy < 0)
-        throw nb::python_error();
+      if (truthy < 0) {
+        // PyObject_IsTrue set a Python error (the return value's __bool__
+        // raised). Wrap it in a message that says where it came from, keeping
+        // the original as the exception's cause.
+        nb::python_error err;
+        nb::raise_from(
+            err, PyExc_ValueError,
+            "could not evaluate the truthiness of a Python module pass's "
+            "return value");
+      }
       return truthy ? llvm::PreservedAnalyses::none()
                     : llvm::PreservedAnalyses::all();
     } catch (...) {
@@ -165,15 +173,18 @@ void populate_passes(nb::module_ &m) {
 
   m.def(
       "run_python_pass_on_module",
-      [](eudsl::Module &mod, nb::callable callback) {
-        PassPipelineEnv env(mod.get().getContext(),
-                            llvm::PipelineTuningOptions(), /*debug=*/false,
-                            /*verifyEach=*/false);
+      [](eudsl::Module &mod, nb::callable callback,
+         std::optional<llvm::PipelineTuningOptions> pto, bool debug,
+         bool verifyEach) {
+        llvm::PipelineTuningOptions opts =
+            pto.value_or(llvm::PipelineTuningOptions());
+        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
         llvm::ModulePassManager mpm;
         mpm.addPass(PyModulePass(&mod, std::move(callback)));
         runPipeline(mpm, mod.get(), env.mam);
       },
-      "module"_a, "callback"_a,
+      "module"_a, "callback"_a, "tuning"_a = nb::none(), "debug"_a = false,
+      "verify_each"_a = false,
       "Run a Python callable as a module pass over the module in place. The "
       "callable receives the Module; return a truthy value if it mutated the "
       "IR (so analyses are invalidated), None/falsy otherwise.");

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -42,6 +42,25 @@ def test_module_pass_can_mutate_ir():
     assert_no_leaks()
 
 
+def test_module_pass_forwards_tuning_and_flags():
+    # The tuning/debug/verify_each arguments are accepted and threaded through
+    # to the pipeline environment; the pass still runs and can mutate the IR.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        def rename(m):
+            m.get_function("f").name = "g"
+
+        tuning = llvm.passmanager.PipelineTuningOptions()
+        tuning.slp_vectorization = False
+        llvm.passmanager.run_python_pass_on_module(
+            mod, rename, tuning=tuning, debug=False, verify_each=True
+        )
+        assert "@g(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
 def test_exception_in_pass_propagates_and_leaves_module_usable():
     with llvm.ir.Context() as ctx:
         mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
@@ -67,9 +86,13 @@ def test_exception_from_unboolable_return_propagates():
                 raise ValueError("no truth value")
 
         # A truthiness that raises exercises the PyObject_IsTrue(<0) branch,
-        # which must propagate rather than be silently coerced or lost.
-        with pytest.raises(ValueError, match="no truth value"):
+        # which must propagate rather than be silently coerced or lost. The
+        # trampoline wraps it with a descriptive message and chains the
+        # original ValueError as the cause.
+        with pytest.raises(ValueError, match="truthiness") as excinfo:
             llvm.passmanager.run_python_pass_on_module(mod, lambda m: Unboolable())
+        assert isinstance(excinfo.value.__cause__, ValueError)
+        assert "no truth value" in str(excinfo.value.__cause__)
         assert "@f(" in str(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -1,0 +1,75 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+
+_SRC = dedent("""\
+    define i32 @f(i32 %x) {
+    entry:
+      ret i32 %x
+    }
+    """)
+
+
+def test_module_pass_is_invoked_once_with_the_module():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        seen = []
+        llvm.passmanager.run_python_pass_on_module(mod, seen.append)
+        assert len(seen) == 1
+        # The callback receives the very same Module object, not a fresh wrapper.
+        assert seen[0] is mod
+        del mod
+    assert_no_leaks()
+
+
+def test_module_pass_can_mutate_ir():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        def rename(m):
+            m.get_function("f").name = "g"
+
+        llvm.passmanager.run_python_pass_on_module(mod, rename)
+        assert "@g(" in str(mod)
+        assert "@f(" not in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_exception_in_pass_propagates_and_leaves_module_usable():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        def boom(m):
+            raise ValueError("boom in pass")
+
+        with pytest.raises(ValueError, match="boom in pass"):
+            llvm.passmanager.run_python_pass_on_module(mod, boom)
+        # The trampoline captured the exception and re-raised it after the
+        # pipeline returned; the module is still usable afterward.
+        assert "@f(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_exception_from_unboolable_return_propagates():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        class Unboolable:
+            def __bool__(self):
+                raise ValueError("no truth value")
+
+        # A truthiness that raises exercises the PyObject_IsTrue(<0) branch,
+        # which must propagate rather than be silently coerced or lost.
+        with pytest.raises(ValueError, match="no truth value"):
+            llvm.passmanager.run_python_pass_on_module(mod, lambda m: Unboolable())
+        assert "@f(" in str(mod)
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -42,6 +42,25 @@ def test_module_pass_can_mutate_ir():
     assert_no_leaks()
 
 
+def test_module_pass_can_mutate_ir_and_report_changed():
+    # A callback that returns a truthy value drives the "IR changed" branch
+    # (PreservedAnalyses::none(), invalidating analyses). That invalidation is
+    # not observable across independent runs, so this pins the observable part:
+    # a truthy return is accepted, the pass runs, and its mutation persists.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        def rename_changed(m):
+            m.get_function("f").name = "g"
+            return True  # truthy -> reported changed
+
+        llvm.passmanager.run_python_pass_on_module(mod, rename_changed)
+        assert "@g(" in str(mod)
+        assert "@f(" not in str(mod)
+        del mod
+    assert_no_leaks()
+
+
 def test_module_pass_forwards_tuning_and_flags():
     # The tuning/debug/verify_each arguments are accepted and threaded through
     # to the pipeline environment; the pass still runs and can mutate the IR.


### PR DESCRIPTION
Introduce PyModulePass, a new-PM module pass whose body is a Python
callable. The new PassManager is concept-based, so the pass only needs a
run(Module&, ModuleAnalysisManager&) plus PassInfoMixin -- no LLVM base
class. run_python_pass builds the shared PassPipelineEnv, adds the pass,
and runs it in place; the callback receives the same Module wrapper the
caller passed (rv_policy::reference), and a truthy return marks the IR
mutated (invalidate analyses) while None/falsy preserves all.