### PR TITLE
[eudsl-llvmpy] Register Python passes by name for textual pipelines

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -315,10 +315,15 @@ void populate_passes(nb::module_ &m) {
       "pipeline. on=PassKind.MODULE (default) names a module pass directly "
       "(e.g. \"my-pass,instcombine\"); on=PassKind.FUNCTION names a function "
       "pass, invoked inside a function(...) pipeline (e.g. "
-      "\"function(my-pass)\"). Pick a name that does not collide with a "
-      "builtin pass. The callable follows the run_python_pass_on_module / "
+      "\"function(my-pass)\"). Registering the same name again replaces the "
+      "callable. Pick a name that does not collide with a builtin pass. The "
+      "callable follows the run_python_pass_on_module / "
       "run_python_pass_on_function contract (truthy return marks the IR "
-      "mutated).");
+      "mutated). Caveats: the registry is not synchronized, so register from a "
+      "single thread (e.g. at import) before running pipelines concurrently; "
+      "and a callable that closes over a Module or Context keeps it alive "
+      "until "
+      "interpreter exit, so prefer callables that take the IR as an argument.");
 
   // Drop the registered callables while the interpreter is still up, so their
   // decref does not run after Python teardown (mirrors the caster registry).

--- a/projects/eudsl-llvmpy/src/IR/Passes.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Passes.cpp
@@ -12,6 +12,8 @@
 #include <llvm/Passes/StandardInstrumentations.h>
 
 #include <exception>
+#include <string>
+#include <unordered_map>
 
 namespace {
 // A Python exception raised inside a pass callback is stashed here instead of
@@ -34,41 +36,25 @@ void runPipeline(llvm::ModulePassManager &mpm, llvm::Module &m,
     std::rethrow_exception(err);
   }
 }
+// Registered Python passes usable by name in a run_passes textual pipeline.
+// Two maps: module passes (named directly, e.g. "my-pass") and function passes
+// (named inside a function(...) pipeline, e.g. "function(my-pass)"). Mirrors
+// the caster registry (Casters.cpp): static maps hold the callables alive,
+// cleared at interpreter exit so the decref happens while the Python runtime is
+// still up.
+std::unordered_map<std::string, nb::callable> &pythonModulePassRegistry() {
+  static std::unordered_map<std::string, nb::callable> registry;
+  return registry;
+}
+std::unordered_map<std::string, nb::callable> &pythonFunctionPassRegistry() {
+  static std::unordered_map<std::string, nb::callable> registry;
+  return registry;
+}
 
-// Bundles the PassBuilder with the four analysis managers and instrumentation,
-// with the lifetimes ModulePassManager::run requires: the managers and the
-// StandardInstrumentations must outlive the run that references them, and the
-// PassBuilder holds a pointer to `pic`. run_passes and run_default_pipeline
-// build this identically, so keeping it in one place stops the two copies from
-// drifting. Member declaration order is the construction order: `pic` before
-// `pb` (which captures &pic), `si` before its registerCallbacks(pic).
-struct PassPipelineEnv {
-  llvm::PassInstrumentationCallbacks pic;
-  llvm::StandardInstrumentations si;
-  llvm::PassBuilder pb;
-  llvm::LoopAnalysisManager lam;
-  llvm::FunctionAnalysisManager fam;
-  llvm::CGSCCAnalysisManager cgam;
-  llvm::ModuleAnalysisManager mam;
-
-  PassPipelineEnv(llvm::LLVMContext &ctx,
-                  const llvm::PipelineTuningOptions &opts, bool debug,
-                  bool verifyEach)
-      : si(ctx, debug, verifyEach), pb(nullptr, opts, std::nullopt, &pic) {
-    si.registerCallbacks(pic);
-    pb.registerModuleAnalyses(mam);
-    pb.registerCGSCCAnalyses(cgam);
-    pb.registerFunctionAnalyses(fam);
-    pb.registerLoopAnalyses(lam);
-    pb.crossRegisterProxies(lam, fam, cgam, mam);
-    // Once a pass callback has stashed an error, skip every subsequent optional
-    // pass so the pipeline winds down to runPipeline's re-raise instead of
-    // running builtins on IR the failed pass may have left half-mutated. (The
-    // manager still runs any isRequired() pass -- those cannot be skipped.)
-    pic.registerShouldRunOptionalPassCallback(
-        [](llvm::StringRef, llvm::Any) { return !pendingPassError; });
-  }
-};
+// Which registry register_python_pass targets (bound as llvm.passmanager
+// PassKind), so the caller picks module vs function with a typed value rather
+// than a stringly-typed flag.
+enum class PyPassKind { Module, Function };
 
 // A new-PM module pass whose body is a Python callable. The new PassManager is
 // concept-based, so a pass needs no LLVM base class beyond the PassInfoMixin
@@ -156,6 +142,69 @@ struct PyFunctionPass : llvm::PassInfoMixin<PyFunctionPass> {
     }
   }
 };
+
+// Bundles the PassBuilder with the four analysis managers and instrumentation,
+// with the lifetimes ModulePassManager::run requires: the managers and the
+// StandardInstrumentations must outlive the run that references them, and the
+// PassBuilder holds a pointer to `pic`. run_passes and run_default_pipeline
+// build this identically, so keeping it in one place stops the two copies from
+// drifting. Member declaration order is the construction order: `pic` before
+// `pb` (which captures &pic), `si` before its registerCallbacks(pic).
+struct PassPipelineEnv {
+  llvm::PassInstrumentationCallbacks pic;
+  llvm::StandardInstrumentations si;
+  llvm::PassBuilder pb;
+  llvm::LoopAnalysisManager lam;
+  llvm::FunctionAnalysisManager fam;
+  llvm::CGSCCAnalysisManager cgam;
+  llvm::ModuleAnalysisManager mam;
+
+  PassPipelineEnv(eudsl::Module &mod, const llvm::PipelineTuningOptions &opts,
+                  bool debug, bool verifyEach)
+      : si(mod.get().getContext(), debug, verifyEach),
+        pb(nullptr, opts, std::nullopt, &pic) {
+    si.registerCallbacks(pic);
+    pb.registerModuleAnalyses(mam);
+    pb.registerCGSCCAnalyses(cgam);
+    pb.registerFunctionAnalyses(fam);
+    pb.registerLoopAnalyses(lam);
+    pb.crossRegisterProxies(lam, fam, cgam, mam);
+    // Once a pass callback has stashed an error, skip every subsequent optional
+    // pass so the pipeline winds down to runPipeline's re-raise instead of
+    // running builtins on IR the failed pass may have left half-mutated. (The
+    // manager still runs any isRequired() pass -- those cannot be skipped.)
+    pic.registerShouldRunOptionalPassCallback(
+        [](llvm::StringRef, llvm::Any) { return !pendingPassError; });
+    // Resolve names registered via register_python_pass when parsing a textual
+    // pipeline. These fire only during parsePassPipeline (inert for the
+    // build*DefaultPipeline and run_python_pass_on_* paths). The module-level
+    // callback captures this call's module so the added pass hands the callback
+    // the right Module wrapper; the function-level callback (consulted inside a
+    // function(...) pipeline) needs no module -- PyFunctionPass gets the
+    // Function directly.
+    eudsl::Module *modPtr = &mod;
+    pb.registerPipelineParsingCallback(
+        [modPtr](llvm::StringRef name, llvm::ModulePassManager &pm,
+                 llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+          auto &reg = pythonModulePassRegistry();
+          auto it = reg.find(std::string(name));
+          if (it == reg.end())
+            return false;
+          pm.addPass(PyModulePass(modPtr, it->second));
+          return true;
+        });
+    pb.registerPipelineParsingCallback(
+        [](llvm::StringRef name, llvm::FunctionPassManager &fpm,
+           llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+          auto &reg = pythonFunctionPassRegistry();
+          auto it = reg.find(std::string(name));
+          if (it == reg.end())
+            return false;
+          fpm.addPass(PyFunctionPass(it->second));
+          return true;
+        });
+  }
+};
 } // namespace
 
 void populate_passes(nb::module_ &m) {
@@ -164,6 +213,10 @@ void populate_passes(nb::module_ &m) {
       .value("O1", llvm::OptimizationLevel::O1)
       .value("O2", llvm::OptimizationLevel::O2)
       .value("O3", llvm::OptimizationLevel::O3);
+
+  nb::enum_<PyPassKind>(m, "PassKind")
+      .value("MODULE", PyPassKind::Module)
+      .value("FUNCTION", PyPassKind::Function);
 
   nb::class_<llvm::PipelineTuningOptions>(m, "PipelineTuningOptions")
       .def(nb::init<>())
@@ -183,7 +236,7 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
+        PassPipelineEnv env(mod, opts, debug, verifyEach);
 
         llvm::ModulePassManager mpm;
         if (llvm::Error err = env.pb.parsePassPipeline(mpm, pipeline))
@@ -201,7 +254,7 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
+        PassPipelineEnv env(mod, opts, debug, verifyEach);
 
         llvm::ModulePassManager mpm =
             (level == llvm::OptimizationLevel::O0)
@@ -220,7 +273,7 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
+        PassPipelineEnv env(mod, opts, debug, verifyEach);
         llvm::ModulePassManager mpm;
         mpm.addPass(PyModulePass(&mod, std::move(callback)));
         runPipeline(mpm, mod.get(), env.mam);
@@ -238,7 +291,7 @@ void populate_passes(nb::module_ &m) {
          bool verifyEach) {
         llvm::PipelineTuningOptions opts =
             pto.value_or(llvm::PipelineTuningOptions());
-        PassPipelineEnv env(mod.get().getContext(), opts, debug, verifyEach);
+        PassPipelineEnv env(mod, opts, debug, verifyEach);
         llvm::ModulePassManager mpm;
         mpm.addPass(llvm::createModuleToFunctionPassAdaptor(
             PyFunctionPass(std::move(callback))));
@@ -249,4 +302,28 @@ void populate_passes(nb::module_ &m) {
       "Run a Python callable as a function pass over each defined function in "
       "the module in place. The callable receives a Function; return a truthy "
       "value if it mutated the function, None/falsy otherwise.");
+
+  m.def(
+      "register_python_pass",
+      [](const std::string &name, nb::callable callback, PyPassKind on) {
+        auto &reg = on == PyPassKind::Function ? pythonFunctionPassRegistry()
+                                               : pythonModulePassRegistry();
+        reg[name] = std::move(callback);
+      },
+      "name"_a, "callback"_a, "on"_a = PyPassKind::Module,
+      "Register a Python callable as a named pass usable in a run_passes "
+      "pipeline. on=PassKind.MODULE (default) names a module pass directly "
+      "(e.g. \"my-pass,instcombine\"); on=PassKind.FUNCTION names a function "
+      "pass, invoked inside a function(...) pipeline (e.g. "
+      "\"function(my-pass)\"). Pick a name that does not collide with a "
+      "builtin pass. The callable follows the run_python_pass_on_module / "
+      "run_python_pass_on_function contract (truthy return marks the IR "
+      "mutated).");
+
+  // Drop the registered callables while the interpreter is still up, so their
+  // decref does not run after Python teardown (mirrors the caster registry).
+  nb::module_::import_("atexit").attr("register")(nb::cpp_function([]() {
+    pythonModulePassRegistry().clear();
+    pythonFunctionPassRegistry().clear();
+  }));
 }

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -40,6 +40,16 @@ _SRC_DECL = dedent("""\
     }
     """)
 
+# Has an `add %x, 0` that instcombine folds away -- lets a composed pipeline
+# show the builtin pass ran after the named Python pass.
+_SRC_ADDZERO = dedent("""\
+    define i32 @f(i32 %x) {
+    entry:
+      %a = add i32 %x, 0
+      ret i32 %a
+    }
+    """)
+
 
 def test_module_pass_is_invoked_once_with_the_module():
     with llvm.ir.Context() as ctx:
@@ -272,5 +282,86 @@ def test_function_pass_forwards_tuning_and_flags():
             mod, lambda fn: names.append(fn.name), tuning=tuning, verify_each=True
         )
         assert sorted(names) == ["f", "g"]
+        del mod
+    assert_no_leaks()
+
+
+def test_registered_pass_runs_by_name():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        calls = []
+
+        def rename(m):
+            calls.append(1)
+            m.get_function("f").name = "renamed"
+
+        llvm.passmanager.register_python_pass("test-rename-f", rename)
+        llvm.passmanager.run_passes(mod, "test-rename-f")
+        assert calls == [1]
+        assert "@renamed(" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_registered_pass_composes_with_builtin():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC_ADDZERO, ctx, "m")
+
+        def rename(m):
+            m.get_function("f").name = "renamed"
+
+        llvm.passmanager.register_python_pass("test-rename-compose", rename)
+        # Named Python pass then a builtin, in order.
+        llvm.passmanager.run_passes(mod, "test-rename-compose,instcombine")
+        assert "@renamed(" in str(mod)
+        assert "add i32 %x, 0" not in str(mod)  # instcombine ran too
+        del mod
+    assert_no_leaks()
+
+
+def test_unregistered_name_still_raises():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        with pytest.raises(RuntimeError, match="unknown pass name"):
+            llvm.passmanager.run_passes(mod, "definitely-not-registered")
+        del mod
+    assert_no_leaks()
+
+
+def test_registered_function_pass_runs_by_name():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC2, ctx, "m")
+        names = []
+        llvm.passmanager.register_python_pass(
+            "test-collect-fn",
+            lambda fn: names.append(fn.name),
+            on=llvm.passmanager.PassKind.FUNCTION,
+        )
+        # Function passes are named inside a function(...) pipeline.
+        llvm.passmanager.run_passes(mod, "function(test-collect-fn)")
+        assert sorted(names) == ["f", "g"]
+        del mod
+    assert_no_leaks()
+
+
+def test_register_python_pass_rejects_non_passkind():
+    # `on` is a typed PassKind enum, not a string.
+    with pytest.raises(TypeError):
+        llvm.passmanager.register_python_pass("bad", lambda m: None, on="module")
+
+
+def test_raising_pass_skips_rest_of_pipeline():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC_ADDZERO, ctx, "m")
+
+        def raiser(m):
+            raise ValueError("stop the pipeline")
+
+        llvm.passmanager.register_python_pass("test-raiser", raiser)
+        with pytest.raises(ValueError, match="stop the pipeline"):
+            llvm.passmanager.run_passes(mod, "test-raiser,instcombine")
+        # After the raise, the remaining optional passes are skipped, so the
+        # add-zero instcombine would have folded is still present.
+        assert "add i32 %x, 0" in str(mod)
         del mod
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -311,10 +311,68 @@ def test_registered_pass_composes_with_builtin():
             m.get_function("f").name = "renamed"
 
         llvm.passmanager.register_python_pass("test-rename-compose", rename)
-        # Named Python pass then a builtin, in order.
+        # A named Python pass and a builtin in one pipeline: both run. This does
+        # not prove ordering -- the two effects (rename, add-zero fold) are
+        # independent -- only that composition works; ordering is pinned
+        # separately in test_registered_passes_run_in_pipeline_order.
         llvm.passmanager.run_passes(mod, "test-rename-compose,instcombine")
         assert "@renamed(" in str(mod)
         assert "add i32 %x, 0" not in str(mod)  # instcombine ran too
+        del mod
+    assert_no_leaks()
+
+
+def test_registered_passes_run_in_pipeline_order():
+    # Two registered Python passes composed as "p1,p2" run in textual order.
+    # Each records its name when invoked, so the recorded sequence pins order
+    # (it would flip if the pipeline ran them in registration/other order).
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        order = []
+        llvm.passmanager.register_python_pass(
+            "test-order-p1", lambda m: order.append("p1")
+        )
+        llvm.passmanager.register_python_pass(
+            "test-order-p2", lambda m: order.append("p2")
+        )
+        llvm.passmanager.run_passes(mod, "test-order-p1,test-order-p2")
+        assert order == ["p1", "p2"]
+        del mod
+    assert_no_leaks()
+
+
+def test_register_python_pass_last_write_wins():
+    # Registering the same name twice replaces the callable (map assignment);
+    # the pipeline invokes only the most recent one.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        calls = []
+        llvm.passmanager.register_python_pass(
+            "test-overwrite", lambda m: calls.append("first")
+        )
+        llvm.passmanager.register_python_pass(
+            "test-overwrite", lambda m: calls.append("second")
+        )
+        llvm.passmanager.run_passes(mod, "test-overwrite")
+        assert calls == ["second"]
+        del mod
+    assert_no_leaks()
+
+
+def test_registered_pass_truthy_return_via_named_path():
+    # The truthy-return -> "changed" convention holds through the named textual
+    # path too (not just the direct run_python_pass_on_module call): the pass
+    # runs and its mutation persists.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+
+        def rename_changed(m):
+            m.get_function("f").name = "renamed"
+            return True  # truthy -> reported changed
+
+        llvm.passmanager.register_python_pass("test-named-changed", rename_changed)
+        llvm.passmanager.run_passes(mod, "test-named-changed")
+        assert "@renamed(" in str(mod)
         del mod
     assert_no_leaks()
 

--- a/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
+++ b/projects/eudsl-llvmpy/tests/passmanager/test_python_passes.py
@@ -365,3 +365,26 @@ def test_raising_pass_skips_rest_of_pipeline():
         assert "add i32 %x, 0" in str(mod)
         del mod
     assert_no_leaks()
+
+
+def test_raising_module_pass_skips_later_python_pass():
+    # Two module-level Python passes composed as "p1,p2": when p1 raises, the
+    # ShouldRun callback must skip p2 as well (not just builtin passes), so p2's
+    # callback never runs and the first error is what propagates.
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        second_ran = []
+
+        def raiser(m):
+            raise ValueError("stop after p1")
+
+        def second(m):
+            second_ran.append(True)
+
+        llvm.passmanager.register_python_pass("test-p1-raiser", raiser)
+        llvm.passmanager.register_python_pass("test-p2-observer", second)
+        with pytest.raises(ValueError, match="stop after p1"):
+            llvm.passmanager.run_passes(mod, "test-p1-raiser,test-p2-observer")
+        assert second_ran == []  # p2 was skipped after p1 raised
+        del mod
+    assert_no_leaks()


### PR DESCRIPTION
register_python_pass(name, callback) records a callable in a static
registry (mirroring the caster registry, cleared at atexit). PassPipelineEnv
now takes the Module and installs a registerPipelineParsingCallback that
resolves a registered name to a PyModulePass, so a registered pass can be
named inside a run_passes pipeline (e.g. "my-pass,instcombine"). The
callback captures the current module and fires only during
parsePassPipeline, so it stays inert for the default-pipeline paths.