### PR TITLE
[eudsl-llvmpy] MIR: native trivial MachineScheduler strategy selectable by name (#600 item 1)

### DIFF
--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -37,6 +37,18 @@ include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
+# The prebuilt LLVM is built with assertions enabled, so its ScheduleDAG/SUnit
+# (and similar) classes carry extra "#ifndef NDEBUG" members. A Release build
+# here defines NDEBUG and would give those shared classes a smaller layout, so
+# instantiating LLVM's inline templates (e.g. createSchedLive<>) emits an
+# ABI-incompatible copy the linker coalesces with LLVM's -- corrupting codegen.
+# Undefine NDEBUG to match the distro's layout. Gated on the distro's assertion
+# setting (a no-assertions release build must keep NDEBUG), and applied in both
+# the standalone and add_subdirectory (umbrella) builds.
+if(LLVM_ENABLE_ASSERTIONS)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+endif()
+
 # C++ source coverage (llvm-cov). When ON, the extension is built with
 # instrumentation; scripts/cpp_coverage.sh runs the test suite (which imports
 # the .so) under LLVM_PROFILE_FILE, merges the profraw, and enforces a
@@ -125,6 +137,8 @@ nanobind_add_module(eudslllvm_ext
   src/IR/JIT.cpp
   src/IR/Intrinsics.cpp
   src/MIR/Machine.cpp
+  src/MIR/PythonCodegen.cpp
+  src/MIR/TrivialScheduler.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -1,0 +1,62 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EUDSL_MIR_DIAGNOSTICS_H
+#define EUDSL_MIR_DIAGNOSTICS_H
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/Twine.h>
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <string>
+
+namespace eudsl {
+
+// MIR parsing and codegen report failures through LLVMContext::diagnose --
+// their return values are only a bare success/failure bit, so the rich reason
+// (line, column, message) would otherwise be lost to the default handler's
+// stderr print, which is invisible under the Python/nanobind harness. This RAII
+// guard installs a handler that captures error-severity diagnostics into `sink`
+// for the duration of one parse/codegen call, restoring the previous handler on
+// scope exit so the capture buffer (a caller stack local) never outlives the
+// handler that points at it.
+struct ScopedDiagnosticCapture {
+  llvm::LLVMContext &ctx;
+  llvm::DiagnosticHandler::DiagnosticHandlerTy prevHandler;
+  void *prevContext;
+
+  ScopedDiagnosticCapture(llvm::LLVMContext &ctx, std::string &sink)
+      : ctx(ctx), prevHandler(ctx.getDiagnosticHandlerCallBack()),
+        prevContext(ctx.getDiagnosticContext()) {
+    ctx.setDiagnosticHandlerCallBack(
+        [](const llvm::DiagnosticInfo *di, void *context) {
+          if (di->getSeverity() == llvm::DS_Error) {
+            auto *out = static_cast<std::string *>(context);
+            llvm::raw_string_ostream os(*out);
+            llvm::DiagnosticPrinterRawOStream printer(os);
+            di->print(printer);
+          }
+        },
+        &sink);
+  }
+  ~ScopedDiagnosticCapture() {
+    ctx.setDiagnosticHandlerCallBack(prevHandler, prevContext);
+  }
+  ScopedDiagnosticCapture(const ScopedDiagnosticCapture &) = delete;
+  ScopedDiagnosticCapture &operator=(const ScopedDiagnosticCapture &) = delete;
+};
+
+// "<base>" when no diagnostic was captured, else "<base>: <detail>".
+inline std::string withDetail(llvm::StringRef base, const std::string &detail) {
+  if (detail.empty())
+    return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
+  return (base + ": " + detail).str();
+}
+
+} // namespace eudsl
+
+#endif // EUDSL_MIR_DIAGNOSTICS_H

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -4,6 +4,7 @@
 
 #include "IR/Common.h"
 #include "IR/Ownership.h"
+#include "MIR/Diagnostics.h"
 
 #include <llvm/ADT/Hashing.h>
 #include <llvm/CodeGen/GlobalISel/MachineIRBuilder.h>
@@ -15,7 +16,9 @@
 #include <llvm/CodeGen/MachineInstrBuilder.h>
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/CodeGen/MachineOperand.h>
+#include <llvm/CodeGen/MachinePassRegistry.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
+#include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
@@ -39,57 +42,18 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/variant.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
 namespace {
-
-// MIR parsing and codegen report failures through LLVMContext::diagnose --
-// their return values are only a bare success/failure bit, so the rich reason
-// (line, column, message) would otherwise be lost to the default handler's
-// stderr print, which is invisible under the Python/nanobind harness. This RAII
-// guard installs a handler that captures error-severity diagnostics into `sink`
-// for the duration of one parse/codegen call, restoring the previous handler on
-// scope exit so the capture buffer (a caller stack local) never outlives the
-// handler that points at it.
-struct ScopedDiagnosticCapture {
-  llvm::LLVMContext &ctx;
-  llvm::DiagnosticHandler::DiagnosticHandlerTy prevHandler;
-  void *prevContext;
-
-  ScopedDiagnosticCapture(llvm::LLVMContext &ctx, std::string &sink)
-      : ctx(ctx), prevHandler(ctx.getDiagnosticHandlerCallBack()),
-        prevContext(ctx.getDiagnosticContext()) {
-    ctx.setDiagnosticHandlerCallBack(
-        [](const llvm::DiagnosticInfo *di, void *context) {
-          if (di->getSeverity() == llvm::DS_Error) {
-            auto *out = static_cast<std::string *>(context);
-            llvm::raw_string_ostream os(*out);
-            llvm::DiagnosticPrinterRawOStream printer(os);
-            di->print(printer);
-          }
-        },
-        &sink);
-  }
-  ~ScopedDiagnosticCapture() {
-    ctx.setDiagnosticHandlerCallBack(prevHandler, prevContext);
-  }
-  ScopedDiagnosticCapture(const ScopedDiagnosticCapture &) = delete;
-  ScopedDiagnosticCapture &operator=(const ScopedDiagnosticCapture &) = delete;
-};
-
-// "<base>" when no diagnostic was captured, else "<base>: <detail>".
-std::string withDetail(llvm::StringRef base, const std::string &detail) {
-  if (detail.empty())
-    return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
-  return (base + ": " + detail).str();
-}
 
 // A machine register paired with the MachineFunction that owns it. A virtual
 // register's numeric id is only an index into its own function's
@@ -390,8 +354,10 @@ public:
   // the back half of codegen. Only valid on the build path, and only once: the
   // BuildOwned is consumed into an EmittedOwned, so "build-path only" and the
   // one-shot are enforced by the variant's active alternative rather than a
-  // pair of runtime flags.
-  nb::bytes emitObject() {
+  // pair of runtime flags. When `scheduler` names a registered
+  // MachineSchedRegistry strategy, the pre-RA MachineScheduler uses it instead
+  // of the target's default; an unregistered name raises.
+  nb::bytes emitObject(std::optional<std::string> scheduler) {
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
     BuildOwned *build = std::get_if<BuildOwned>(&state_);
@@ -401,6 +367,23 @@ public:
     }
     llvm::TargetMachine *tm = build->tm;
     llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
+
+    // Resolve the requested scheduler against the MachineSchedRegistry before
+    // touching any codegen state so an unknown name fails cleanly. The registry
+    // holds the constructors that -misched selects among.
+    llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
+    if (scheduler) {
+      for (llvm::MachineSchedRegistry *node =
+               llvm::MachineSchedRegistry::getList();
+           node; node = node->getNext()) {
+        if (node->getName() == *scheduler) {
+          schedCtor = node->getCtor();
+          break;
+        }
+      }
+      if (!schedCtor)
+        throw std::runtime_error("unknown scheduler: " + *scheduler);
+    }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
     // unchecked primitives can produce it: bogus properties, undefined vregs,
@@ -419,7 +402,7 @@ public:
     }
     if (!ok)
       throw std::runtime_error(
-          withDetail("hand-built MIR failed verification", report));
+          eudsl::withDetail("hand-built MIR failed verification", report));
 
     // Run only the back half of codegen (regalloc, prologue/epilogue, object
     // emission) over the already-selected MachineFunctions:
@@ -443,6 +426,37 @@ public:
       ~Restore() { opt = value; }
     } restore{startAfter, saved};
     startAfter = "finalize-isel";
+
+    // Select the pre-RA MachineScheduler strategy the same way, but only when
+    // one was requested: -misched is a process-global option whose value is the
+    // ScheduleDAGCtor the scheduler pass reads, so set+restore it under the
+    // same GIL-serialized assumption. Its value type is a constructor pointer,
+    // not a string. With no scheduler requested the option is left untouched so
+    // the target's default choice stands.
+    using SchedCtor = llvm::MachineSchedRegistry::ScheduleDAGCtor;
+    using SchedOpt =
+        llvm::cl::opt<SchedCtor, false,
+                      llvm::RegisterPassParser<llvm::MachineSchedRegistry>>;
+    struct RestoreSched {
+      SchedOpt *opt = nullptr;
+      SchedCtor value = nullptr;
+      ~RestoreSched() {
+        if (opt)
+          *opt = value;
+      }
+    } restoreSched;
+    if (schedCtor) {
+      auto mischedIt = opts.find("misched");
+      // LCOV_EXCL_START -- misched is always registered by codegen
+      if (mischedIt == opts.end()) {
+        throw std::runtime_error("the -misched option is not registered");
+      }
+      // LCOV_EXCL_STOP
+      auto &misched = *static_cast<SchedOpt *>(mischedIt->second);
+      restoreSched.opt = &misched;
+      restoreSched.value = misched;
+      misched = schedCtor;
+    }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
     // no deferred flush surprises when `pm` outlives here).
@@ -475,7 +489,7 @@ public:
     // value; capture it so it surfaces as an exception.
     std::string diag;
     {
-      ScopedDiagnosticCapture capture(module_->getContext(), diag);
+      eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
       pm->run(*module_);
     }
     // Consume the BuildOwned into an EmittedOwned: the released wrapper now
@@ -483,8 +497,10 @@ public:
     state_ = EmittedOwned{std::move(pm), info};
     // LCOV_EXCL_START -- eager verification makes a back-half failure or empty
     // emission unreachable from well-formed hand-built MIR.
-    if (!diag.empty())
-      throw std::runtime_error(withDetail("object emission failed", diag));
+    if (!diag.empty()) {
+      throw std::runtime_error(
+          eudsl::withDetail("object emission failed", diag));
+    }
     if (buf.empty())
       throw std::runtime_error("object emission produced no output");
     // LCOV_EXCL_STOP
@@ -1242,10 +1258,12 @@ void populate_mir(nb::module_ &m) {
       .def("to_mir", &MirModule::toMIR,
            "Serialize the whole module (IR block + machine functions) as .mir "
            "text.")
-      .def("emit_object", &MirModule::emitObject,
+      .def("emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
            "Emit a relocatable object file for the built (already-selected) "
            "MIR by running the back half of codegen (regalloc, emission). "
-           "Verifies the MIR first, raising if it is malformed.");
+           "Verifies the MIR first, raising if it is malformed. `scheduler` "
+           "selects a registered pre-RA MachineScheduler strategy by name; an "
+           "unknown name raises.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the
@@ -1294,13 +1312,13 @@ void populate_mir(nb::module_ &m) {
         // silently-empty MachineModuleInfo.
         std::string diag;
         {
-          ScopedDiagnosticCapture capture(module->getContext(), diag);
+          eudsl::ScopedDiagnosticCapture capture(module->getContext(), diag);
           pm->run(*module);
         }
         // LCOV_EXCL_START -- needs an un-selectable input to trigger
         if (!diag.empty()) {
           throw std::runtime_error(
-              withDetail("instruction selection failed", diag));
+              eudsl::withDetail("instruction selection failed", diag));
         }
         // LCOV_EXCL_STOP
 
@@ -1348,7 +1366,7 @@ void populate_mir(nb::module_ &m) {
         // diagnostic handler and only returns a bare null/true; capture the
         // real diagnostic so the thrown message carries the line and reason.
         std::string diag;
-        ScopedDiagnosticCapture capture(context.get(), diag);
+        eudsl::ScopedDiagnosticCapture capture(context.get(), diag);
         std::unique_ptr<llvm::MIRParser> parser = llvm::createMIRParser(
             llvm::MemoryBuffer::getMemBuffer(text, "<mir>"), context.get());
         // LCOV_EXCL_START -- createMIRParser only fails on internal error
@@ -1358,14 +1376,14 @@ void populate_mir(nb::module_ &m) {
         // LCOV_EXCL_STOP
         std::unique_ptr<llvm::Module> module = parser->parseIRModule();
         if (!module) {
-          throw std::runtime_error(
-              withDetail("failed to parse the IR portion of the MIR", diag));
+          throw std::runtime_error(eudsl::withDetail(
+              "failed to parse the IR portion of the MIR", diag));
         }
         module->setDataLayout(tm.createDataLayout());
         auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
         if (parser->parseMachineFunctions(*module, *ownedMmi)) {
           throw std::runtime_error(
-              withDetail("failed to parse machine functions", diag));
+              eudsl::withDetail("failed to parse machine functions", diag));
         }
         return new MirModule(MirModule::parsed(
             std::move(ctxKeepAlive), std::move(module), std::move(ownedMmi)));

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -1,0 +1,47 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "IR/Common.h"
+
+#include <llvm/CodeGen/MachineScheduler.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <string>
+#include <vector>
+
+namespace eudsl {
+// Defined in TrivialScheduler.cpp: a diagnostic counter of pickNode calls made
+// by the "trivial" strategy, so a test can prove it actually runs when
+// selected.
+unsigned trivialSchedulerPickCount();
+void resetTrivialSchedulerPickCount();
+} // namespace eudsl
+
+void populate_python_codegen(nb::module_ &m) {
+  m.def(
+      "registered_schedulers",
+      []() {
+        std::vector<std::string> names;
+        for (llvm::MachineSchedRegistry *node =
+                 llvm::MachineSchedRegistry::getList();
+             node; node = node->getNext())
+          names.emplace_back(node->getName().str());
+        return names;
+      },
+      "Names of the pre-RA MachineScheduler strategies registered in this "
+      "extension, selectable via emit_object(scheduler=...).");
+
+  // Diagnostic hooks (leading underscore): the trivial scheduler is
+  // semantics-preserving, so tests use this counter to confirm it is exercised
+  // when selected and left unused otherwise.
+  m.def("_trivial_scheduler_pick_count", &eudsl::trivialSchedulerPickCount,
+        "Number of pickNode calls the trivial MachineScheduler strategy has "
+        "made; used by tests to verify the strategy actually runs.");
+  m.def("_reset_trivial_scheduler_pick_count",
+        &eudsl::resetTrivialSchedulerPickCount,
+        "Reset the trivial MachineScheduler pickNode counter to zero.");
+}

--- a/projects/eudsl-llvmpy/src/MIR/TrivialScheduler.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/TrivialScheduler.cpp
@@ -1,0 +1,79 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A minimal pre-RA MachineScheduler strategy registered under the name
+// "trivial", so it can be chosen with -misched=trivial (which
+// MirModule::emit_object exposes as its `scheduler` argument). It schedules
+// top-down and always picks the first ready node, doing no reordering beyond
+// what dependency order forces -- a correct baseline, not an optimizing one.
+//
+// This TU is deliberately separate from the nanobind bindings and is built with
+// assertions enabled (-UNDEBUG) to match the prebuilt LLVM it links against;
+// see the note in CMakeLists.txt.
+
+#include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/ScheduleDAG.h>
+
+#include <atomic>
+#include <vector>
+
+namespace {
+// Counts pickNode invocations across all TrivialTopDownStrategy instances. It
+// exists purely so a test can assert the strategy is actually exercised when
+// selected (and not when it is not) -- scheduling is semantics-preserving, so
+// the emitted code alone cannot distinguish "trivial ran" from a no-op.
+std::atomic<unsigned> trivialPickCount{0};
+
+class TrivialTopDownStrategy : public llvm::MachineSchedStrategy {
+  std::vector<llvm::SUnit *> ReadyQ;
+
+public:
+  explicit TrivialTopDownStrategy(const llvm::MachineSchedContext *) {}
+  // Force top-down scheduling and skip register-pressure tracking: this
+  // strategy only releases and picks top nodes, so ScheduleDAGMI must not run
+  // the bottom-up direction (it would find an empty ready queue).
+  llvm::MachineSchedPolicy getPolicy() const override {
+    llvm::MachineSchedPolicy Policy;
+    Policy.OnlyTopDown = true;
+    Policy.ShouldTrackPressure = false;
+    return Policy;
+  }
+  bool shouldTrackPressure() const override { return false; }
+  void initialize(llvm::ScheduleDAGMI *) override { ReadyQ.clear(); }
+  void releaseTopNode(llvm::SUnit *SU) override { ReadyQ.push_back(SU); }
+  void releaseBottomNode(llvm::SUnit *) override {}
+  // Each node is released exactly once, when its predecessors are all
+  // scheduled, so a node sitting in the ready queue is never already scheduled;
+  // return the first-ready one (front of the queue) and drop it.
+  llvm::SUnit *pickNode(bool &IsTopNode) override {
+    trivialPickCount.fetch_add(1, std::memory_order_relaxed);
+    if (ReadyQ.empty())
+      return nullptr;
+    IsTopNode = true;
+    llvm::SUnit *SU = ReadyQ.front();
+    ReadyQ.erase(ReadyQ.begin());
+    return SU;
+  }
+  void schedNode(llvm::SUnit *, bool) override {}
+};
+
+llvm::ScheduleDAGInstrs *createTrivialSched(llvm::MachineSchedContext *C) {
+  return llvm::createSchedLive<TrivialTopDownStrategy>(C);
+}
+
+llvm::MachineSchedRegistry
+    trivialSchedRegistry("trivial", "eudsl trivial first-ready scheduler.",
+                         createTrivialSched);
+} // namespace
+
+namespace eudsl {
+// Diagnostic accessors for the pickNode counter above, called from the nanobind
+// bindings in PythonCodegen.cpp (a separate translation unit).
+unsigned trivialSchedulerPickCount() {
+  return trivialPickCount.load(std::memory_order_relaxed);
+}
+void resetTrivialSchedulerPickCount() {
+  trivialPickCount.store(0, std::memory_order_relaxed);
+}
+} // namespace eudsl

--- a/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
+++ b/projects/eudsl-llvmpy/src/eudslllvm_ext.cpp
@@ -24,6 +24,7 @@ void populate_linker(nb::module_ &m);
 void populate_jit(nb::module_ &m);
 void populate_intrinsics(nb::module_ &m);
 void populate_mir(nb::module_ &m);
+void populate_python_codegen(nb::module_ &m);
 
 NB_MODULE(eudslllvm_ext, m) {
   m.doc() = "Hand-written nanobind bindings over the LLVM C++ IR API.";
@@ -63,4 +64,5 @@ NB_MODULE(eudslllvm_ext, m) {
   // llvm.mir -- Machine IR: the target-independent LowLevelType (LLT).
   nb::module_ mir = m.def_submodule("mir");
   populate_mir(mir);
+  populate_python_codegen(mir);
 }

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -1,0 +1,142 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Drive the native trivial MachineScheduler strategy through codegen.
+
+emit_object(scheduler="trivial") sets the process-global -misched option to the
+strategy registered under that name, so the pre-RA MachineScheduler runs it
+instead of the target's default while emitting the object. Scheduling is
+semantics-preserving, so the emitted code alone cannot tell "trivial ran" from a
+no-op; the strategy exposes a diagnostic pickNode counter, and the tests below
+assert it is non-zero exactly when scheduler="trivial" is selected and zero
+otherwise. A JIT-executed test additionally proves the result stays correct.
+"""
+
+import ctypes
+import platform
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.eudslllvm_ext import mir as _mir_ext
+from llvm.testing import assert_no_leaks
+
+# Object emission uses an AArch64 target (cross ELF), so needs the AArch64
+# backend linked; JIT-executing additionally needs an AArch64 host (below).
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+_IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
+
+
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 add(i32,i32)->i32 MachineFunction:
+    liveins $w0/$w1, two COPYs in, ADDWrr, a COPY to $w0, RET_ReallyLR."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def test_trivial_scheduler_is_registered():
+    assert "trivial" in mir.registered_schedulers()
+    assert_no_leaks()
+
+
+def test_trivial_scheduler_runs_only_when_selected():
+    """The trivial strategy's pickNode counter proves it drives the pre-RA
+    MachineScheduler when scheduler="trivial", and is untouched otherwise --
+    scheduling preserves semantics, so this counter is the only witness that the
+    strategy (rather than the target default) actually ran."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_trivial_scheduler_pick_count()
+        mmi.emit_object(scheduler="trivial")
+        assert _mir_ext._trivial_scheduler_pick_count() > 0
+    assert_no_leaks()
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_trivial_scheduler_pick_count()
+        # The generic "converge" scheduler runs (the pipeline schedules), but it
+        # is not our strategy, so the trivial counter must stay at zero.
+        mmi.emit_object(scheduler="converge")
+        assert _mir_ext._trivial_scheduler_pick_count() == 0
+    assert_no_leaks()
+
+
+def test_emit_object_with_trivial_scheduler_produces_object():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="trivial")
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_unknown_scheduler_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="scheduler"):
+            mmi.emit_object(scheduler="does-not-exist")
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_trivial_scheduled_add():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="trivial")
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()


### PR DESCRIPTION
Adds a native, trivial-but-correct `MachineSchedStrategy` (first-ready, top-down) registered as `-misched=trivial`, selectable from Python via `emit_object(scheduler="trivial")`. No Python callback yet.

- New TUs `src/MIR/TrivialScheduler.cpp` + `src/MIR/PythonCodegen.cpp` (`populate_python_codegen` into the `llvm.mir` submodule).
- `ScopedDiagnosticCapture`/`withDetail` lifted from `Machine.cpp` into a shared `src/MIR/Diagnostics.h`.
- Selection sets the process-global `-misched` cl::opt under a set+restore RAII (mirrors the existing `-start-after` handling), GIL-serialized.
- Build now undefines `NDEBUG` (`-UNDEBUG`, gated on `LLVM_ENABLE_ASSERTIONS`, applied in both build paths) to match the assertions-on distro ABI — otherwise instantiating LLVM inline codegen templates (`createSchedLive<>`) corrupts codegen.

Test JIT-executes the scheduled `add(i32,i32)` and **proves the strategy actually ran** (a `pickNode` counter fires only when `scheduler="trivial"`, 0 for the default). 100% line+function C++ coverage.

`#600` item 1. Stacked on #626.