### PR TITLE
[eudsl] Symlink ccache into /usr/bin in x86_64 before-all

### DIFF
--- a/projects/eudsl-llvmpy/pyproject.toml
+++ b/projects/eudsl-llvmpy/pyproject.toml
@@ -102,7 +102,7 @@ test-command = "ccache -sv"
 before-all = [
     "yum install -y clang libarchive-devel antlr-tool libxml2-devel libxslt-devel libcurl-devel java java-devel",
     # ccache
-    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && popd; fi)",
+    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && ln -s /usr/local/bin/ccache /usr/bin/ccache && popd; fi)",
     "echo $(if [ \"$(arch)\" == \"aarch64\" ]; then dnf install -y ccache; fi)",
     "ccache -z"
 ]

--- a/projects/eudsl-nbgen/pyproject.toml
+++ b/projects/eudsl-nbgen/pyproject.toml
@@ -86,7 +86,7 @@ repair-wheel-command = []
 before-all = [
     "yum install -y clang",
     # ccache
-    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && popd; fi)",
+    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && ln -s /usr/local/bin/ccache /usr/bin/ccache && popd; fi)",
     "echo $(if [ \"$(arch)\" == \"aarch64\" ]; then dnf install -y ccache; fi)",
     "ccache -z"
 ]

--- a/projects/eudsl-py/pyproject.toml
+++ b/projects/eudsl-py/pyproject.toml
@@ -89,7 +89,7 @@ test-command = "ccache -s"
 before-all = [
     "yum install -y clang",
     # ccache
-    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && popd; fi)",
+    "echo $(if [ \"$(arch)\" == \"x86_64\" ]; then curl -sLO https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz && tar -xf ccache-4.10.2-linux-x86_64.tar.xz && pushd ccache-4.10.2-linux-x86_64 && make install && ln -s /usr/local/bin/ccache /usr/bin/ccache && popd; fi)",
     "echo $(if [ \"$(arch)\" == \"aarch64\" ]; then dnf install -y ccache; fi)",
     "ccache -z"
 ]


### PR DESCRIPTION
## Symptom

The `Build eudsl ubuntu_x86_64` job fails while configuring CMake for `eudsl-llvmpy` inside the manylinux/cibuildwheel container:

```
/bin/sh: /usr/bin/ccache: No such file or directory
FAILED: [code=127] ... testCXXCompiler.cxx.o
-- Check for working CXX compiler: /usr/bin/clang++ - broken
```

## Root cause

The build passes `CMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache` into the container (the host runner's `which ccache` resolves to `/usr/bin/ccache`, set in `.github/actions/setup_base/action.yml`). But the container's `before-all` installs ccache from the release tarball via `make install`, which lands it in `/usr/local/bin/ccache` — **not** `/usr/bin/ccache`. CMake's compiler check then invokes a non-existent launcher and dies with exit 127.

`eudsl-tblgen` already works because its `before-all` includes `&& ln -s /usr/local/bin/ccache /usr/bin/ccache`. That symlink was never propagated to `eudsl-llvmpy`, `eudsl-nbgen`, and `eudsl-py`.

## Why it only started failing now (not a code regression)

The eudsl build step branches on the event type (`build_test_release_eudsl.yml:171`):

```bash
if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
    cibuildwheel "$PWD/projects/eudsl-llvmpy" ...                    # build INSIDE the manylinux container
else
    pip wheel "$PWD/projects/eudsl-llvmpy" ... --no-build-isolation  # build on the HOST
fi
```

- **push / pull_request** (everyday CI): `eudsl-llvmpy` and `eudsl-nbgen` are built **on the host** via `pip wheel --no-build-isolation`. The host has ccache at `/usr/bin/ccache` (installed by `aminya/setup-cpp`), so the launcher path resolves fine. ✅
- **workflow_dispatch** (manual/release build): they are built **inside the manylinux container** via `cibuildwheel`, where `/usr/bin/ccache` only exists if `before-all` creates the symlink. ❌

`eudsl-tblgen` is *always* built via cibuildwheel (unconditional, as a cibuildwheel smoketest), so its missing-symlink bug was caught and fixed long ago. The llvmpy/nbgen container paths only execute on `workflow_dispatch`, which is rarely triggered — so the identical bug sat dormant.

The two failing runs were both `workflow_dispatch` on the same commit as the last green push run (no new code) — a rarely-used path was simply invoked, exposing the latent bug.

## Fix

Add the same symlink to the x86_64 branch of `before-all` in `eudsl-llvmpy`, `eudsl-nbgen`, and `eudsl-py`, matching `eudsl-tblgen`. The aarch64 branch is unaffected (`dnf install -y ccache` already places it in `/usr/bin`).

(Note: `eudsl-py` is skipped entirely on `workflow_dispatch` and never uses cibuildwheel today, so its edit is for consistency/future-proofing; `eudsl-llvmpy` and `eudsl-nbgen` are the ones actually failing.)