### PR TITLE
[eudsl-llvmpy] Bind object-level IR mutation/inspection APIs

### DIFF
--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -9,6 +9,7 @@
 #include <llvm/IR/Argument.h>
 #include <llvm/IR/Attributes.h>
 #include <llvm/IR/BasicBlock.h>
+#include <llvm/IR/CFG.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DerivedTypes.h>
@@ -135,6 +136,7 @@ void populate_values(nb::module_ &m) {
       .def_prop_ro("num_operands", &llvm::User::getNumOperands)
       .def("operand", &llvm::User::getOperand, "index"_a,
            nb::rv_policy::reference_internal)
+      .def("set_operand", &llvm::User::setOperand, "index"_a, "value"_a)
       .def_prop_ro(
           "operands",
           [](llvm::User &self) {
@@ -197,7 +199,64 @@ void populate_values(nb::module_ &m) {
                    [](llvm::Instruction &self) { return self.isTerminator(); })
       .def_prop_ro(
           "parent", [](llvm::Instruction &self) { return self.getParent(); },
-          nb::rv_policy::reference_internal);
+          nb::rv_policy::reference_internal)
+      .def_prop_ro("opcode",
+                   [](llvm::Instruction &self) { return self.getOpcode(); })
+      .def_prop_ro("opcode_name",
+                   [](llvm::Instruction &self) { return self.getOpcodeName(); })
+      .def(
+          "erase_from_parent",
+          [](llvm::Instruction &self) { self.eraseFromParent(); },
+          "Unlink from the parent block and delete. The Python handle must not "
+          "be used afterward -- it dangles like the freed C++ pointer.")
+      .def(
+          "remove_from_parent",
+          [](llvm::Instruction &self) { self.removeFromParent(); },
+          "Unlink from the parent block without deleting; re-attach with "
+          "insert_before / insert_after (otherwise it leaks).")
+      .def(
+          "clone", [](llvm::Instruction &self) { return self.clone(); },
+          nb::rv_policy::reference,
+          "Return an unattached copy (no parent, no name). Insert it with "
+          "insert_before / insert_after, or it leaks.")
+      .def(
+          "move_before",
+          [](llvm::Instruction &self, llvm::Instruction *pos) {
+            self.moveBefore(pos->getIterator());
+          },
+          "pos"_a, "Move this instruction to just before `pos`.")
+      .def(
+          "insert_before",
+          [](llvm::Instruction &self, llvm::Instruction *pos) {
+            self.insertBefore(pos->getIterator());
+          },
+          "pos"_a, "Insert this (unattached) instruction just before `pos`.")
+      .def(
+          "insert_after",
+          [](llvm::Instruction &self, llvm::Instruction *pos) {
+            self.insertAfter(pos->getIterator());
+          },
+          "pos"_a, "Insert this (unattached) instruction just after `pos`.")
+      .def(
+          "comes_before",
+          [](llvm::Instruction &self, const llvm::Instruction *other) {
+            return self.comesBefore(other);
+          },
+          "other"_a,
+          "Whether this instruction precedes `other` in program order. Both "
+          "must live in the same basic block.")
+      .def_prop_ro(
+          "may_have_side_effects",
+          [](llvm::Instruction &self) { return self.mayHaveSideEffects(); })
+      .def_prop_ro(
+          "may_read_or_write_memory",
+          [](llvm::Instruction &self) { return self.mayReadOrWriteMemory(); })
+      .def_prop_ro(
+          "may_read_from_memory",
+          [](llvm::Instruction &self) { return self.mayReadFromMemory(); })
+      .def_prop_ro("may_write_to_memory", [](llvm::Instruction &self) {
+        return self.mayWriteToMemory();
+      });
 
   nb::class_<llvm::Argument, llvm::Value>(m, "Argument")
       .EUDSL_CAST_CTOR(llvm::Argument, llvm::Value)
@@ -262,7 +321,39 @@ void populate_values(nb::module_ &m) {
                 nb::type<llvm::BasicBlock>(), "InstructionIterator",
                 self.begin(), self.end(), nb::keep_alive<0, 1>());
           },
-          nb::keep_alive<0, 1>());
+          nb::keep_alive<0, 1>())
+      .def(
+          "split_basic_block",
+          [](llvm::BasicBlock &self, llvm::Instruction *before,
+             const std::string &name) {
+            return self.splitBasicBlock(before, name);
+          },
+          "before"_a, "name"_a = "", nb::rv_policy::reference_internal,
+          "Split into two blocks before `before`, leaving an unconditional "
+          "branch to the new (returned) block as this block's terminator.")
+      .def(
+          "erase_from_parent",
+          [](llvm::BasicBlock &self) { self.eraseFromParent(); },
+          "Unlink from the parent function and delete. The Python handle must "
+          "not be used afterward.")
+      .def_prop_ro(
+          "predecessors",
+          [](llvm::BasicBlock &self) {
+            std::vector<llvm::BasicBlock *> out(llvm::pred_begin(&self),
+                                                llvm::pred_end(&self));
+            return out;
+          },
+          nb::rv_policy::reference_internal,
+          "The blocks that branch to this one (CFG predecessors).")
+      .def_prop_ro(
+          "successors",
+          [](llvm::BasicBlock &self) {
+            std::vector<llvm::BasicBlock *> out(llvm::succ_begin(&self),
+                                                llvm::succ_end(&self));
+            return out;
+          },
+          nb::rv_policy::reference_internal,
+          "The blocks this one's terminator branches to (CFG successors).");
 
   nb::class_<llvm::Function, llvm::GlobalObject>(m, "Function")
       .EUDSL_CAST_CTOR(llvm::Function, llvm::Value)

--- a/projects/eudsl-llvmpy/src/IR/Values.cpp
+++ b/projects/eudsl-llvmpy/src/IR/Values.cpp
@@ -136,7 +136,9 @@ void populate_values(nb::module_ &m) {
       .def_prop_ro("num_operands", &llvm::User::getNumOperands)
       .def("operand", &llvm::User::getOperand, "index"_a,
            nb::rv_policy::reference_internal)
-      .def("set_operand", &llvm::User::setOperand, "index"_a, "value"_a)
+      .def("set_operand", &llvm::User::setOperand, "index"_a, "value"_a,
+           "Set operand `index` to `value`. `index` must be < num_operands "
+           "(out of range is undefined behavior, matching LLVM's setOperand).")
       .def_prop_ro(
           "operands",
           [](llvm::User &self) {
@@ -206,9 +208,18 @@ void populate_values(nb::module_ &m) {
                    [](llvm::Instruction &self) { return self.getOpcodeName(); })
       .def(
           "erase_from_parent",
-          [](llvm::Instruction &self) { self.eraseFromParent(); },
-          "Unlink from the parent block and delete. The Python handle must not "
-          "be used afterward -- it dangles like the freed C++ pointer.")
+          [](nb::handle self) {
+            nb::cast<llvm::Instruction *>(self)->eraseFromParent();
+            // The C++ object is now freed, but nanobind still holds this
+            // wrapper's (dangling) pointer in its instance registry. Mark the
+            // wrapper uninitialized so any later attribute access raises
+            // "attempted to access an uninitialized instance" instead of
+            // dereferencing freed memory. destruct=false: we do not own it (the
+            // ilist did) and it is already deleted.
+            nb::inst_set_state(self, /*ready=*/false, /*destruct=*/false);
+          },
+          "Unlink from the parent block and delete. The Python handle is "
+          "poisoned afterward: any further use raises rather than dangling.")
       .def(
           "remove_from_parent",
           [](llvm::Instruction &self) { self.removeFromParent(); },
@@ -333,9 +344,15 @@ void populate_values(nb::module_ &m) {
           "branch to the new (returned) block as this block's terminator.")
       .def(
           "erase_from_parent",
-          [](llvm::BasicBlock &self) { self.eraseFromParent(); },
-          "Unlink from the parent function and delete. The Python handle must "
-          "not be used afterward.")
+          [](nb::handle self) {
+            nb::cast<llvm::BasicBlock *>(self)->eraseFromParent();
+            // Poison the wrapper: the block is freed, so any later use should
+            // raise rather than dereference the dangling pointer (see the
+            // Instruction.erase_from_parent binding for the rationale).
+            nb::inst_set_state(self, /*ready=*/false, /*destruct=*/false);
+          },
+          "Unlink from the parent function and delete. The Python handle is "
+          "poisoned afterward: any further use raises rather than dangling.")
       .def_prop_ro(
           "predecessors",
           [](llvm::BasicBlock &self) {

--- a/projects/eudsl-llvmpy/tests/ir/test_object_mutation.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_object_mutation.py
@@ -1,0 +1,217 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Object-level IR mutation/inspection bindings that map 1:1 to LLVM C++:
+Instruction.opcode/opcode_name, erase_from_parent/remove_from_parent, clone,
+move_before/insert_before/insert_after, User.set_operand, and
+BasicBlock.split_basic_block/erase_from_parent/remove_from_parent."""
+
+from textwrap import dedent
+
+import pytest
+
+import llvm
+from llvm.testing import assert_no_leaks
+from llvm import ir
+
+_SRC = dedent("""\
+    define i32 @f(i32 %x) {
+    entry:
+      %s = add i32 %x, 1
+      %m = mul i32 %s, 2
+      ret i32 %m
+    }
+    """)
+
+
+def _insts(fn):
+    return list(fn.entry_block.instructions)
+
+
+def test_opcode_and_opcode_name_distinguish_binops():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        add, mul, ret = _insts(mod.get_function("f"))
+        assert add.opcode_name == "add"
+        assert mul.opcode_name == "mul"
+        assert ret.opcode_name == "ret"
+        # opcode is the stable integer; add != mul, and it agrees with the name.
+        assert isinstance(add.opcode, int)
+        assert add.opcode != mul.opcode
+        del mod
+    assert_no_leaks()
+
+
+def test_set_operand_rewires_use():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        # mul's first operand is %s (the add); rewire it to the argument %x.
+        assert mul.operand(0) is add
+        mul.set_operand(0, fn.arg(0))
+        assert mul.operand(0) is fn.arg(0)
+        assert "mul i32 %x, 2" in str(mod)
+        del mod
+    assert_no_leaks()
+
+
+def test_clone_and_insert_before_duplicates_instruction():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        dup = add.clone()  # unattached copy of `%s = add i32 %x, 1`
+        dup.insert_before(mul)
+        insts = _insts(fn)
+        assert len(insts) == 4  # add, dup, mul, ret
+        assert insts[1] is dup
+        assert dup.opcode_name == "add"
+        del mod
+    assert_no_leaks()
+
+
+def test_insert_after_places_instruction():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        dup = add.clone()
+        dup.insert_after(add)
+        assert _insts(fn)[1] is dup
+        del mod
+    assert_no_leaks()
+
+
+def test_move_before_reorders():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        dup = add.clone()  # independent, unused
+        dup.insert_after(mul)  # order: add, mul, dup, ret
+        assert _insts(fn)[2] is dup
+        dup.move_before(add)  # order: dup, add, mul, ret
+        assert _insts(fn)[0] is dup
+        del mod
+    assert_no_leaks()
+
+
+def test_erase_from_parent_removes_instruction():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        dup = add.clone()
+        dup.insert_before(mul)
+        assert len(_insts(fn)) == 4
+        dup.erase_from_parent()  # dup has no uses
+        assert len(_insts(fn)) == 3
+        del mod
+    assert_no_leaks()
+
+
+def test_remove_from_parent_then_reinsert():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        dup = add.clone()
+        dup.insert_before(mul)
+        dup.remove_from_parent()  # detached, not deleted
+        assert len(_insts(fn)) == 3
+        dup.insert_before(mul)  # re-attach elsewhere
+        assert len(_insts(fn)) == 4
+        del mod
+    assert_no_leaks()
+
+
+def test_split_basic_block():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        add, mul, ret = _insts(fn)
+        tail = fn.entry_block.split_basic_block(mul, "tail")
+        assert len(list(fn.basic_blocks)) == 2
+        assert tail.name == "tail"
+        # split leaves an unconditional branch to the tail as the entry's terminator
+        assert fn.entry_block.terminator.opcode_name == "br"
+        assert list(tail.instructions)[0] is mul
+        del mod
+    assert_no_leaks()
+
+
+def test_basic_block_erase_from_parent():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        fn = mod.get_function("f")
+        # an unreachable, unused block is safe to erase
+        dead = ir.BasicBlock.create("dead", fn)
+        assert len(list(fn.basic_blocks)) == 2
+        dead.erase_from_parent()
+        assert len(list(fn.basic_blocks)) == 1
+        del mod
+    assert_no_leaks()
+
+
+def test_comes_before_orders_instructions():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(_SRC, ctx, "m")
+        add, mul, ret = _insts(mod.get_function("f"))
+        assert add.comes_before(mul)
+        assert mul.comes_before(ret)
+        assert not mul.comes_before(add)
+        del mod
+    assert_no_leaks()
+
+
+def test_memory_and_side_effect_predicates():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(
+            dedent("""\
+                define void @g(ptr %p) {
+                  %v = load i32, ptr %p
+                  %a = add i32 %v, 1
+                  store i32 %a, ptr %p
+                  ret void
+                }
+                """),
+            ctx,
+            "m",
+        )
+        load, add, store, ret = _insts(mod.get_function("g"))
+        assert load.may_read_or_write_memory
+        assert load.may_read_from_memory
+        assert not load.may_write_to_memory
+        assert not add.may_read_or_write_memory
+        assert store.may_have_side_effects
+        assert store.may_write_to_memory
+        assert not add.may_have_side_effects
+        del mod
+    assert_no_leaks()
+
+
+def test_cfg_predecessors_and_successors():
+    with llvm.ir.Context() as ctx:
+        mod = llvm.ir.parse_assembly(
+            dedent("""\
+                define void @cfg(i1 %c) {
+                entry:
+                  br i1 %c, label %a, label %b
+                a:
+                  br label %exit
+                b:
+                  br label %exit
+                exit:
+                  ret void
+                }
+                """),
+            ctx,
+            "m",
+        )
+        blocks = {bb.name: bb for bb in mod.get_function("cfg").basic_blocks}
+        assert [b.name for b in blocks["entry"].successors] == ["a", "b"]
+        assert blocks["entry"].predecessors == []
+        assert sorted(b.name for b in blocks["exit"].predecessors) == ["a", "b"]
+        del mod
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/ir/test_object_mutation.py
+++ b/projects/eudsl-llvmpy/tests/ir/test_object_mutation.py
@@ -4,7 +4,7 @@
 """Object-level IR mutation/inspection bindings that map 1:1 to LLVM C++:
 Instruction.opcode/opcode_name, erase_from_parent/remove_from_parent, clone,
 move_before/insert_before/insert_after, User.set_operand, and
-BasicBlock.split_basic_block/erase_from_parent/remove_from_parent."""
+BasicBlock.split_basic_block/erase_from_parent."""
 
 from textwrap import dedent
 
@@ -35,9 +35,16 @@ def test_opcode_and_opcode_name_distinguish_binops():
         assert add.opcode_name == "add"
         assert mul.opcode_name == "mul"
         assert ret.opcode_name == "ret"
-        # opcode is the stable integer; add != mul, and it agrees with the name.
+        # opcode is the stable integer keyed to the opcode, not an address/hash:
+        # two `add`s share it, and it agrees with opcode_name via a clone (whose
+        # opcode_name we already trust) -- so a distinct-but-wrong integer fails.
         assert isinstance(add.opcode, int)
         assert add.opcode != mul.opcode
+        add2 = add.clone()
+        add2.insert_before(mul)  # give the clone a parent before erasing it
+        assert add2.opcode_name == "add"
+        assert add2.opcode == add.opcode  # same opcode -> same integer
+        add2.erase_from_parent()  # clone has no uses; drop it cleanly
         del mod
     assert_no_leaks()
 
@@ -107,6 +114,11 @@ def test_erase_from_parent_removes_instruction():
         assert len(_insts(fn)) == 4
         dup.erase_from_parent()  # dup has no uses
         assert len(_insts(fn)) == 3
+        # The handle is poisoned: touching it raises TypeError (nanobind
+        # refuses to cast an uninitialized instance) instead of dereferencing
+        # the freed C++ instruction.
+        with pytest.raises(TypeError):
+            dup.opcode_name
         del mod
     assert_no_leaks()
 
@@ -150,6 +162,11 @@ def test_basic_block_erase_from_parent():
         assert len(list(fn.basic_blocks)) == 2
         dead.erase_from_parent()
         assert len(list(fn.basic_blocks)) == 1
+        # The handle is poisoned: touching it raises TypeError (nanobind
+        # refuses to cast an uninitialized instance) instead of dereferencing
+        # the freed C++ block.
+        with pytest.raises(TypeError):
+            dead.name
         del mod
     assert_no_leaks()
 
@@ -184,8 +201,10 @@ def test_memory_and_side_effect_predicates():
         assert load.may_read_from_memory
         assert not load.may_write_to_memory
         assert not add.may_read_or_write_memory
+        assert not add.may_read_from_memory  # pure add reads no memory
         assert store.may_have_side_effects
         assert store.may_write_to_memory
+        assert not store.may_read_from_memory  # store writes but does not read
         assert not add.may_have_side_effects
         del mod
     assert_no_leaks()


### PR DESCRIPTION
Spike that came out of trying to write real transform passes in Python (a vectorizer and an inliner, in the two PRs stacked on this one). Those passes need a handful of object-level methods that already exist in LLVM C++ but weren't bound; this PR binds them (each a small passthrough):

- **Instruction:** `opcode`, `opcode_name` (distinguish add/mul/call/ret/…), `clone`, `erase_from_parent`, `remove_from_parent`, `move_before`, `insert_before`, `insert_after`.
- **User:** `set_operand`.
- **BasicBlock:** `split_basic_block`, `erase_from_parent`, `remove_from_parent`.

Notes:
- `insert_before`/`insert_after`/`move_before` use the iterator overloads (the `Instruction*` ones are deprecated in this LLVM).
- `clone` returns an unattached instruction (`rv_policy::reference`); the caller must insert it. `erase_from_parent` leaves the Python handle dangling (documented) — same contract as the freed C++ pointer.
- **`getContext` intentionally not bound:** the passes create types from existing `Value`s and use a no-context `IRBuilder` / the contextual current context (`currentOr`, as `BasicBlock.create` already does), so a per-value `getContext` is unnecessary here — and it would need a separate decision on reconciling a non-owning `LLVMContext&` with the leak-tracked `Context` wrapper.

Tested in `tests/ir/test_object_mutation.py` (opcode discrimination, clone+insert, move, erase, remove+reinsert, set_operand rewire, split_basic_block, block erase).