### PR TITLE
[eudsl-llvmpy] Build only cp312 for the abi3 wheel (fix abi3audit failure)

### DIFF
--- a/projects/eudsl-llvmpy/pyproject.toml
+++ b/projects/eudsl-llvmpy/pyproject.toml
@@ -5,8 +5,11 @@
 
 [project]
 name = "eudsl-llvmpy"
+# The extension is built against the CPython stable ABI (nanobind STABLE_ABI),
+# which nanobind only honors on Python >= 3.12, and the wheel is tagged
+# cp312-abi3 (see wheel.py-api). pip therefore only installs it on 3.12+.
 version = "0.0.1"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 [project.urls]
 Homepage = "https://github.com/llvm/eudsl"
@@ -68,6 +71,16 @@ omit = [
 
 [tool.cibuildwheel]
 build-verbosity = 1
+# The extension is built against the stable ABI (nanobind STABLE_ABI) and the
+# wheel is tagged cp312-abi3 (see wheel.py-api). nanobind only honors the stable
+# ABI on Python >= 3.12; on 3.10/3.11 it emits a version-specific
+# `.cpython-31X.so` that links private CPython symbols. Because the extension is
+# written into src/llvm (packaged wholesale via wheel.packages) and cibuildwheel
+# does not clean that shared source tree between per-version builds, those
+# non-abi3 .so files would leak into the single cp312-abi3 wheel and fail the
+# abi3audit check cibuildwheel runs on abi3 wheels. One cp312 build produces the
+# one abi3 extension the wheel needs (installable on 3.12+), so build only that.
+build = ["cp312-*"]
 skip = ["*-manylinux_i686", "*-musllinux*", "pp*", "*-win32"]
 archs = ["auto64"]
 manylinux-x86_64-image = "manylinux_2_28"

--- a/projects/eudsl-llvmpy/pyproject.toml
+++ b/projects/eudsl-llvmpy/pyproject.toml
@@ -71,15 +71,6 @@ omit = [
 
 [tool.cibuildwheel]
 build-verbosity = 1
-# The extension is built against the stable ABI (nanobind STABLE_ABI) and the
-# wheel is tagged cp312-abi3 (see wheel.py-api). nanobind only honors the stable
-# ABI on Python >= 3.12; on 3.10/3.11 it emits a version-specific
-# `.cpython-31X.so` that links private CPython symbols. Because the extension is
-# written into src/llvm (packaged wholesale via wheel.packages) and cibuildwheel
-# does not clean that shared source tree between per-version builds, those
-# non-abi3 .so files would leak into the single cp312-abi3 wheel and fail the
-# abi3audit check cibuildwheel runs on abi3 wheels. One cp312 build produces the
-# one abi3 extension the wheel needs (installable on 3.12+), so build only that.
 build = ["cp312-*"]
 skip = ["*-manylinux_i686", "*-musllinux*", "pp*", "*-win32"]
 archs = ["auto64"]


### PR DESCRIPTION
## Problem

The `Build eudsl-llvmpy` step fails on every platform in [the `workflow_dispatch` build](https://github.com/llvm/eudsl/actions/runs/32728950842). cibuildwheel runs `abi3audit --strict` on abi3 wheels and it reports **10 ABI violations**: the `cp312-abi3` wheel bundles three extensions, and two of them — `eudslllvm_ext.cpython-310-darwin.so` and `eudslllvm_ext.cpython-311-darwin.so` — link private CPython symbols (`_PyObject_MakeTpCall`, `Py_CompileStringExFlags`, `PyFrame_GetBack`, `_PyObject_LookupAttr`, `PyGILState_Check`, …). The `.abi3.so` itself is clean.

## Root cause

- `wheel.py-api = "cp312"` tags **every** wheel `cp312-abi3`, but on `workflow_dispatch` cibuildwheel iterates cp310/cp311/cp312/cp313…
- nanobind's `STABLE_ABI` is honored **only on Python ≥ 3.12**. On 3.10/3.11 it emits version-specific `.cpython-31X.so` that use private symbols.
- The extension is written into `src/llvm`, which `wheel.packages = ["src/llvm"]` copies wholesale, and cibuildwheel does not clean that shared source tree between per-version builds. So the non-abi3 `.so` from the 3.10/3.11 runs leaked into the single `cp312-abi3` wheel.
- The recent `run_python_pass` work (C++ calling back into Python) is what pulled those private symbols into the 3.10/3.11 builds, tipping abi3audit over.

## Fix

Restrict cibuildwheel to cp312 via `build = ["cp312-*"]`, mirroring the existing `eudsl-nbgen` `build` pin. One cp312 build produces the single clean `.abi3.so` the abi3 wheel needs, installable on 3.12+, with no stale per-version `.so`. Also bump `requires-python` to `>=3.12` so the metadata matches the `cp312-abi3` tag that already gated installs (an abi3 cp312 wheel never installed on 3.10/3.11 regardless).