### PR TITLE
[eudsl-llvmpy] Add function-level Python passes (run_python_function_pass)

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -119,6 +119,33 @@ struct PyModulePass : llvm::PassInfoMixin<PyModulePass> {
     }
   }
 };
+
+// The per-function analogue of PyModulePass. Wrapped in a
+// ModuleToFunctionPassAdaptor it runs once per defined function; the callback
+// receives the llvm::Function (bound directly, so nanobind hands back its
+// wrapper). Same truthy-return / GIL contract as PyModulePass.
+struct PyFunctionPass : llvm::PassInfoMixin<PyFunctionPass> {
+  nb::callable callback;
+
+  explicit PyFunctionPass(nb::callable callback)
+      : callback(std::move(callback)) {}
+
+  llvm::PreservedAnalyses run(llvm::Function &f,
+                              llvm::FunctionAnalysisManager &) {
+    nb::gil_scoped_acquire gil;
+    try {
+      nb::object res = callback(nb::cast(&f, nb::rv_policy::reference));
+      int truthy = PyObject_IsTrue(res.ptr());
+      if (truthy < 0)
+        throw nb::python_error();
+      return truthy ? llvm::PreservedAnalyses::none()
+                    : llvm::PreservedAnalyses::all();
+    } catch (...) {
+      pendingPassError = std::current_exception();
+      return llvm::PreservedAnalyses::all();
+    }
+  }
+};
 } // namespace
 
 void populate_passes(nb::module_ &m) {
@@ -193,4 +220,20 @@ void populate_passes(nb::module_ &m) {
       "Run a Python callable as a module pass over the module in place. The "
       "callable receives the Module; return a truthy value if it mutated the "
       "IR (so analyses are invalidated), None/falsy otherwise.");
+
+  m.def(
+      "run_python_pass_on_function",
+      [](eudsl::Module &mod, nb::callable callback) {
+        PassPipelineEnv env(mod.get().getContext(),
+                            llvm::PipelineTuningOptions(), /*debug=*/false,
+                            /*verifyEach=*/false);
+        llvm::ModulePassManager mpm;
+        mpm.addPass(llvm::createModuleToFunctionPassAdaptor(
+            PyFunctionPass(std::move(callback))));
+        runPipeline(mpm, mod.get(), env.mam);
+      },
+      "module"_a, "callback"_a,
+      "Run a Python callable as a function pass over each defined function in "
+      "the module in place. The callable receives a Function; return a truthy "
+      "value if it mutated the function, None/falsy otherwise.");
 }

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -132,12 +132,22 @@ struct PyFunctionPass : llvm::PassInfoMixin<PyFunctionPass> {
 
   llvm::PreservedAnalyses run(llvm::Function &f,
                               llvm::FunctionAnalysisManager &) {
+    // GIL guard outside the try for the same reason as PyModulePass::run: the
+    // catch stashes via std::current_exception() (touching Python refcounts for
+    // an nb::python_error) and so must run while the GIL is held.
     nb::gil_scoped_acquire gil;
     try {
       nb::object res = callback(nb::cast(&f, nb::rv_policy::reference));
       int truthy = PyObject_IsTrue(res.ptr());
-      if (truthy < 0)
-        throw nb::python_error();
+      if (truthy < 0) {
+        // The return value's __bool__ raised; wrap it with a message that says
+        // where it came from, chaining the original as the exception's cause.
+        nb::python_error err;
+        nb::raise_from(
+            err, PyExc_ValueError,
+            "could not evaluate the truthiness of a Python function pass's "
+            "return value");
+      }
       return truthy ? llvm::PreservedAnalyses::none()
                     : llvm::PreservedAnalyses::all();
     } catch (...) {
@@ -223,16 +233,19 @@ void populate_passes(nb::module_ &m) {
 
   m.def(
       "run_python_pass_on_function",
-      [](eudsl::Module &mod, nb::callable callback) {
-        PassPipelineEnv env(mod.get().getContext(),
-                            llvm::PipelineTuningOptions(), /*debug=*/false,
-                            /*verifyEach=*/false);
+      [](eudsl::Module &mod, nb::callable callback,
+         std::optional<llvm::PipelineTuningOptions> pto, bool debug,
+         bool verifyEach) {
+        llvm::PipelineTuningOptions opts =
+            pto.value_or(llvm::PipelineTuningOptions());
+        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
         llvm::ModulePassManager mpm;
         mpm.addPass(llvm::createModuleToFunctionPassAdaptor(
             PyFunctionPass(std::move(callback))));
         runPipeline(mpm, mod.get(), env.mam);
       },
-      "module"_a, "callback"_a,
+      "module"_a, "callback"_a, "tuning"_a = nb::none(), "debug"_a = false,
+      "verify_each"_a = false,
       "Run a Python callable as a function pass over each defined function in "
       "the module in place. The callable receives a Function; return a truthy "
       "value if it mutated the function, None/falsy otherwise.");

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -18,6 +18,17 @@ _SRC = dedent("""\
     }
     """)
 
+_SRC2 = dedent("""\
+    define i32 @f(i32 %x) {
+    entry:
+      ret i32 %x
+    }
+    define i32 @g(i32 %y) {
+    entry:
+      ret i32 %y
+    }
+    """)
+
 
 def test_module_pass_is_invoked_once_with_the_module():
     with llvm.ir.Context() as ctx:
@@ -155,5 +166,66 @@ def test_none_returning_pass_runs_repeatedly_without_error():
         llvm.passmanager.run_python_pass_on_module(mod, noop)
         llvm.passmanager.run_python_pass_on_module(mod, noop)
         assert "@f(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_function_pass_runs_once_per_function():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+        names = []
+        llvm.passmanager.run_python_pass_on_function(
+            mod, lambda fn: names.append(fn.name)
+        )
+        assert sorted(names) == ["f", "g"]
+        del mod
+    assert_no_leaks()
+
+
+def test_function_pass_can_mutate_each_function():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+
+        def suffix(fn):
+            fn.name = fn.name + "_x"
+
+        llvm.passmanager.run_python_pass_on_function(mod, suffix)
+        assert "@f_x(" in str(mod)
+        assert "@g_x(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_exception_in_function_pass_propagates():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+        seen = []
+
+        def boom(fn):
+            seen.append(fn.name)
+            raise ValueError("boom in " + fn.name)
+
+        # Exceptions unwind through the adaptor's extra -fno-exceptions frames;
+        # the trampoline must still capture and re-raise them (not std::terminate).
+        # The first function's error propagates and the second function is
+        # skipped (the ShouldRun callback gates the adaptor's inner passes).
+        with pytest.raises(ValueError, match="boom in f"):
+            llvm.passmanager.run_python_pass_on_function(mod, boom)
+        assert seen == ["f"]  # g was skipped after f raised
+        assert "@f(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_function_pass_unboolable_return_propagates():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+
+        class Unboolable:
+            def __bool__(self):
+                raise ValueError("no truth value")
+
+        with pytest.raises(ValueError, match="no truth value"):
+            llvm.passmanager.run_python_pass_on_function(mod, lambda fn: Unboolable())
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -29,6 +29,17 @@ _SRC2 = dedent("""\
     }
     """)
 
+# One defined function plus a bare declaration -- the function-pass adaptor
+# should visit only the defined one.
+_SRC_DECL = dedent("""\
+    declare i32 @ext(i32)
+    define i32 @f(i32 %x) {
+    entry:
+      %r = call i32 @ext(i32 %x)
+      ret i32 %r
+    }
+    """)
+
 
 def test_module_pass_is_invoked_once_with_the_module():
     with llvm.ir.Context() as ctx:
@@ -225,7 +236,41 @@ def test_function_pass_unboolable_return_propagates():
             def __bool__(self):
                 raise ValueError("no truth value")
 
-        with pytest.raises(ValueError, match="no truth value"):
+        # The trampoline wraps the __bool__ failure with a descriptive message
+        # and chains the original ValueError as the cause.
+        with pytest.raises(ValueError, match="truthiness") as excinfo:
             llvm.passmanager.run_python_pass_on_function(mod, lambda fn: Unboolable())
+        assert isinstance(excinfo.value.__cause__, ValueError)
+        assert "no truth value" in str(excinfo.value.__cause__)
+        del mod
+    assert_no_leaks()
+
+
+def test_function_pass_skips_declarations():
+    # The ModuleToFunctionPassAdaptor visits only defined functions, so a bare
+    # declaration must not be handed to the callback.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC_DECL, ctx, "m")
+        names = []
+        llvm.passmanager.run_python_pass_on_function(
+            mod, lambda fn: names.append(fn.name)
+        )
+        assert names == ["f"]  # @ext (declaration) was not visited
+        del mod
+    assert_no_leaks()
+
+
+def test_function_pass_forwards_tuning_and_flags():
+    # tuning/debug/verify_each are accepted and threaded through to the pipeline
+    # environment; the pass still runs once per defined function.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+        names = []
+        tuning = llvm.passmanager.PipelineTuningOptions()
+        tuning.slp_vectorization = False
+        llvm.passmanager.run_python_pass_on_function(
+            mod, lambda fn: names.append(fn.name), tuning=tuning, verify_each=True
+        )
+        assert sorted(names) == ["f", "g"]
         del mod
     assert_no_leaks()


### PR DESCRIPTION
PyFunctionPass mirrors PyModulePass at function scope; run_python_function_pass
wraps it in a ModuleToFunctionPassAdaptor so it runs once per defined
function, handing the callback the llvm::Function. A separate entry point
(rather than a mode arg on run_python_pass) keeps the two distinct callback
signatures explicit.