### PR TITLE
[eudsl-llvmpy] Reject double-terminator + add MachineBasicBlock.is_terminated (#593 item 6b)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -189,25 +189,32 @@ void requireVReg(llvm::MachineIRBuilder &b, const TypedRegister &reg,
 // (G_BR, a return, ...) -- control cannot fall through off the end. A block
 // ending in only a conditional G_BRCOND is NOT terminated: it still falls
 // through, which is exactly why the standard `build_brcond` + `build_br` pair
-// is two terminators in one block. isBarrier() is what distinguishes the
-// unconditional closers from the fall-through conditional.
+// is two terminators in one block. We require *both* isTerminator() and
+// isBarrier(): isBarrier() distinguishes the unconditional closers from the
+// fall-through conditional, and pairing it with isTerminator() excludes the
+// rare barrier-but-not-terminator instruction (e.g. a target TRAP), which does
+// not close the block for branch purposes.
 bool blockEndsInBarrier(const llvm::MachineBasicBlock &mbb) {
-  return !mbb.empty() && mbb.back().isBarrier();
+  return !mbb.empty() && mbb.back().isTerminator() && mbb.back().isBarrier();
 }
 
 // Appending a terminator to a block that already ends in a barrier builds a
-// malformed block (a second, unreachable terminator past the barrier) that the
-// verifier -- gone under NDEBUG -- would otherwise catch. The builder only ever
-// inserts at the end of its block (setMBB parks the insert point at end(); no
-// mid-block insert point is exposed), so back() is reliably where the next
-// instruction lands. Reject the double-terminator here.
+// malformed block (a second, unreachable terminator past the barrier). The
+// machine verifier catches this, but only when run explicitly via verify():
+// the automatic verification and the build-helper asserts that would flag it
+// during construction are gone under NDEBUG, so in a release build the bad
+// block is otherwise built silently. The builder only ever inserts at the end
+// of its block (setMBB parks the insert point at end(); no mid-block insert
+// point is exposed), so back() is reliably where the next instruction lands.
+// Reject the double-terminator here.
 void requireNotTerminated(llvm::MachineIRBuilder &b, const char *role) {
-  if (blockEndsInBarrier(b.getMBB()))
+  if (blockEndsInBarrier(b.getMBB())) {
     throw nb::value_error(
         (std::string(role) +
          " into a block that already ends in a barrier terminator; a block "
-         "cannot have a second (unconditional) terminator")
+         "cannot have a second terminator after an unconditional one")
             .c_str());
+  }
 }
 
 // getInstrInfo() can be null for a target without one; real backends always
@@ -993,9 +1000,10 @@ void populate_mir(nb::module_ &m) {
           [](llvm::MachineBasicBlock &self) {
             return blockEndsInBarrier(self);
           },
-          "Whether this block ends in a barrier terminator (e.g. G_BR or a "
-          "return) so control cannot fall through. A block ending in only a "
-          "conditional G_BRCOND is not terminated -- it falls through.")
+          "Whether this block ends in a barrier terminator (G_BR today; a "
+          "return once such a builder exists) so control cannot fall through. "
+          "A block ending in only a conditional G_BRCOND is not terminated -- "
+          "it falls through.")
       .def_prop_ro(
           "successors",
           [](llvm::MachineBasicBlock &self) {

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -185,6 +185,31 @@ void requireVReg(llvm::MachineIRBuilder &b, const TypedRegister &reg,
             .c_str());
 }
 
+// A block is "terminated" once its last instruction is a barrier terminator
+// (G_BR, a return, ...) -- control cannot fall through off the end. A block
+// ending in only a conditional G_BRCOND is NOT terminated: it still falls
+// through, which is exactly why the standard `build_brcond` + `build_br` pair
+// is two terminators in one block. isBarrier() is what distinguishes the
+// unconditional closers from the fall-through conditional.
+bool blockEndsInBarrier(const llvm::MachineBasicBlock &mbb) {
+  return !mbb.empty() && mbb.back().isBarrier();
+}
+
+// Appending a terminator to a block that already ends in a barrier builds a
+// malformed block (a second, unreachable terminator past the barrier) that the
+// verifier -- gone under NDEBUG -- would otherwise catch. The builder only ever
+// inserts at the end of its block (setMBB parks the insert point at end(); no
+// mid-block insert point is exposed), so back() is reliably where the next
+// instruction lands. Reject the double-terminator here.
+void requireNotTerminated(llvm::MachineIRBuilder &b, const char *role) {
+  if (blockEndsInBarrier(b.getMBB()))
+    throw nb::value_error(
+        (std::string(role) +
+         " into a block that already ends in a barrier terminator; a block "
+         "cannot have a second (unconditional) terminator")
+            .c_str());
+}
+
 // getInstrInfo() can be null for a target without one; real backends always
 // have it (these MachineFunctions come from create_machine_function/codegen
 // with a real subtarget), so this is purely defensive.
@@ -964,6 +989,14 @@ void populate_mir(nb::module_ &m) {
           "is_entry_block",
           [](llvm::MachineBasicBlock &self) { return self.isEntryBlock(); })
       .def_prop_ro(
+          "is_terminated",
+          [](llvm::MachineBasicBlock &self) {
+            return blockEndsInBarrier(self);
+          },
+          "Whether this block ends in a barrier terminator (e.g. G_BR or a "
+          "return) so control cannot fall through. A block ending in only a "
+          "conditional G_BRCOND is not terminated -- it falls through.")
+      .def_prop_ro(
           "successors",
           [](llvm::MachineBasicBlock &self) {
             std::vector<llvm::MachineBasicBlock *> succs(self.succ_begin(),
@@ -1529,6 +1562,7 @@ void populate_mir(nb::module_ &m) {
           [](llvm::MachineIRBuilder &self,
              llvm::MachineBasicBlock *dest) -> llvm::MachineInstr * {
             requireSameFunction(self.getMF(), dest, "dest");
+            requireNotTerminated(self, "build_br");
             return self.buildBr(*dest).getInstr();
           },
           "dest"_a, nb::rv_policy::reference_internal,
@@ -1540,6 +1574,7 @@ void populate_mir(nb::module_ &m) {
              llvm::MachineBasicBlock *dest) {
             requireVReg(self, cond, "cond");
             requireSameFunction(self.getMF(), dest, "dest");
+            requireNotTerminated(self, "build_brcond");
             self.buildBrCond(cond.reg(), *dest);
           },
           "cond"_a, "dest"_a,

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -89,6 +89,44 @@ def test_build_if_diamond_with_phi():
     assert_no_leaks()
 
 
+def test_is_terminated_reflects_barrier_terminator():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        entry = mf.blocks[0]
+        dest = mf.create_block()
+        # A fresh (empty) block has no terminator -- control falls through.
+        assert not entry.is_terminated
+        # A block ending in only a conditional G_BRCOND still falls through, so
+        # it is not "terminated" (the standard pattern appends a G_BR next).
+        cond = b.build_constant(s1, 1)
+        b.build_brcond(cond, dest)
+        assert not entry.is_terminated
+        # The trailing unconditional G_BR is a barrier: control can no longer
+        # fall through, so the block is now terminated.
+        b.build_br(dest)
+        assert entry.is_terminated
+    assert_no_leaks()
+
+
+def test_terminator_builders_reject_second_terminator():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        dest = mf.create_block()
+        cond = b.build_constant(s1, 1)  # built before the block is closed
+        b.build_br(dest)  # closes the entry block with a G_BR barrier
+        # A second terminator would be an unreachable double terminator past the
+        # barrier; both terminator builders refuse to append it.
+        with pytest.raises(ValueError, match="second .*terminator"):
+            b.build_br(dest)
+        with pytest.raises(ValueError, match="second .*terminator"):
+            b.build_brcond(cond, dest)
+    assert_no_leaks()
+
+
 def test_create_block_accepts_ir_basic_block():
     with ir.Context() as ctx:
         mmi, mf = _new_function(ctx)

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -119,10 +119,11 @@ def test_terminator_builders_reject_second_terminator():
         cond = b.build_constant(s1, 1)  # built before the block is closed
         b.build_br(dest)  # closes the entry block with a G_BR barrier
         # A second terminator would be an unreachable double terminator past the
-        # barrier; both terminator builders refuse to append it.
-        with pytest.raises(ValueError, match="second .*terminator"):
+        # barrier; both terminator builders refuse to append it. Match the role
+        # prefix too, so a swapped role string in the guard is caught.
+        with pytest.raises(ValueError, match=r"build_br .*second .*terminator"):
             b.build_br(dest)
-        with pytest.raises(ValueError, match="second .*terminator"):
+        with pytest.raises(ValueError, match=r"build_brcond .*second .*terminator"):
             b.build_brcond(cond, dest)
     assert_no_leaks()
 


### PR DESCRIPTION
Closes item 6b of #593. That item noted the `build_empty_phi` two-step primitive
is deliberate (nothing to change) and that guarding a loop-body **double
terminator** cleanly "would need a new *is-terminated* `MachineBasicBlock`
accessor."

`MachineIRBuilder` only ever inserts at the **end** of its block — `set_block`
parks the insert point at `end()` and no mid-block insert point is exposed for
MIR — so `getMBB().back()` reliably reflects the block's last instruction. On
that basis:

- **`MachineBasicBlock.is_terminated`** — `True` when the block ends in a
  *barrier* terminator (`G_BR`, a return, …) so control cannot fall through. A
  block ending in only a conditional `G_BRCOND` is **not** terminated: it still
  falls through, which is exactly why the standard `build_brcond` + `build_br`
  pair is two terminators in one block. `isBarrier()` is what distinguishes the
  unconditional closers from the fall-through conditional.
- **Guard `build_br` / `build_brcond`** against appending a terminator to a
  block that already ends in a barrier — an unreachable double terminator past
  the barrier that the verifier (gone under `NDEBUG`) would otherwise catch.
  The `brcond`+`br` pattern, and the DSL `if`/loops built on it, still build
  fine (the block ends in `G_BRCOND`, not a barrier, when the `br` is appended).

Scope note: the generic `build`/`build_instr`/`add_*` path stays caller-trusted
(consistent with #593 item 4); only the high-level convenience terminator
builders are guarded. The DSL keeps rejecting early `return`/`break`/`continue`
inside control flow at the AST level (`RejectUnsupportedJumps`) — this guard is
the MIR-level backstop.