### PR TITLE
[eudsl-llvmpy] Typed Register (owning function) + generic build; drop DSL anchor (#593 item 2)

### DIFF
--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -4,6 +4,16 @@ Guidance for this project: the hand-written nanobind bindings over the LLVM
 C++ API, plus the DSL frontend built on them. These apply to every PR in the
 stack, so check new code against them before pushing.
 
+## Breaking changes are fine
+
+There are no stability contracts here -- no external API guarantees, and no
+test expectation is sacred. Make a breaking change whenever it makes sense or
+improves the APIs/functionality: change signatures, rename bindings, alter
+equality/hash semantics, drop a behavior. Do not preserve a worse design for
+backward compatibility. When you make such a change, update the affected tests,
+docstrings, and README to match rather than working around them -- a pinned
+assertion that documents the old behavior is something to update, not defend.
+
 ## Mirror the LLVM C++ API
 
 Bind names as LLVM spells them. Do not rename or merge a method or field

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -255,7 +255,10 @@ The object model is bound as its own hierarchy (MIR is not part of the `Value`
 hierarchy): `MachineFunction`, `MachineBasicBlock`, `MachineInstr`,
 `MachineOperand`, `Register`, plus `LLT` (the generic low-level type) and
 `MachineFunctionProperty`. `MirModule` owns the `MachineFunction`s and
-keeps everything they reference alive.
+keeps everything they reference alive. A `Register` carries the
+`MachineFunction` that minted it (a physical register carries none), so a vreg
+passed into a *different* function's builder is rejected — its numeric id would
+otherwise silently alias a same-typed register in that function.
 
 > The examples below use AArch64 opcodes/registers/triples, so they need the
 > AArch64 backend linked (`EUDSL_LLVMPY_TARGETS`); on other hosts
@@ -336,6 +339,9 @@ already-selected **target** MIR directly and run only the back half of codegen.
 `reg_class`/`physreg` resolve register classes and physical registers by name,
 `create_vreg` makes class-constrained vregs, `add_reg` appends operands with the
 full flag set (def/use, implicit, kill, …), and `set_property` marks the function.
+(`build(opcode, dsts, srcs)` is a typed one-shot alternative to
+`build_instr` + `add_reg`: each dst is an `LLT` to mint a fresh vreg for or a
+`Register` to define, each src is a `Register` use.)
 `emit_object()` then runs register allocation and emission (via
 `-start-after=finalize-isel`, so no instruction selection), and `LLJIT.add_object`
 loads the result:

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -361,9 +361,11 @@ with ir.Context() as ctx:
     mf.blocks[0].add_livein(w0); mf.blocks[0].add_livein(w1)
     v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
     for dst, src in ((v0, w0), (v1, w1)):
-        c = b.build_instr(mf.opcode("COPY")); c.add_reg(dst, is_def=True); c.add_reg(src)
-    a = b.build_instr(mf.opcode("ADDWrr")); a.add_reg(v2, is_def=True); a.add_reg(v0); a.add_reg(v1)
-    c = b.build_instr(mf.opcode("COPY")); c.add_reg(w0, is_def=True); c.add_reg(v2)
+        b.build(mf.opcode("COPY"), [dst], [src])   # dst = COPY src
+    b.build(mf.opcode("ADDWrr"), [v2], [v0, v1])   # v2 = ADDWrr v0, v1
+    b.build(mf.opcode("COPY"), [w0], [v2])         # $w0 = COPY v2
+    # RET_ReallyLR takes an *implicit* use of $w0, which build's plain-use srcs
+    # can't express, so drop to build_instr + add_reg for that one operand.
     r = b.build_instr(mf.opcode("RET_ReallyLR")); r.add_reg(w0, implicit=True)
     for p in ("IsSSA", "TracksLiveness", "NoPHIs"):
         mf.set_property(getattr(mir.MachineFunctionProperty, p))

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -5,6 +5,7 @@
 #include "IR/Common.h"
 #include "IR/Ownership.h"
 
+#include <llvm/ADT/Hashing.h>
 #include <llvm/CodeGen/GlobalISel/MachineIRBuilder.h>
 #include <llvm/CodeGen/MIRParser/MIRParser.h>
 #include <llvm/CodeGen/MIRPrinter.h>
@@ -109,9 +110,10 @@ std::string withDetail(llvm::StringRef base, const std::string &detail) {
 // by the `owned` factory from the register's own virtual-ness, and the
 // constructor is private, so no caller can construct an inconsistent pairing (a
 // vreg with no owner, or a physreg with one) -- the illegal states are
-// unrepresentable. Equality and hashing are by register id (see the binding),
-// so they are intra-function only; the owner is consulted only when a register
-// is consumed by the builder.
+// unrepresentable. Equality and hashing consider both id and owner, so two
+// same-id registers from different functions are distinct rather than
+// colliding; the owner is also checked whenever a register is consumed by the
+// builder.
 class TypedRegister {
 public:
   static TypedRegister owned(llvm::MachineFunction &mf, llvm::Register reg) {
@@ -535,11 +537,10 @@ void populate_mir(nb::module_ &m) {
   // target's real registers). Bound as TypedRegister so a virtual register also
   // carries the MachineFunction that minted it (physregs carry none), letting
   // the builder reject a register passed into a different function. Equality
-  // and hashing are by id -- a register's identity *within its function* -- so
-  // two registers with the same id from different functions compare and hash
-  // equal even though they are distinct; do not key a set/dict on registers
-  // gathered across functions. (The builder still rejects a cross-function
-  // register at build time regardless.)
+  // and hashing consider both id and owner, so two same-id registers from
+  // different functions are distinct -- they can safely coexist as set/dict
+  // keys, and a cross-function `==` is False (as well as rejected at build
+  // time).
   nb::class_<TypedRegister>(m, "Register")
       .def_prop_ro("id", [](TypedRegister &self) { return self.reg().id(); })
       .def_prop_ro("is_valid",
@@ -557,17 +558,18 @@ void populate_mir(nb::module_ &m) {
       .def(
           "__eq__",
           [](TypedRegister &self, TypedRegister other) {
-            return self.reg() == other.reg();
+            return self.reg() == other.reg() && self.owner() == other.owner();
           },
           nb::is_operator())
       .def(
           "__ne__",
           [](TypedRegister &self, TypedRegister other) {
-            return self.reg() != other.reg();
+            return self.reg() != other.reg() || self.owner() != other.owner();
           },
           nb::is_operator())
       .def("__hash__", [](TypedRegister &self) {
-        return static_cast<Py_ssize_t>(self.reg().id());
+        return static_cast<Py_ssize_t>(
+            llvm::hash_combine(self.reg().id(), self.owner()));
       });
 
   // A target register class (e.g. AArch64 GPR32), looked up by name via

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -39,6 +39,7 @@
 #include <llvm/Target/TargetOptions.h>
 
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/variant.h>
 
 #include <memory>
 #include <string>
@@ -89,28 +90,60 @@ std::string withDetail(llvm::StringRef base, const std::string &detail) {
   return (base + ": " + detail).str();
 }
 
+// A machine register paired with the MachineFunction that owns it. A virtual
+// register's numeric id is only an index into its own function's
+// MachineRegisterInfo, so the same id names a *different* register (possibly
+// even a same-typed one) in another function; passing a foreign vreg builds
+// corrupt MIR that the verifier -- gone under NDEBUG -- would otherwise catch.
+// Carrying the owner lets the build/consume helpers reject a cross-function
+// vreg structurally (by identity), rather than hoping a type/index mismatch
+// happens to expose it. A physical register is target-static (the same
+// MCRegister across every function of a target), so it carries a null owner and
+// is accepted anywhere -- matching how physregs are used (block live-ins, COPYs
+// to/from $wN). Equality and hashing stay by register id (see the binding); the
+// owner is consulted only when a register is consumed by the builder.
+struct TypedRegister {
+  llvm::Register reg;
+  llvm::MachineFunction *mf; // owning function for a vreg; null for a physreg
+};
+
+// Reject a virtual register minted by a different MachineFunction than `mf`.
+// This is the single structural cross-function guard shared by every site that
+// consumes a caller-supplied register (the builder helpers, add_reg/def/use,
+// G_PHI incomings, the generic `build`), so the check -- and its message --
+// live in one place. A physical register (null owner) is target-static and
+// passes.
+void requireOwnedVReg(const llvm::MachineFunction &mf, const TypedRegister &reg,
+                      const char *role) {
+  if (reg.reg.isVirtual() && reg.mf != &mf)
+    throw nb::value_error(
+        (std::string(role) + " belongs to a different MachineFunction")
+            .c_str());
+}
+
 // GlobalISel's build helpers validate their operands only with asserts, which
 // are compiled out under NDEBUG (the shipped wheel), so bad input would emit
 // malformed MIR or fault in a later pass instead of raising. Enforce the same
 // preconditions here regardless of build mode: `reg` must be a generic virtual
-// register of `b`'s MachineFunction carrying type `ty`. MachineRegisterInfo::
-// getType returns an invalid LLT{} for a non-virtual, out-of-bounds, or
-// wrong-function register, so a single type compare rejects both a type
-// mismatch and a register minted by a different MachineFunction.
-void requireVRegOfType(llvm::MachineIRBuilder &b, llvm::Register reg,
+// register of `b`'s MachineFunction carrying type `ty`. The owner check rejects
+// a register minted by a different function; MachineRegisterInfo::getType then
+// returns an invalid LLT{} for a non-virtual or out-of-bounds register, so the
+// type compare rejects both a type mismatch and a physical register.
+void requireVRegOfType(llvm::MachineIRBuilder &b, const TypedRegister &reg,
                        llvm::LLT ty, const char *role) {
-  if (b.getMF().getRegInfo().getType(reg) != ty)
+  requireOwnedVReg(b.getMF(), reg, role);
+  if (b.getMF().getRegInfo().getType(reg.reg) != ty)
     throw nb::value_error((std::string(role) +
                            " must be a virtual register of this "
                            "MachineFunction with the result type")
                               .c_str());
 }
 
-// A MachineBasicBlock / Register crosses the Python boundary as a bare handle
-// with no back-link to its function; passing one from a different function
-// builds corrupt MIR (cross-linked CFGs, out-of-bounds vreg indexes) that the
-// verifier -- gone under NDEBUG -- would otherwise catch. Guard provenance
-// against the builder's (or another block's) function.
+// A MachineBasicBlock crosses the Python boundary as a bare handle with no
+// back-link to its function; passing one from a different function builds
+// corrupt MIR (cross-linked CFGs) that the verifier -- gone under NDEBUG --
+// would otherwise catch. Guard provenance against the builder's (or another
+// block's) function. (Registers get the same guarantee from TypedRegister.)
 void requireSameFunction(const llvm::MachineFunction &mf,
                          const llvm::MachineBasicBlock *mbb, const char *role) {
   if (mbb->getParent() != &mf)
@@ -119,9 +152,10 @@ void requireSameFunction(const llvm::MachineFunction &mf,
             .c_str());
 }
 
-void requireVReg(llvm::MachineIRBuilder &b, llvm::Register reg,
+void requireVReg(llvm::MachineIRBuilder &b, const TypedRegister &reg,
                  const char *role) {
-  if (!b.getMF().getRegInfo().getType(reg).isValid())
+  requireOwnedVReg(b.getMF(), reg, role);
+  if (!b.getMF().getRegInfo().getType(reg.reg).isValid())
     throw nb::value_error(
         (std::string(role) +
          " must be a generic virtual register of this MachineFunction")
@@ -162,28 +196,29 @@ const llvm::TargetRegisterInfo &requireTRI(const llvm::MachineFunction &mf) {
 // opposite operand kind (kill on a use, dead on a def) and out-of-range
 // subregister indices -- all guarded by asserts in LLVM that vanish under
 // NDEBUG, so an otherwise-silent corrupt operand would result.
-void addRegOperand(llvm::MachineInstr &mi, llvm::Register reg, bool isDef,
+void addRegOperand(llvm::MachineInstr &mi, const TypedRegister &reg, bool isDef,
                    bool isImp, bool isKill, bool isDead, bool isUndef,
                    bool isEarlyClobber, unsigned subReg, bool isDebug,
                    bool isInternalRead, bool isRenamable) {
+  llvm::MachineFunction &mf = *mi.getMF();
+  requireOwnedVReg(mf, reg, "register");
   if (isKill && isDef)
     throw nb::value_error(
         "is_kill is only valid on a use operand (is_def=False)");
   if (isDead && !isDef)
     throw nb::value_error(
         "is_dead is only valid on a def operand (is_def=True)");
-  if (isRenamable && !reg.isPhysical())
+  if (isRenamable && !reg.reg.isPhysical())
     throw nb::value_error("is_renamable is only valid on a physical register");
-  llvm::MachineFunction &mf = *mi.getMF();
   if (subReg) {
     const llvm::TargetRegisterInfo &tri = requireTRI(mf);
     if (subReg >= tri.getNumSubRegIndices())
       throw nb::index_error("sub_reg index out of range");
   }
-  mi.addOperand(mf,
-                llvm::MachineOperand::CreateReg(
-                    reg, isDef, isImp, isKill, isDead, isUndef, isEarlyClobber,
-                    subReg, isDebug, isInternalRead, isRenamable));
+  mi.addOperand(mf, llvm::MachineOperand::CreateReg(
+                        reg.reg, isDef, isImp, isKill, isDead, isUndef,
+                        isEarlyClobber, subReg, isDebug, isInternalRead,
+                        isRenamable));
 }
 
 // The "current MachineIRBuilder" is tracked on a thread-local stack, mirroring
@@ -476,35 +511,39 @@ void populate_mir(nb::module_ &m) {
 
   // llvm::Register -- a machine register operand's value (a tagged unsigned:
   // virtual registers are SSA-ish temporaries from ISel, physical are the
-  // target's real registers).
-  nb::class_<llvm::Register>(m, "Register")
-      .def_prop_ro("id", [](llvm::Register &self) { return self.id(); })
+  // target's real registers). Bound as TypedRegister so a virtual register also
+  // carries the MachineFunction that minted it (physregs carry none), letting
+  // the builder reject a register passed into a different function. Equality
+  // and hashing are by id (a register's identity within its function),
+  // unchanged.
+  nb::class_<TypedRegister>(m, "Register")
+      .def_prop_ro("id", [](TypedRegister &self) { return self.reg.id(); })
       .def_prop_ro("is_valid",
-                   [](llvm::Register &self) { return self.isValid(); })
+                   [](TypedRegister &self) { return self.reg.isValid(); })
       .def_prop_ro("is_virtual",
-                   [](llvm::Register &self) { return self.isVirtual(); })
+                   [](TypedRegister &self) { return self.reg.isVirtual(); })
       .def_prop_ro("is_physical",
-                   [](llvm::Register &self) { return self.isPhysical(); })
+                   [](TypedRegister &self) { return self.reg.isPhysical(); })
       .def_prop_ro("virt_reg_index",
-                   [](llvm::Register &self) {
-                     if (!self.isVirtual())
+                   [](TypedRegister &self) {
+                     if (!self.reg.isVirtual())
                        throw nb::value_error("register is not virtual");
-                     return self.virtRegIndex();
+                     return self.reg.virtRegIndex();
                    })
       .def(
           "__eq__",
-          [](llvm::Register &self, llvm::Register other) {
-            return self == other;
+          [](TypedRegister &self, TypedRegister other) {
+            return self.reg == other.reg;
           },
           nb::is_operator())
       .def(
           "__ne__",
-          [](llvm::Register &self, llvm::Register other) {
-            return self != other;
+          [](TypedRegister &self, TypedRegister other) {
+            return self.reg != other.reg;
           },
           nb::is_operator())
-      .def("__hash__", [](llvm::Register &self) {
-        return static_cast<Py_ssize_t>(self.id());
+      .def("__hash__", [](TypedRegister &self) {
+        return static_cast<Py_ssize_t>(self.reg.id());
       });
 
   // A target register class (e.g. AArch64 GPR32), looked up by name via
@@ -578,10 +617,18 @@ void populate_mir(nb::module_ &m) {
                      return self.isReg() ? self.getSubReg() : 0;
                    })
       .def_prop_ro("reg",
-                   [](llvm::MachineOperand &self) -> llvm::Register {
+                   [](llvm::MachineOperand &self) -> TypedRegister {
                      if (!self.isReg())
                        throw nb::value_error("operand is not a register");
-                     return self.getReg();
+                     // A virtual register's owner is the function it was read
+                     // from, so a register inspected off one instruction can be
+                     // fed back into that same function's builder; a physreg is
+                     // target-static and carries no owner.
+                     llvm::Register reg = self.getReg();
+                     llvm::MachineInstr *mi = self.getParent();
+                     llvm::MachineFunction *mf =
+                         (reg.isVirtual() && mi) ? mi->getMF() : nullptr;
+                     return TypedRegister{reg, mf};
                    })
       .def_prop_ro("imm",
                    [](llvm::MachineOperand &self) {
@@ -787,7 +834,7 @@ void populate_mir(nb::module_ &m) {
           "Repoint a branch's target block (operand 0), e.g. a G_BR.")
       .def(
           "add_phi_incoming",
-          [](llvm::MachineInstr &self, llvm::Register reg,
+          [](llvm::MachineInstr &self, TypedRegister reg,
              llvm::MachineBasicBlock *mbb) {
             // Appending (value, block) operands only makes sense for a G_PHI;
             // on any other instruction it silently grows it with junk operands
@@ -797,8 +844,9 @@ void populate_mir(nb::module_ &m) {
                   "add_phi_incoming requires a G_PHI instruction");
             }
             llvm::MachineFunction &mf = *self.getMF();
+            requireOwnedVReg(mf, reg, "value");
             self.addOperand(mf,
-                            llvm::MachineOperand::CreateReg(reg,
+                            llvm::MachineOperand::CreateReg(reg.reg,
                                                             /*isDef=*/false));
             self.addOperand(mf, llvm::MachineOperand::CreateMBB(mbb));
           },
@@ -806,7 +854,7 @@ void populate_mir(nb::module_ &m) {
           "Append a (value, predecessor-block) incoming pair to a G_PHI.")
       .def(
           "add_def",
-          [](llvm::MachineInstr &self, llvm::Register reg) {
+          [](llvm::MachineInstr &self, TypedRegister reg) {
             addRegOperand(self, reg, /*isDef=*/true, /*isImp=*/false,
                           /*isKill=*/false, /*isDead=*/false, /*isUndef=*/false,
                           /*isEarlyClobber=*/false, /*subReg=*/0,
@@ -816,7 +864,7 @@ void populate_mir(nb::module_ &m) {
           "reg"_a, "Append a register def operand.")
       .def(
           "add_use",
-          [](llvm::MachineInstr &self, llvm::Register reg, bool implicit) {
+          [](llvm::MachineInstr &self, TypedRegister reg, bool implicit) {
             addRegOperand(self, reg, /*isDef=*/false, /*isImp=*/implicit,
                           /*isKill=*/false, /*isDead=*/false, /*isUndef=*/false,
                           /*isEarlyClobber=*/false, /*subReg=*/0,
@@ -827,7 +875,7 @@ void populate_mir(nb::module_ &m) {
           "Append a register use operand (implicit=True for an implicit use).")
       .def(
           "add_reg",
-          [](llvm::MachineInstr &self, llvm::Register reg, bool isDef,
+          [](llvm::MachineInstr &self, TypedRegister reg, bool isDef,
              bool isImp, bool isKill, bool isDead, bool isUndef,
              bool isEarlyClobber, unsigned subReg, bool isDebug,
              bool isInternalRead, bool isRenamable) {
@@ -929,13 +977,13 @@ void populate_mir(nb::module_ &m) {
           "old"_a, "new"_a, "Replace a CFG successor edge with another block.")
       .def(
           "add_livein",
-          [](llvm::MachineBasicBlock &self, llvm::Register reg) {
+          [](llvm::MachineBasicBlock &self, TypedRegister reg) {
             // asMCReg() only asserts physicality (compiled out under NDEBUG),
             // so a virtual register would be truncated into a garbage
             // MCRegister and recorded as a bogus livein. Reject it here.
-            if (!reg.isPhysical())
+            if (!reg.reg.isPhysical())
               throw nb::value_error("add_livein requires a physical register");
-            self.addLiveIn(reg.asMCReg());
+            self.addLiveIn(reg.reg.asMCReg());
           },
           "reg"_a, "Declare a physical register live-in to this block.")
       .def("__str__",
@@ -968,8 +1016,9 @@ void populate_mir(nb::module_ &m) {
           nb::rv_policy::reference_internal)
       .def(
           "create_generic_virtual_register",
-          [](llvm::MachineFunction &self, llvm::LLT ty) -> llvm::Register {
-            return self.getRegInfo().createGenericVirtualRegister(ty);
+          [](llvm::MachineFunction &self, llvm::LLT ty) -> TypedRegister {
+            return TypedRegister{
+                self.getRegInfo().createGenericVirtualRegister(ty), &self};
           },
           "type"_a, "Create a new generic virtual register of the given LLT.")
       .def(
@@ -992,11 +1041,11 @@ void populate_mir(nb::module_ &m) {
       .def(
           "physreg",
           [](llvm::MachineFunction &self,
-             const std::string &name) -> llvm::Register {
+             const std::string &name) -> TypedRegister {
             const llvm::TargetRegisterInfo &tri = requireTRI(self);
             for (unsigned i = 1, e = tri.getNumRegs(); i < e; ++i) {
               if (name == tri.getName(i))
-                return llvm::Register(i);
+                return TypedRegister{llvm::Register(i), nullptr};
             }
             throw nb::key_error(
                 ("no physical register named '" + name + "'").c_str());
@@ -1005,8 +1054,9 @@ void populate_mir(nb::module_ &m) {
       .def(
           "create_vreg",
           [](llvm::MachineFunction &self,
-             const llvm::TargetRegisterClass *rc) -> llvm::Register {
-            return self.getRegInfo().createVirtualRegister(rc);
+             const llvm::TargetRegisterClass *rc) -> TypedRegister {
+            return TypedRegister{self.getRegInfo().createVirtualRegister(rc),
+                                 &self};
           },
           "reg_class"_a,
           "Create a new virtual register constrained to a register class.")
@@ -1346,7 +1396,7 @@ void populate_mir(nb::module_ &m) {
       .def(
           "build_constant",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
-             int64_t value) -> llvm::Register {
+             int64_t value) -> TypedRegister {
             // buildConstant derives the width from ty's scalar size; a pointer,
             // scalable-vector, or invalid LLT hits asserting accessors that
             // vanish under NDEBUG and would emit a wrong-width G_CONSTANT.
@@ -1354,42 +1404,47 @@ void populate_mir(nb::module_ &m) {
               throw nb::value_error("build_constant requires a scalar or "
                                     "fixed-vector type");
             }
-            return self.buildConstant(ty, value).getReg(0);
+            return TypedRegister{self.buildConstant(ty, value).getReg(0),
+                                 &self.getMF()};
           },
           "type"_a, "value"_a)
       .def(
           "build_add",
-          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
-             llvm::Register rhs) -> llvm::Register {
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, TypedRegister lhs,
+             TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return self.buildAdd(ty, lhs, rhs).getReg(0);
+            return TypedRegister{self.buildAdd(ty, lhs.reg, rhs.reg).getReg(0),
+                                 &self.getMF()};
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_sub",
-          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
-             llvm::Register rhs) -> llvm::Register {
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, TypedRegister lhs,
+             TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return self.buildSub(ty, lhs, rhs).getReg(0);
+            return TypedRegister{self.buildSub(ty, lhs.reg, rhs.reg).getReg(0),
+                                 &self.getMF()};
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_mul",
-          [](llvm::MachineIRBuilder &self, llvm::LLT ty, llvm::Register lhs,
-             llvm::Register rhs) -> llvm::Register {
+          [](llvm::MachineIRBuilder &self, llvm::LLT ty, TypedRegister lhs,
+             TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return self.buildMul(ty, lhs, rhs).getReg(0);
+            return TypedRegister{self.buildMul(ty, lhs.reg, rhs.reg).getReg(0),
+                                 &self.getMF()};
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
           "build_copy",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
-             llvm::Register src) -> llvm::Register {
+             TypedRegister src) -> TypedRegister {
             requireVRegOfType(self, src, ty, "src");
-            return self.buildCopy(ty, src).getReg(0);
+            return TypedRegister{self.buildCopy(ty, src.reg).getReg(0),
+                                 &self.getMF()};
           },
           "type"_a, "src"_a)
       .def_prop_ro(
@@ -1416,8 +1471,8 @@ void populate_mir(nb::module_ &m) {
       .def(
           "build_icmp",
           [](llvm::MachineIRBuilder &self, llvm::CmpInst::Predicate pred,
-             llvm::LLT ty, llvm::Register lhs,
-             llvm::Register rhs) -> llvm::Register {
+             llvm::LLT ty, TypedRegister lhs,
+             TypedRegister rhs) -> TypedRegister {
             // buildICmp only asserts these (gone under NDEBUG): an integer
             // predicate, an s1 (or vector-of-s1) result, and same-typed operand
             // vregs of this function.
@@ -1431,10 +1486,12 @@ void populate_mir(nb::module_ &m) {
             requireVReg(self, lhs, "lhs");
             requireVReg(self, rhs, "rhs");
             const llvm::MachineRegisterInfo &mri = self.getMF().getRegInfo();
-            if (mri.getType(lhs) != mri.getType(rhs))
+            if (mri.getType(lhs.reg) != mri.getType(rhs.reg))
               throw nb::value_error("build_icmp operands must have the same "
                                     "type");
-            return self.buildICmp(pred, ty, lhs, rhs).getReg(0);
+            return TypedRegister{
+                self.buildICmp(pred, ty, lhs.reg, rhs.reg).getReg(0),
+                &self.getMF()};
           },
           "predicate"_a, "type"_a, "lhs"_a, "rhs"_a)
       .def(
@@ -1449,19 +1506,19 @@ void populate_mir(nb::module_ &m) {
           "instruction so its target can be repointed.")
       .def(
           "build_brcond",
-          [](llvm::MachineIRBuilder &self, llvm::Register cond,
+          [](llvm::MachineIRBuilder &self, TypedRegister cond,
              llvm::MachineBasicBlock *dest) {
             requireVReg(self, cond, "cond");
             requireSameFunction(self.getMF(), dest, "dest");
-            self.buildBrCond(cond, *dest);
+            self.buildBrCond(cond.reg, *dest);
           },
           "cond"_a, "dest"_a,
           "Build a conditional branch (G_BRCOND) on `cond` to `dest`.")
       .def(
           "build_phi",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
-             std::vector<std::pair<llvm::Register, llvm::MachineBasicBlock *>>
-                 incomings) -> llvm::Register {
+             std::vector<std::pair<TypedRegister, llvm::MachineBasicBlock *>>
+                 incomings) -> TypedRegister {
             // A G_PHI with no operands is structurally invalid; each incoming
             // value must be a vreg of this function with the phi's type, and
             // each predecessor block must belong to this function.
@@ -1478,10 +1535,10 @@ void populate_mir(nb::module_ &m) {
                 self.buildInstr(llvm::TargetOpcode::G_PHI);
             phi.addDef(res);
             for (auto &[reg, mbb] : incomings) {
-              phi.addUse(reg);
+              phi.addUse(reg.reg);
               phi.addMBB(mbb);
             }
-            return res;
+            return TypedRegister{res, &self.getMF()};
           },
           "type"_a, "incomings"_a,
           "Build a G_PHI from (value, predecessor-block) pairs.")
@@ -1513,7 +1570,47 @@ void populate_mir(nb::module_ &m) {
           "BuildMI analogue for target-specific opcodes. Like BuildMI, the "
           "appended operands are not validated against the opcode's "
           "MCInstrDesc (arity/kind/def-first order are the caller's "
-          "responsibility).");
+          "responsibility).")
+      .def(
+          "build",
+          [](llvm::MachineIRBuilder &self, unsigned opcode,
+             std::vector<std::variant<llvm::LLT, TypedRegister>> dsts,
+             std::vector<TypedRegister> srcs) -> llvm::MachineInstr * {
+            // The typed analogue of GlobalISel's buildInstr(opcode, DstOps,
+            // SrcOps): each dst is either an LLT (a fresh generic vreg of that
+            // type is minted for it) or an existing Register to define, and
+            // each src is a Register use -- so, unlike the single-def
+            // build_add/... helpers, this expresses multiple defs and writing
+            // into a caller-provided vreg. buildInstr validates arity/types
+            // only with asserts (gone under NDEBUG); guard the opcode and every
+            // caller-supplied register's provenance here, and leave the rest
+            // (like build_instr) as the caller's responsibility.
+            requireValidOpcode(requireTII(self.getMF()), opcode);
+            llvm::SmallVector<llvm::DstOp, 1> dstOps;
+            for (auto &dst : dsts) {
+              if (auto *ty = std::get_if<llvm::LLT>(&dst)) {
+                dstOps.emplace_back(*ty);
+              } else {
+                const TypedRegister &reg = std::get<TypedRegister>(dst);
+                requireOwnedVReg(self.getMF(), reg, "dst");
+                dstOps.emplace_back(reg.reg);
+              }
+            }
+            llvm::SmallVector<llvm::SrcOp, 2> srcOps;
+            for (const TypedRegister &src : srcs) {
+              requireOwnedVReg(self.getMF(), src, "src");
+              srcOps.emplace_back(src.reg);
+            }
+            return self.buildInstr(opcode, dstOps, srcOps).getInstr();
+          },
+          "opcode"_a, "dsts"_a, "srcs"_a, nb::rv_policy::reference_internal,
+          "Build an instruction from typed destination and source operands "
+          "(the buildInstr(opcode, DstOps, SrcOps) analogue). Each dst is an "
+          "LLT (a fresh generic vreg of that type is created and defined) or a "
+          "Register to define; each src is a Register use. Returns the "
+          "instruction so its operands -- including any minted defs -- can be "
+          "read. Like build_instr, operands are not validated against the "
+          "opcode's MCInstrDesc.");
 
   // The innermost MachineIRBuilder entered as a context manager, mirroring the
   // IR module's current_builder(). Raises when there is none.

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -92,19 +92,39 @@ std::string withDetail(llvm::StringRef base, const std::string &detail) {
 
 // A machine register paired with the MachineFunction that owns it. A virtual
 // register's numeric id is only an index into its own function's
-// MachineRegisterInfo, so the same id names a *different* register (possibly
-// even a same-typed one) in another function; passing a foreign vreg builds
-// corrupt MIR that the verifier -- gone under NDEBUG -- would otherwise catch.
-// Carrying the owner lets the build/consume helpers reject a cross-function
-// vreg structurally (by identity), rather than hoping a type/index mismatch
-// happens to expose it. A physical register is target-static (the same
-// MCRegister across every function of a target), so it carries a null owner and
-// is accepted anywhere -- matching how physregs are used (block live-ins, COPYs
-// to/from $wN). Equality and hashing stay by register id (see the binding); the
-// owner is consulted only when a register is consumed by the builder.
-struct TypedRegister {
-  llvm::Register reg;
-  llvm::MachineFunction *mf; // owning function for a vreg; null for a physreg
+// MachineRegisterInfo, so the same id names a *different* register in another
+// function. When that id also happens to be a valid, same-typed register in
+// the target function, feeding the foreign one in produces well-formed MIR that
+// even the verifier cannot flag (it references a register that is legal there);
+// only the out-of-bounds / wrong-type foreign ids are detectable, and only when
+// asserts are on. Carrying the owner lets the build/consume helpers reject a
+// cross-function vreg structurally, by identity, rather than relying on a
+// type/index mismatch that may never surface. A physical register is
+// target-static (the same MCRegister across every function of a target), so it
+// carries a null owner and is accepted anywhere -- matching how physregs are
+// used (block live-ins, COPYs to/from $wN).
+//
+// The vreg<=>owner correspondence is an invariant: a virtual register has a
+// non-null owner, a physical register has none. It is not passed in but derived
+// by the `owned` factory from the register's own virtual-ness, and the
+// constructor is private, so no caller can construct an inconsistent pairing (a
+// vreg with no owner, or a physreg with one) -- the illegal states are
+// unrepresentable. Equality and hashing are by register id (see the binding),
+// so they are intra-function only; the owner is consulted only when a register
+// is consumed by the builder.
+class TypedRegister {
+public:
+  static TypedRegister owned(llvm::MachineFunction &mf, llvm::Register reg) {
+    return TypedRegister(reg, reg.isVirtual() ? &mf : nullptr);
+  }
+  llvm::Register reg() const { return reg_; }
+  llvm::MachineFunction *owner() const { return mf_; }
+
+private:
+  TypedRegister(llvm::Register reg, llvm::MachineFunction *mf)
+      : reg_(reg), mf_(mf) {}
+  llvm::Register reg_;
+  llvm::MachineFunction *mf_;
 };
 
 // Reject a virtual register minted by a different MachineFunction than `mf`.
@@ -115,7 +135,7 @@ struct TypedRegister {
 // passes.
 void requireOwnedVReg(const llvm::MachineFunction &mf, const TypedRegister &reg,
                       const char *role) {
-  if (reg.reg.isVirtual() && reg.mf != &mf)
+  if (reg.reg().isVirtual() && reg.owner() != &mf)
     throw nb::value_error(
         (std::string(role) + " belongs to a different MachineFunction")
             .c_str());
@@ -132,18 +152,19 @@ void requireOwnedVReg(const llvm::MachineFunction &mf, const TypedRegister &reg,
 void requireVRegOfType(llvm::MachineIRBuilder &b, const TypedRegister &reg,
                        llvm::LLT ty, const char *role) {
   requireOwnedVReg(b.getMF(), reg, role);
-  if (b.getMF().getRegInfo().getType(reg.reg) != ty)
+  if (b.getMF().getRegInfo().getType(reg.reg()) != ty)
     throw nb::value_error((std::string(role) +
                            " must be a virtual register of this "
                            "MachineFunction with the result type")
                               .c_str());
 }
 
-// A MachineBasicBlock crosses the Python boundary as a bare handle with no
-// back-link to its function; passing one from a different function builds
-// corrupt MIR (cross-linked CFGs) that the verifier -- gone under NDEBUG --
-// would otherwise catch. Guard provenance against the builder's (or another
-// block's) function. (Registers get the same guarantee from TypedRegister.)
+// The Python API lets any MachineBasicBlock be passed to any builder or block,
+// with nothing tying the argument to the target function; passing one from a
+// different function builds corrupt MIR (cross-linked CFGs) that the verifier
+// -- gone under NDEBUG -- would otherwise catch. Guard provenance via
+// getParent() against the builder's (or another block's) function. (Registers
+// get the same guarantee from TypedRegister's owner.)
 void requireSameFunction(const llvm::MachineFunction &mf,
                          const llvm::MachineBasicBlock *mbb, const char *role) {
   if (mbb->getParent() != &mf)
@@ -155,7 +176,7 @@ void requireSameFunction(const llvm::MachineFunction &mf,
 void requireVReg(llvm::MachineIRBuilder &b, const TypedRegister &reg,
                  const char *role) {
   requireOwnedVReg(b.getMF(), reg, role);
-  if (!b.getMF().getRegInfo().getType(reg.reg).isValid())
+  if (!b.getMF().getRegInfo().getType(reg.reg()).isValid())
     throw nb::value_error(
         (std::string(role) +
          " must be a generic virtual register of this MachineFunction")
@@ -208,7 +229,7 @@ void addRegOperand(llvm::MachineInstr &mi, const TypedRegister &reg, bool isDef,
   if (isDead && !isDef)
     throw nb::value_error(
         "is_dead is only valid on a def operand (is_def=True)");
-  if (isRenamable && !reg.reg.isPhysical())
+  if (isRenamable && !reg.reg().isPhysical())
     throw nb::value_error("is_renamable is only valid on a physical register");
   if (subReg) {
     const llvm::TargetRegisterInfo &tri = requireTRI(mf);
@@ -216,7 +237,7 @@ void addRegOperand(llvm::MachineInstr &mi, const TypedRegister &reg, bool isDef,
       throw nb::index_error("sub_reg index out of range");
   }
   mi.addOperand(mf, llvm::MachineOperand::CreateReg(
-                        reg.reg, isDef, isImp, isKill, isDead, isUndef,
+                        reg.reg(), isDef, isImp, isKill, isDead, isUndef,
                         isEarlyClobber, subReg, isDebug, isInternalRead,
                         isRenamable));
 }
@@ -514,36 +535,39 @@ void populate_mir(nb::module_ &m) {
   // target's real registers). Bound as TypedRegister so a virtual register also
   // carries the MachineFunction that minted it (physregs carry none), letting
   // the builder reject a register passed into a different function. Equality
-  // and hashing are by id (a register's identity within its function),
-  // unchanged.
+  // and hashing are by id -- a register's identity *within its function* -- so
+  // two registers with the same id from different functions compare and hash
+  // equal even though they are distinct; do not key a set/dict on registers
+  // gathered across functions. (The builder still rejects a cross-function
+  // register at build time regardless.)
   nb::class_<TypedRegister>(m, "Register")
-      .def_prop_ro("id", [](TypedRegister &self) { return self.reg.id(); })
+      .def_prop_ro("id", [](TypedRegister &self) { return self.reg().id(); })
       .def_prop_ro("is_valid",
-                   [](TypedRegister &self) { return self.reg.isValid(); })
+                   [](TypedRegister &self) { return self.reg().isValid(); })
       .def_prop_ro("is_virtual",
-                   [](TypedRegister &self) { return self.reg.isVirtual(); })
+                   [](TypedRegister &self) { return self.reg().isVirtual(); })
       .def_prop_ro("is_physical",
-                   [](TypedRegister &self) { return self.reg.isPhysical(); })
+                   [](TypedRegister &self) { return self.reg().isPhysical(); })
       .def_prop_ro("virt_reg_index",
                    [](TypedRegister &self) {
-                     if (!self.reg.isVirtual())
+                     if (!self.reg().isVirtual())
                        throw nb::value_error("register is not virtual");
-                     return self.reg.virtRegIndex();
+                     return self.reg().virtRegIndex();
                    })
       .def(
           "__eq__",
           [](TypedRegister &self, TypedRegister other) {
-            return self.reg == other.reg;
+            return self.reg() == other.reg();
           },
           nb::is_operator())
       .def(
           "__ne__",
           [](TypedRegister &self, TypedRegister other) {
-            return self.reg != other.reg;
+            return self.reg() != other.reg();
           },
           nb::is_operator())
       .def("__hash__", [](TypedRegister &self) {
-        return static_cast<Py_ssize_t>(self.reg.id());
+        return static_cast<Py_ssize_t>(self.reg().id());
       });
 
   // A target register class (e.g. AArch64 GPR32), looked up by name via
@@ -620,15 +644,16 @@ void populate_mir(nb::module_ &m) {
                    [](llvm::MachineOperand &self) -> TypedRegister {
                      if (!self.isReg())
                        throw nb::value_error("operand is not a register");
-                     // A virtual register's owner is the function it was read
-                     // from, so a register inspected off one instruction can be
-                     // fed back into that same function's builder; a physreg is
-                     // target-static and carries no owner.
-                     llvm::Register reg = self.getReg();
-                     llvm::MachineInstr *mi = self.getParent();
-                     llvm::MachineFunction *mf =
-                         (reg.isVirtual() && mi) ? mi->getMF() : nullptr;
-                     return TypedRegister{reg, mf};
+                     // Carry provenance so a register inspected off an
+                     // instruction can be fed back into its own function's
+                     // builder: `owned` records the function for a virtual
+                     // register and no owner for a (target-static) physical
+                     // one. An operand reachable through this binding always
+                     // belongs to an inserted instruction, so getParent() (and
+                     // its getMF()) is non-null; a future binding exposing a
+                     // detached operand would need to revisit this.
+                     return TypedRegister::owned(*self.getParent()->getMF(),
+                                                 self.getReg());
                    })
       .def_prop_ro("imm",
                    [](llvm::MachineOperand &self) {
@@ -846,7 +871,7 @@ void populate_mir(nb::module_ &m) {
             llvm::MachineFunction &mf = *self.getMF();
             requireOwnedVReg(mf, reg, "value");
             self.addOperand(mf,
-                            llvm::MachineOperand::CreateReg(reg.reg,
+                            llvm::MachineOperand::CreateReg(reg.reg(),
                                                             /*isDef=*/false));
             self.addOperand(mf, llvm::MachineOperand::CreateMBB(mbb));
           },
@@ -981,9 +1006,9 @@ void populate_mir(nb::module_ &m) {
             // asMCReg() only asserts physicality (compiled out under NDEBUG),
             // so a virtual register would be truncated into a garbage
             // MCRegister and recorded as a bogus livein. Reject it here.
-            if (!reg.reg.isPhysical())
+            if (!reg.reg().isPhysical())
               throw nb::value_error("add_livein requires a physical register");
-            self.addLiveIn(reg.reg.asMCReg());
+            self.addLiveIn(reg.reg().asMCReg());
           },
           "reg"_a, "Declare a physical register live-in to this block.")
       .def("__str__",
@@ -1017,8 +1042,8 @@ void populate_mir(nb::module_ &m) {
       .def(
           "create_generic_virtual_register",
           [](llvm::MachineFunction &self, llvm::LLT ty) -> TypedRegister {
-            return TypedRegister{
-                self.getRegInfo().createGenericVirtualRegister(ty), &self};
+            return TypedRegister::owned(
+                self, self.getRegInfo().createGenericVirtualRegister(ty));
           },
           "type"_a, "Create a new generic virtual register of the given LLT.")
       .def(
@@ -1045,7 +1070,7 @@ void populate_mir(nb::module_ &m) {
             const llvm::TargetRegisterInfo &tri = requireTRI(self);
             for (unsigned i = 1, e = tri.getNumRegs(); i < e; ++i) {
               if (name == tri.getName(i))
-                return TypedRegister{llvm::Register(i), nullptr};
+                return TypedRegister::owned(self, llvm::Register(i));
             }
             throw nb::key_error(
                 ("no physical register named '" + name + "'").c_str());
@@ -1055,8 +1080,8 @@ void populate_mir(nb::module_ &m) {
           "create_vreg",
           [](llvm::MachineFunction &self,
              const llvm::TargetRegisterClass *rc) -> TypedRegister {
-            return TypedRegister{self.getRegInfo().createVirtualRegister(rc),
-                                 &self};
+            return TypedRegister::owned(
+                self, self.getRegInfo().createVirtualRegister(rc));
           },
           "reg_class"_a,
           "Create a new virtual register constrained to a register class.")
@@ -1404,8 +1429,8 @@ void populate_mir(nb::module_ &m) {
               throw nb::value_error("build_constant requires a scalar or "
                                     "fixed-vector type");
             }
-            return TypedRegister{self.buildConstant(ty, value).getReg(0),
-                                 &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(), self.buildConstant(ty, value).getReg(0));
           },
           "type"_a, "value"_a)
       .def(
@@ -1414,8 +1439,9 @@ void populate_mir(nb::module_ &m) {
              TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return TypedRegister{self.buildAdd(ty, lhs.reg, rhs.reg).getReg(0),
-                                 &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(),
+                self.buildAdd(ty, lhs.reg(), rhs.reg()).getReg(0));
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
@@ -1424,8 +1450,9 @@ void populate_mir(nb::module_ &m) {
              TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return TypedRegister{self.buildSub(ty, lhs.reg, rhs.reg).getReg(0),
-                                 &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(),
+                self.buildSub(ty, lhs.reg(), rhs.reg()).getReg(0));
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
@@ -1434,8 +1461,9 @@ void populate_mir(nb::module_ &m) {
              TypedRegister rhs) -> TypedRegister {
             requireVRegOfType(self, lhs, ty, "lhs");
             requireVRegOfType(self, rhs, ty, "rhs");
-            return TypedRegister{self.buildMul(ty, lhs.reg, rhs.reg).getReg(0),
-                                 &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(),
+                self.buildMul(ty, lhs.reg(), rhs.reg()).getReg(0));
           },
           "type"_a, "lhs"_a, "rhs"_a)
       .def(
@@ -1443,8 +1471,8 @@ void populate_mir(nb::module_ &m) {
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
              TypedRegister src) -> TypedRegister {
             requireVRegOfType(self, src, ty, "src");
-            return TypedRegister{self.buildCopy(ty, src.reg).getReg(0),
-                                 &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(), self.buildCopy(ty, src.reg()).getReg(0));
           },
           "type"_a, "src"_a)
       .def_prop_ro(
@@ -1486,12 +1514,12 @@ void populate_mir(nb::module_ &m) {
             requireVReg(self, lhs, "lhs");
             requireVReg(self, rhs, "rhs");
             const llvm::MachineRegisterInfo &mri = self.getMF().getRegInfo();
-            if (mri.getType(lhs.reg) != mri.getType(rhs.reg))
+            if (mri.getType(lhs.reg()) != mri.getType(rhs.reg()))
               throw nb::value_error("build_icmp operands must have the same "
                                     "type");
-            return TypedRegister{
-                self.buildICmp(pred, ty, lhs.reg, rhs.reg).getReg(0),
-                &self.getMF()};
+            return TypedRegister::owned(
+                self.getMF(),
+                self.buildICmp(pred, ty, lhs.reg(), rhs.reg()).getReg(0));
           },
           "predicate"_a, "type"_a, "lhs"_a, "rhs"_a)
       .def(
@@ -1510,7 +1538,7 @@ void populate_mir(nb::module_ &m) {
              llvm::MachineBasicBlock *dest) {
             requireVReg(self, cond, "cond");
             requireSameFunction(self.getMF(), dest, "dest");
-            self.buildBrCond(cond.reg, *dest);
+            self.buildBrCond(cond.reg(), *dest);
           },
           "cond"_a, "dest"_a,
           "Build a conditional branch (G_BRCOND) on `cond` to `dest`.")
@@ -1535,10 +1563,10 @@ void populate_mir(nb::module_ &m) {
                 self.buildInstr(llvm::TargetOpcode::G_PHI);
             phi.addDef(res);
             for (auto &[reg, mbb] : incomings) {
-              phi.addUse(reg.reg);
+              phi.addUse(reg.reg());
               phi.addMBB(mbb);
             }
-            return TypedRegister{res, &self.getMF()};
+            return TypedRegister::owned(self.getMF(), res);
           },
           "type"_a, "incomings"_a,
           "Build a G_PHI from (value, predecessor-block) pairs.")
@@ -1582,9 +1610,12 @@ void populate_mir(nb::module_ &m) {
             // each src is a Register use -- so, unlike the single-def
             // build_add/... helpers, this expresses multiple defs and writing
             // into a caller-provided vreg. buildInstr validates arity/types
-            // only with asserts (gone under NDEBUG); guard the opcode and every
-            // caller-supplied register's provenance here, and leave the rest
-            // (like build_instr) as the caller's responsibility.
+            // only with asserts, so bad input aborts the process (our LLVM is
+            // built with assertions on) or, where an assert is compiled out,
+            // silently builds malformed MIR. Guard the opcode and every
+            // caller-supplied register's provenance here so those raise a clean
+            // Python error instead; leave the rest (like build_instr) as the
+            // caller's responsibility.
             requireValidOpcode(requireTII(self.getMF()), opcode);
             llvm::SmallVector<llvm::DstOp, 1> dstOps;
             for (auto &dst : dsts) {
@@ -1593,13 +1624,13 @@ void populate_mir(nb::module_ &m) {
               } else {
                 const TypedRegister &reg = std::get<TypedRegister>(dst);
                 requireOwnedVReg(self.getMF(), reg, "dst");
-                dstOps.emplace_back(reg.reg);
+                dstOps.emplace_back(reg.reg());
               }
             }
             llvm::SmallVector<llvm::SrcOp, 2> srcOps;
             for (const TypedRegister &src : srcs) {
               requireOwnedVReg(self.getMF(), src, "src");
-              srcOps.emplace_back(src.reg);
+              srcOps.emplace_back(src.reg());
             }
             return self.buildInstr(opcode, dstOps, srcOps).getInstr();
           },

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine.py
@@ -9,6 +9,11 @@ mechanism the IR builder uses): `with MachineIRBuilder(mf):` makes it current
 and current_machine_builder() reads it back. A MachineValue wraps a Register
 plus its LLT and overloads `+ - *` onto build_add/build_sub/build_mul; Python
 ints coerce to a G_CONSTANT of the other operand's type.
+
+A Register now carries the MachineFunction that minted it, so feeding a value
+from one @machine_function body into another's builder is rejected in C++ (the
+builder compares the register's owner against its own function) -- the DSL does
+not need a separate Python-side anchor for that.
 """
 
 import inspect
@@ -28,28 +33,13 @@ class MachineValue:
     def __init__(self, reg, llt):
         self.reg = reg
         self.llt = llt
-        # Anchor to the builder tracing this value's MachineFunction. A
-        # MachineValue carries a bare reg + llt, so a value that escapes its
-        # @machine_function body could otherwise emit into a different (e.g.
-        # nested) function's builder, referencing vregs it doesn't own. A
-        # MachineValue is only ever constructed while a builder is current.
-        self._builder = current_machine_builder()
-
-    def _require_current(self):
-        if self._builder is not current_machine_builder():
-            raise RuntimeError(
-                "MachineValue used outside the @machine_function body that "
-                "created it (it belongs to a different MachineFunction)"
-            )
 
     def _coerce(self, other):
         """A MachineValue passes through; a Python int becomes a G_CONSTANT of
         this value's LLT. Only an exact int (not bool, not float) is accepted --
         int(other) would silently truncate a float or parse a str into a
         wrong-typed constant that survives into the release wheel."""
-        self._require_current()
         if isinstance(other, MachineValue):
-            other._require_current()
             return other
         if type(other) is not int:
             raise TypeError(

--- a/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
@@ -241,6 +241,72 @@ def test_build_rejects_out_of_range_opcode():
     assert_no_leaks()
 
 
+def test_build_emits_multiple_defs():
+    """build's headline over the single-def helpers is multiple defs: G_UADDO
+    yields a (result, carry) pair, so both operand 0 and operand 1 are defs."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        s32, s1 = mir.LLT.scalar(32), mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        a = mf.create_generic_virtual_register(s32)
+        c = mf.create_generic_virtual_register(s32)
+        uaddo = b.build(mf.opcode("G_UADDO"), [s32, s1], [a, c])
+        assert uaddo.opcode_name == "G_UADDO"
+        assert uaddo.num_defs == 2
+        assert uaddo.operand(0).is_def and uaddo.operand(1).is_def
+    assert_no_leaks()
+
+
+def test_build_rejects_registers_from_another_function():
+    """build guards both destinations and sources: a foreign vreg used as a dst
+    or a src is rejected by owner (its own guard call sites, not just the
+    shared helper reached via other builders)."""
+    with ir.Context() as ctx:
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        mmi_g = mir.create_machine_function(ir.Module("g", ctx), tm, "g")
+        foreign = mir.MachineIRBuilder(mmi_g.machine_function("g")).build_constant(
+            s32, 1
+        )
+        mmi_f = mir.create_machine_function(ir.Module("f", ctx), tm, "f")
+        mf = mmi_f.machine_function("f")
+        b = mir.MachineIRBuilder(mf)
+        own = mf.create_generic_virtual_register(s32)
+        g_add = mf.opcode("G_ADD")
+        with pytest.raises(ValueError, match="dst .*different MachineFunction"):
+            b.build(g_add, [foreign], [own, own])
+        with pytest.raises(ValueError, match="src .*different MachineFunction"):
+            b.build(g_add, [s32], [foreign, own])
+    assert_no_leaks()
+
+
+def test_register_read_off_operand_feeds_back_into_builder():
+    """A register inspected off an instruction's operand carries its owning
+    function, so it is accepted when fed back into that function's builder --
+    the round-trip the owner field must not wrongly reject."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        a = mf.create_generic_virtual_register(s32)
+        c = mf.create_generic_virtual_register(s32)
+        add = b.build(mf.opcode("G_ADD"), [s32], [a, c])
+        read_back = add.operand(0).reg  # the def vreg, read off the operand
+        assert read_back.is_virtual
+        # Accepted by both the typed helper and the raw operand appender.
+        assert b.build_add(s32, read_back, read_back).is_virtual
+        instr = b.build_instr(mf.opcode("G_ADD"))
+        instr.add_def(read_back)  # no "different MachineFunction" error
+        assert instr.operand(0).reg.id == read_back.id
+    assert_no_leaks()
+
+
 def test_machine_ir_builder_context_manager_tracks_current():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_generic.py
@@ -161,7 +161,10 @@ def test_build_add_rejects_register_from_another_function():
 
         mmi_f = mir.create_machine_function(ir.Module("f", ctx), tm, "f")
         bf = mir.MachineIRBuilder(mmi_f.machine_function("f"))
-        with pytest.raises(ValueError, match="virtual register of this"):
+        # The register carries function g as its owner, so f's builder rejects
+        # it by provenance (see test_cross_function_vreg_collision_rejected for
+        # why the owner, not just the id/type, is what makes this sound).
+        with pytest.raises(ValueError, match="different MachineFunction"):
             bf.build_add(s32, foreign, foreign)
     assert_no_leaks()
 
@@ -193,6 +196,48 @@ def test_create_generic_virtual_register_is_virtual():
         # (the builder validates operand type against the result type).
         b = mir.MachineIRBuilder(mf)
         assert b.build_add(s64, reg, reg).is_virtual
+    assert_no_leaks()
+
+
+def test_build_typed_instr_mints_and_reuses_destinations():
+    """`build` is the typed buildInstr(opcode, DstOps, SrcOps): an LLT dst mints
+    a fresh generic vreg and defines it; a Register dst defines that existing
+    vreg. Both are exercised here on a G_ADD, plus the Register source uses."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        s32 = mir.LLT.scalar(32)
+        b = mir.MachineIRBuilder(mf)
+        a = mf.create_generic_virtual_register(s32)
+        c = mf.create_generic_virtual_register(s32)
+        g_add = mf.opcode("G_ADD")
+
+        # LLT dst: a fresh generic vreg is minted for the def.
+        minted = b.build(g_add, [s32], [a, c])
+        assert minted.opcode_name == "G_ADD"
+        assert minted.operand(0).is_def and minted.operand(0).reg.is_virtual
+        assert minted.operand(0).reg.id not in (a.id, c.id)  # a new register
+        assert minted.operand(1).reg.id == a.id
+        assert minted.operand(2).reg.id == c.id
+
+        # Register dst: the caller's existing vreg is defined instead.
+        dst = mf.create_generic_virtual_register(s32)
+        reused = b.build(g_add, [dst], [a, c])
+        assert reused.operand(0).reg.id == dst.id
+    assert_no_leaks()
+
+
+def test_build_rejects_out_of_range_opcode():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "f")
+        mf = mmi.machine_function("f")
+        b = mir.MachineIRBuilder(mf)
+        with pytest.raises(IndexError, match="opcode number out of range"):
+            b.build(10**9, [mir.LLT.scalar(32)], [])
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_build_selected.py
@@ -181,3 +181,19 @@ def test_selected_add_survives_mir_roundtrip():
         mmi2 = mir.parse_mir(text, ctx, jit.TargetMachine(triple=_TRIPLE))
         assert mmi2.machine_function("add").verify() is True
     assert_no_leaks()
+
+
+def test_build_brcond_rejects_physical_register():
+    """A generic builder op like build_brcond needs a *generic vreg* condition.
+    A physical register belongs to no function (it is target-static), so it
+    passes the cross-function owner guard -- but it is still not a generic
+    virtual register of this function, so it is rejected on that ground."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        mf = mmi.machine_function("add")
+        b = mir.MachineIRBuilder(mf)
+        with pytest.raises(ValueError, match="generic virtual register"):
+            b.build_brcond(mf.physreg("W0"), mf.blocks[0])
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -213,6 +213,11 @@ def test_cross_function_vreg_collision_rejected():
         phi = bf.build_empty_phi(s32)
         with pytest.raises(ValueError, match="different MachineFunction"):
             phi.add_phi_incoming(foreign, mf.blocks[0])
+        # ...also the requireVReg / build_phi-incoming consuming sites.
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.build_icmp(ir.ICmpPredicate.EQ, mir.LLT.scalar(1), own, foreign)
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.build_phi(s32, [(foreign, mf.blocks[0])])
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -188,6 +188,34 @@ def test_cross_function_register_rejected():
     assert_no_leaks()
 
 
+def test_cross_function_vreg_collision_rejected():
+    """The load-bearing case for a register knowing its function: f and g each
+    mint their *first* vreg, so both share vreg id 0 with the same type. Feeding
+    g's %0 into f's builder must still be rejected -- a plain id+type check
+    (what the register carried before) would see f's own %0 and wrongly accept
+    it. The owner (function g) is what distinguishes them."""
+    with ir.Context() as ctx:
+        mmi_f, mf = _new_function(ctx, "f")
+        mmi_g, mg = _new_function(ctx, "g")
+        s32 = mir.LLT.scalar(32)
+        bf, bg = mir.MachineIRBuilder(mf), mir.MachineIRBuilder(mg)
+        own = bf.build_constant(s32, 1)  # f's %0
+        foreign = bg.build_constant(s32, 1)  # g's %0 -- same id and type
+        assert own.id == foreign.id  # the collision that used to slip through
+        # Every site that consumes a caller-supplied register rejects the
+        # foreign one by owner, while the same-shaped local register is fine.
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.build_add(s32, own, foreign)
+        assert bf.build_add(s32, own, own).is_virtual
+        instr = mf.blocks[0].instructions[0]
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            instr.add_use(foreign)
+        phi = bf.build_empty_phi(s32)
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            phi.add_phi_incoming(foreign, mf.blocks[0])
+    assert_no_leaks()
+
+
 def test_set_branch_target_on_non_branch_raises():
     with ir.Context() as ctx:
         mmi, mf = _new_function(ctx)

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -202,6 +202,9 @@ def test_cross_function_vreg_collision_rejected():
         own = bf.build_constant(s32, 1)  # f's %0
         foreign = bg.build_constant(s32, 1)  # g's %0 -- same id and type
         assert own.id == foreign.id  # the collision that used to slip through
+        # Equality considers the owner, so the two same-id registers are
+        # distinct despite the id collision (they can coexist as dict keys).
+        assert own != foreign
         # Every site that consumes a caller-supplied register rejects the
         # foreign one by owner, while the same-shaped local register is fine.
         with pytest.raises(ValueError, match="different MachineFunction"):

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
@@ -158,6 +158,9 @@ def test_non_int_coercion_raises():
 
 
 def test_value_from_other_function_raises():
+    """A value from one @machine_function body used in another's is rejected:
+    its Register carries function g as its owner, so f's builder refuses it
+    (ValueError from the C++ owner check, not a Python-side anchor)."""
     with ir.Context() as ctx:
         tm = jit.TargetMachine(triple=_TRIPLE)
         s32 = mir.LLT.scalar(32)
@@ -168,7 +171,7 @@ def test_value_from_other_function_raises():
             leaked["a"] = a
             return a
 
-        with pytest.raises(RuntimeError, match="different MachineFunction"):
+        with pytest.raises(ValueError, match="different MachineFunction"):
 
             @machine_function(module=ir.Module("f", ctx), target=tm)
             def f(b: s32):

--- a/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_dsl_machine.py
@@ -180,6 +180,26 @@ def test_value_from_other_function_raises():
     assert_no_leaks()
 
 
+def test_value_reused_under_second_builder_of_same_function():
+    """Dropping the per-builder anchor ties a MachineValue to its *function*,
+    not to the specific builder instance that was current when it was made: a
+    value built under one MachineIRBuilder is still usable under a second
+    builder of the same MachineFunction (the C++ owner check keys on the
+    function). Contrast test_value_from_other_function_raises."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_TRIPLE)
+        s32 = mir.LLT.scalar(32)
+        mf = mir.create_machine_function(mod, tm, "f").machine_function("f")
+        with mir.MachineIRBuilder(mf):
+            a = MachineValue(mf.create_generic_virtual_register(s32), s32)
+        with mir.MachineIRBuilder(mf):  # a fresh builder over the same function
+            out = a + a
+        assert out.reg.is_virtual
+        assert any(i.opcode_name == "G_ADD" for i in mf.blocks[0].instructions)
+    assert_no_leaks()
+
+
 def test_builder_stack_cleared_when_body_raises():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)

--- a/projects/eudsl-llvmpy/tests/mir/test_inspect.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_inspect.py
@@ -325,10 +325,11 @@ def test_register_accessors():
         assert vreg.is_valid
         assert vreg.is_virtual
         assert vreg.virt_reg_index >= 0
-        # Equality + hashing (by register id).
+        # Equality and hashing consider id + owning function: the same register
+        # read twice compares and hashes equal; a different register does not.
         assert vreg == add.operand(0).reg
+        assert hash(vreg) == hash(add.operand(0).reg)
         assert vreg != add.operand(1).reg
-        assert hash(vreg) == vreg.id
         assert (vreg == "not a register") is False
         # virt_reg_index is virtual-only.
         phys = (


### PR DESCRIPTION
Implements both recommendations from [#593 item 2](https://github.com/llvm/eudsl/issues/593) (deferred from #582): a typed `Register` that knows its `MachineFunction`, and a fuller `MachineIRBuilder` surface — then refactors the DSL, which previously handled cross-function provenance in Python.

## Part A — typed `Register`

`Register` is bound from a `TypedRegister` value type that pairs the register with the `MachineFunction` that minted it (a physreg carries no owner, since physregs are target-static). The **invariant is enforced by construction**: the constructor is private and a single `owned(mf, reg)` factory *derives* the owner from `reg.isVirtual()`, so a vreg-with-no-owner or physreg-with-owner is unrepresentable (not merely unchecked).

A single shared guard, `requireOwnedVReg(mf, reg, role)`, rejects any vreg whose owner isn't the consuming builder's function, and is called from **every** consuming site (`build_add/sub/mul/copy/icmp/brcond/phi`, `add_reg/def/use`, `add_phi_incoming`, and the new `build`).

This closes the **index-collision hole** the old `getType`-only check missed: a vreg's numeric id is only an index into its own function's `MachineRegisterInfo`, so when `f` and `g` each mint `%0:s32`, feeding `g`'s `%0` into `f`'s builder used to pass (it found `f`'s own same-typed `%0`). It now raises. `MachineOperand.reg` tags the register with its owning function so it round-trips back into the builder.

Register **equality and hashing consider both id and owner** (`__eq__`/`__ne__` compare `(id, owner)`, `__hash__` combines them), so two same-id registers from different functions are distinct — they can safely coexist as `set`/`dict` keys, and a cross-function `==` is `False`.

## Part B — richer builder surface

Adds `MachineIRBuilder.build(opcode, dsts, srcs)`, the typed analogue of `buildInstr(Opc, ArrayRef<DstOp>, ArrayRef<SrcOp>)`: each dst is an `LLT` (mints a fresh generic vreg and defines it) or a `Register` (defines that existing vreg), each src is a `Register` use. Unlike the fixed single-def helpers it expresses multiple defs and writing into a caller-provided vreg; it returns the `MachineInstr` so minted defs are readable. The "Building target MIR" README example now uses `build(...)` for the COPY/ADDWrr instructions (keeping `build_instr` + `add_reg` only for `RET_ReallyLR`'s implicit operand, which `build`'s plain-use srcs can't express).

## DSL refactor

Removes the Python-side `_builder`/`_require_current` anchor from `MachineValue` (added in #583). The typed register now enforces cross-function provenance structurally in C++, so the anchor is redundant. Observable change: a value used across `@machine_function` bodies now raises `ValueError` ("belongs to a different MachineFunction") from the builder rather than a Python `RuntimeError`. A value built under one builder is still usable under a second builder of the *same* function (the owner check keys on the function, not the builder instance).