### PR TITLE
[eudsl-llvmpy] Add MachineIRBuilder.branch / cond_branch convenience helpers (#593 item 6d)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -329,7 +329,12 @@ For lower-level construction, `MachineIRBuilder` exposes the typed `build_*`
 helpers (`build_constant`, `build_add`, `build_br`, `build_brcond`, `build_phi`,
 …) and a generic `build_instr(opcode)` for any opcode; `MachineFunction.opcode`
 looks a target opcode up by mnemonic (the generated opcode enums are not in
-installed LLVM headers, so lookup is by name via `TargetInstrInfo`).
+installed LLVM headers, so lookup is by name via `TargetInstrInfo`). For
+control flow, `branch(dest)` and `cond_branch(cond, true_block, false_block)`
+fold the terminator emission and the CFG successor edge(s) into one call — MIR
+tracks the successor list and the branch operand separately, so these keep the
+two in sync (`cond_branch` returns the fall-through `G_BR` so its target can be
+repointed).
 
 ### Building target MIR and lowering to native code
 

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -1598,8 +1598,11 @@ void populate_mir(nb::module_ &m) {
           },
           "dest"_a, nb::rv_policy::reference_internal,
           "Unconditional branch to `dest` that also wires the CFG successor "
-          "edge from the current block (build_br + add_successor in one step); "
-          "returns the G_BR so its target can be repointed.")
+          "edge from the current block (add_successor + build_br in one step); "
+          "returns the G_BR so its target can be repointed. This helper owns "
+          "the "
+          "edge -- do not also call add_successor(dest) yourself, as neither "
+          "dedups and the edge would be wired twice.")
       .def(
           "cond_branch",
           [](llvm::MachineIRBuilder &self, TypedRegister cond,
@@ -1609,6 +1612,14 @@ void populate_mir(nb::module_ &m) {
             requireSameFunction(self.getMF(), true_block, "true block");
             requireSameFunction(self.getMF(), false_block, "false block");
             requireNotTerminated(self, "cond_branch");
+            // Equal true/false blocks would wire the same successor edge twice
+            // (addSuccessor does not dedup) -- a malformed CFG. Such a branch
+            // is degenerate anyway (both arms go to the same place); reject it.
+            if (true_block == false_block) {
+              throw nb::value_error(
+                  "cond_branch true_block and false_block must differ; equal "
+                  "blocks would wire a duplicate successor edge");
+            }
             self.buildBrCond(cond.reg(), *true_block);
             llvm::MachineInstr *falseBr = self.buildBr(*false_block).getInstr();
             self.getMBB().addSuccessor(true_block);
@@ -1621,7 +1632,9 @@ void populate_mir(nb::module_ &m) {
           "G_BR to `false_block`, wiring both CFG successor edges from the "
           "current block (build_brcond + build_br + two add_successor calls in "
           "one step). Returns the fallthrough G_BR so its target can be "
-          "repointed.")
+          "repointed. `true_block` and `false_block` must differ, and this "
+          "helper owns both edges -- do not also call add_successor for them "
+          "yourself, as neither dedups and the edges would be wired twice.")
       .def(
           "build_phi",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -1588,6 +1588,41 @@ void populate_mir(nb::module_ &m) {
           "cond"_a, "dest"_a,
           "Build a conditional branch (G_BRCOND) on `cond` to `dest`.")
       .def(
+          "branch",
+          [](llvm::MachineIRBuilder &self,
+             llvm::MachineBasicBlock *dest) -> llvm::MachineInstr * {
+            requireSameFunction(self.getMF(), dest, "dest");
+            requireNotTerminated(self, "branch");
+            self.getMBB().addSuccessor(dest);
+            return self.buildBr(*dest).getInstr();
+          },
+          "dest"_a, nb::rv_policy::reference_internal,
+          "Unconditional branch to `dest` that also wires the CFG successor "
+          "edge from the current block (build_br + add_successor in one step); "
+          "returns the G_BR so its target can be repointed.")
+      .def(
+          "cond_branch",
+          [](llvm::MachineIRBuilder &self, TypedRegister cond,
+             llvm::MachineBasicBlock *true_block,
+             llvm::MachineBasicBlock *false_block) -> llvm::MachineInstr * {
+            requireVReg(self, cond, "cond");
+            requireSameFunction(self.getMF(), true_block, "true block");
+            requireSameFunction(self.getMF(), false_block, "false block");
+            requireNotTerminated(self, "cond_branch");
+            self.buildBrCond(cond.reg(), *true_block);
+            llvm::MachineInstr *falseBr = self.buildBr(*false_block).getInstr();
+            self.getMBB().addSuccessor(true_block);
+            self.getMBB().addSuccessor(false_block);
+            return falseBr;
+          },
+          "cond"_a, "true_block"_a, "false_block"_a,
+          nb::rv_policy::reference_internal,
+          "Conditional branch: G_BRCOND on `cond` to `true_block`, fallthrough "
+          "G_BR to `false_block`, wiring both CFG successor edges from the "
+          "current block (build_brcond + build_br + two add_successor calls in "
+          "one step). Returns the fallthrough G_BR so its target can be "
+          "repointed.")
+      .def(
           "build_phi",
           [](llvm::MachineIRBuilder &self, llvm::LLT ty,
              std::vector<std::pair<TypedRegister, llvm::MachineBasicBlock *>>

--- a/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
+++ b/projects/eudsl-llvmpy/src/llvm/dsl/machine_cf.py
@@ -52,11 +52,10 @@ class _MIRIfOp:
         self.merge_block = mf.create_block()
         self.else_block = None
         # G_BRCOND cond -> then, then a fall-through G_BR whose target starts at
-        # merge; else_ctx_manager repoints it to the else block.
-        b.build_brcond(cond.reg, self.then_block)
-        self.false_br = b.build_br(self.merge_block)
-        self.entry_block.add_successor(self.then_block)
-        self.entry_block.add_successor(self.merge_block)
+        # merge; else_ctx_manager repoints it to the else block. cond_branch
+        # emits both terminators and wires both successor edges, returning the
+        # fall-through G_BR so we can repoint it later.
+        self.false_br = b.cond_branch(cond.reg, self.then_block, self.merge_block)
         self.then_vals = None
         self.else_vals = None
         self.then_pred = None
@@ -69,8 +68,7 @@ class _MIRIfOp:
         # predecessor (b.insert_block), which nested control flow may have moved.
         b = self.builder
         pred = b.insert_block
-        b.build_br(self.merge_block)
-        pred.add_successor(self.merge_block)
+        b.branch(self.merge_block)  # G_BR + successor edge from pred
         return pred
 
     def _repoint_false_edge(self, new_target):
@@ -199,8 +197,7 @@ class _MIRLoop:
         self.header = mf.create_block()
         body = mf.create_block()
         self.exit_block = mf.create_block()
-        b.build_br(self.header)
-        preheader.add_successor(self.header)
+        b.branch(self.header)  # G_BR + successor edge preheader -> header
 
         b.set_block(self.header)
         # The type witness is the first MachineValue among the bounds/carried
@@ -252,10 +249,9 @@ class _MIRLoop:
                     "while condition must evaluate to an i1 MachineValue "
                     "(e.g. a comparison like `a < b`)"
                 )
-        b.build_brcond(cond.reg, body)
-        b.build_br(self.exit_block)
-        self.header.add_successor(body)
-        self.header.add_successor(self.exit_block)
+        # Branch to body when the condition holds, else fall through to exit;
+        # cond_branch emits both terminators and wires both successor edges.
+        b.cond_branch(cond.reg, body, self.exit_block)
 
         b.set_block(body)
         _loop_stack.append(self)
@@ -270,8 +266,7 @@ class _MIRLoop:
         b = self.builder
         body_end = b.insert_block  # nested control flow may have moved us
         next_iv = self._iv_val + self.step if self.kind == "for" else None
-        b.build_br(self.header)
-        body_end.add_successor(self.header)
+        b.branch(self.header)  # G_BR + successor edge body_end -> header
         if self.kind == "for":
             self.iv_phi.add_phi_incoming(next_iv.reg, body_end)
         if len(self.next_carried) != len(self.carried_phis):

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -49,20 +49,17 @@ def test_build_if_diamond_with_phi():
         then_bb = mf.create_block()
         else_bb = mf.create_block()
         join_bb = mf.create_block()
-        entry.add_successor(then_bb)
-        entry.add_successor(else_bb)
-        b.build_brcond(cond, then_bb)
-        b.build_br(else_bb)
+        # cond_branch emits G_BRCOND -> then, fall-through G_BR -> else, and
+        # wires both successor edges from entry, in one call.
+        b.cond_branch(cond, then_bb, else_bb)
 
         b.set_block(then_bb)
         tv = b.build_add(s32, x, one)
-        b.build_br(join_bb)
-        then_bb.add_successor(join_bb)
+        b.branch(join_bb)  # G_BR + then->join successor edge
 
         b.set_block(else_bb)
         ev = b.build_sub(s32, x, two)
-        b.build_br(join_bb)
-        else_bb.add_successor(join_bb)
+        b.branch(join_bb)  # G_BR + else->join successor edge
 
         b.set_block(join_bb)
         r = b.build_phi(s32, [(tv, then_bb), (ev, else_bb)])
@@ -125,6 +122,76 @@ def test_terminator_builders_reject_second_terminator():
             b.build_br(dest)
         with pytest.raises(ValueError, match=r"build_brcond .*second .*terminator"):
             b.build_brcond(cond, dest)
+    assert_no_leaks()
+
+
+def test_branch_and_cond_branch_wire_successors():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        entry = mf.blocks[0]
+        then_bb = mf.create_block()
+        else_bb = mf.create_block()
+        join_bb = mf.create_block()
+
+        cond = b.build_constant(s1, 1)
+        # cond_branch: G_BRCOND -> then, fall-through G_BR -> else, plus both
+        # successor edges, and it returns the fall-through G_BR.
+        false_br = b.cond_branch(cond, then_bb, else_bb)
+        assert false_br.opcode_name == "G_BR"
+        succ_numbers = {s.number for s in entry.successors}
+        assert succ_numbers == {then_bb.number, else_bb.number}
+        ops = [i.opcode_name for i in entry.instructions]
+        assert ops[-2:] == ["G_BRCOND", "G_BR"]
+
+        # branch: G_BR + the single successor edge from the current block.
+        b.set_block(then_bb)
+        br = b.branch(join_bb)
+        assert br.opcode_name == "G_BR"
+        assert [s.number for s in then_bb.successors] == [join_bb.number]
+    assert_no_leaks()
+
+
+def test_branch_helpers_reject_cross_function_operands():
+    with ir.Context() as ctx:
+        mmi_f, mf = _new_function(ctx, "f")
+        mmi_g, mg = _new_function(ctx, "g")
+        s1 = mir.LLT.scalar(1)
+        bf = mir.MachineIRBuilder(mf)
+        foreign_block = mg.create_block()  # belongs to g
+        foreign_cond = mir.MachineIRBuilder(mg).build_constant(s1, 1)  # g's vreg
+        local = mf.create_block()
+        cond = bf.build_constant(s1, 1)
+        # branch rejects a foreign destination.
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.branch(foreign_block)
+        # cond_branch rejects a foreign condition register and either foreign
+        # block (true or false).
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.cond_branch(foreign_cond, local, mf.blocks[0])
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.cond_branch(cond, foreign_block, mf.blocks[0])
+        with pytest.raises(ValueError, match="different MachineFunction"):
+            bf.cond_branch(cond, local, foreign_block)
+    assert_no_leaks()
+
+
+def test_branch_helpers_reject_second_terminator():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        dest = mf.create_block()
+        other = mf.create_block()
+        cond = b.build_constant(s1, 1)  # built before the block is closed
+        b.branch(dest)  # closes the entry block with a G_BR barrier
+        # branch/cond_branch route through the same double-terminator guard as
+        # build_br/build_brcond, so neither appends past the barrier.
+        with pytest.raises(ValueError, match="second .*terminator"):
+            b.branch(dest)
+        with pytest.raises(ValueError, match="second .*terminator"):
+            b.cond_branch(cond, dest, other)
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_cf_primitives.py
@@ -144,12 +144,35 @@ def test_branch_and_cond_branch_wire_successors():
         assert succ_numbers == {then_bb.number, else_bb.number}
         ops = [i.opcode_name for i in entry.instructions]
         assert ops[-2:] == ["G_BRCOND", "G_BR"]
+        # Pin the branch *targets*, not just the successor set/opcode order: a
+        # swapped routing (G_BRCOND -> else, G_BR -> then) produces the same
+        # successor set and opcode order, so only the operand targets catch it.
+        # G_BRCOND operand(1) is the true target; the returned G_BR operand(0)
+        # is the fall-through (false) target.
+        brcond = next(i for i in entry.instructions if i.opcode_name == "G_BRCOND")
+        assert brcond.operand(1).mbb.number == then_bb.number
+        assert false_br.operand(0).mbb.number == else_bb.number
 
         # branch: G_BR + the single successor edge from the current block.
         b.set_block(then_bb)
         br = b.branch(join_bb)
         assert br.opcode_name == "G_BR"
         assert [s.number for s in then_bb.successors] == [join_bb.number]
+        assert br.operand(0).mbb.number == join_bb.number
+    assert_no_leaks()
+
+
+def test_cond_branch_rejects_equal_true_and_false_blocks():
+    with ir.Context() as ctx:
+        mmi, mf = _new_function(ctx)
+        s1 = mir.LLT.scalar(1)
+        b = mir.MachineIRBuilder(mf)
+        same = mf.create_block()
+        cond = b.build_constant(s1, 1)
+        # Equal true/false blocks would wire the same successor edge twice
+        # (addSuccessor does not dedup) -- a malformed CFG; the helper rejects it.
+        with pytest.raises(ValueError, match="true_block and false_block must differ"):
+            b.cond_branch(cond, same, same)
     assert_no_leaks()
 
 


### PR DESCRIPTION
Closes item 6d of #593 (the "branch helper that also wires the successor").

**Stacked on #623 (item 6b)** — base branch is `mbb-double-terminator-guard`.
Review/merge #623 first.

MIR tracks a block's CFG **successor list** and its **branch terminator
operands** separately, so emitting a branch and wiring the matching successor
edge are two steps that must stay in sync — forgetting the `add_successor`
produces MIR whose terminator points somewhere the CFG doesn't list, which the
verifier only catches later. Two additive helpers fold both:

- **`branch(dest)`** — `G_BR` to `dest` + the successor edge from the current
  block; returns the `G_BR` so its target can be repointed.
- **`cond_branch(cond, true_block, false_block)`** — `G_BRCOND` on `cond` to
  `true_block`, fall-through `G_BR` to `false_block`, and both successor edges,
  in one call. Returns the fall-through `G_BR` (the repointable one).

`branch`/`cond_branch` sit on top of the existing surface — `build_br`,
`build_brcond`, and `add_successor` are unchanged. The successor edge attaches
to `getMBB()`, the builder's current insert block, which is exactly the block
the terminator lands in.

Because this is stacked on 6b, both helpers route through the same
`requireNotTerminated` double-terminator guard as `build_br`/`build_brcond`, so
neither appends a terminator past a barrier (`test_branch_helpers_reject_second_terminator`).

Adopted at the call sites to show the ergonomics win:
- the if-diamond primitive test (`test_build_if_diamond_with_phi`): the
  `add_successor` × 2 + `build_brcond` + `build_br` block becomes one
  `cond_branch`, and each closing `build_br` + `add_successor` becomes `branch`.
- the DSL lowering in `machine_cf.py` (`_MIRIfOp`, `_MIRLoop`): the four-line
  brcond/br/two-successor blocks collapse to a single `cond_branch`, and the
  preheader/body back-edge `build_br` + `add_successor` pairs to `branch`.