### PR TITLE
[eudsl-llvmpy] MIR: route pickNode through a Python callable (#600 item 2)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -53,6 +53,14 @@
 #include <variant>
 #include <vector>
 
+namespace eudsl {
+// Defined in TrivialScheduler.cpp: install / clear the per-thread Python pick
+// callback the "python" MachineScheduler strategy reads at construction. Called
+// under the GIL around the emission pipeline run below.
+void setPendingPickCallback(nb::callable cb);
+void clearPendingPickCallback();
+} // namespace eudsl
+
 namespace {
 
 // A machine register paired with the MachineFunction that owns it. A virtual
@@ -356,8 +364,16 @@ public:
   // one-shot are enforced by the variant's active alternative rather than a
   // pair of runtime flags. When `scheduler` names a registered
   // MachineSchedRegistry strategy, the pre-RA MachineScheduler uses it instead
-  // of the target's default; an unregistered name raises.
-  nb::bytes emitObject(std::optional<std::string> scheduler) {
+  // of the target's default; an unregistered name raises. When `pick` is a
+  // Python callable, the "python" strategy is selected instead and routes each
+  // pickNode choice through the callable (see PyMachineSchedStrategy);
+  // `scheduler` and `pick` are mutually exclusive.
+  nb::bytes emitObject(std::optional<std::string> scheduler,
+                       std::optional<nb::callable> pick) {
+    if (scheduler && pick) {
+      throw nb::value_error(
+          "emit_object accepts at most one of scheduler= and pick=");
+    }
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
     BuildOwned *build = std::get_if<BuildOwned>(&state_);
@@ -370,19 +386,23 @@ public:
 
     // Resolve the requested scheduler against the MachineSchedRegistry before
     // touching any codegen state so an unknown name fails cleanly. The registry
-    // holds the constructors that -misched selects among.
+    // holds the constructors that -misched selects among; `pick` selects the
+    // "python" strategy by that name and additionally installs the callable.
+    std::optional<std::string> schedName = scheduler;
+    if (pick)
+      schedName = "python";
     llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
-    if (scheduler) {
+    if (schedName) {
       for (llvm::MachineSchedRegistry *node =
                llvm::MachineSchedRegistry::getList();
            node; node = node->getNext()) {
-        if (node->getName() == *scheduler) {
+        if (node->getName() == *schedName) {
           schedCtor = node->getCtor();
           break;
         }
       }
       if (!schedCtor)
-        throw std::runtime_error("unknown scheduler: " + *scheduler);
+        throw std::runtime_error("unknown scheduler: " + *schedName);
     }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
@@ -456,6 +476,23 @@ public:
       restoreSched.opt = &misched;
       restoreSched.value = misched;
       misched = schedCtor;
+    }
+
+    // Install the Python pick callback for the "python" strategy, if one was
+    // given, and clear it once the pipeline has run so it never leaks into a
+    // later emit. The strategy is constructed inside pm->run() below, on this
+    // thread, and copies the callback then; both the install and the clear
+    // touch Python refcounts and run under the GIL (held throughout emit).
+    struct RestorePick {
+      bool active = false;
+      ~RestorePick() {
+        if (active)
+          eudsl::clearPendingPickCallback();
+      }
+    } restorePick;
+    if (pick) {
+      eudsl::setPendingPickCallback(*pick);
+      restorePick.active = true;
     }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
@@ -1258,12 +1295,17 @@ void populate_mir(nb::module_ &m) {
       .def("to_mir", &MirModule::toMIR,
            "Serialize the whole module (IR block + machine functions) as .mir "
            "text.")
-      .def("emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
-           "Emit a relocatable object file for the built (already-selected) "
-           "MIR by running the back half of codegen (regalloc, emission). "
-           "Verifies the MIR first, raising if it is malformed. `scheduler` "
-           "selects a registered pre-RA MachineScheduler strategy by name; an "
-           "unknown name raises.");
+      .def(
+          "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
+          "pick"_a = nb::none(),
+          "Emit a relocatable object file for the built (already-selected) "
+          "MIR by running the back half of codegen (regalloc, emission). "
+          "Verifies the MIR first, raising if it is malformed. `scheduler` "
+          "selects a registered pre-RA MachineScheduler strategy by name; an "
+          "unknown name raises. `pick` is a Python callable that drives the "
+          "scheduler's pickNode: it receives the ready SUnits as a list[SUnit] "
+          "and returns the one to schedule next. `scheduler` and `pick` are "
+          "mutually exclusive.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -5,6 +5,7 @@
 #include "IR/Common.h"
 
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/ScheduleDAG.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
@@ -22,6 +23,12 @@ void resetTrivialSchedulerPickCount();
 } // namespace eudsl
 
 void populate_python_codegen(nb::module_ &m) {
+  // llvm::SUnit -- one scheduling unit (a MachineInstr plus its dependency
+  // edges) the pre-RA MachineScheduler orders. Bound opaque: a python `pick`
+  // callback receives the ready SUnits as a list[SUnit] and returns the one to
+  // schedule next, matched back by pointer identity. No fields are exposed yet.
+  nb::class_<llvm::SUnit>(m, "SUnit");
+
   m.def(
       "registered_schedulers",
       []() {

--- a/projects/eudsl-llvmpy/src/MIR/TrivialScheduler.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/TrivialScheduler.cpp
@@ -2,11 +2,16 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// A minimal pre-RA MachineScheduler strategy registered under the name
-// "trivial", so it can be chosen with -misched=trivial (which
-// MirModule::emit_object exposes as its `scheduler` argument). It schedules
-// top-down and always picks the first ready node, doing no reordering beyond
-// what dependency order forces -- a correct baseline, not an optimizing one.
+// Two pre-RA MachineScheduler strategies, both registered in the
+// MachineSchedRegistry so they can be chosen with -misched=<name> (which
+// MirModule::emit_object exposes as its `scheduler` argument):
+//
+//   "trivial" -- schedules top-down and always picks the first ready node,
+//     doing no reordering beyond what dependency order forces; a correct
+//     baseline, not an optimizing one.
+//   "python"  -- same top-down shape, but pickNode delegates the choice to a
+//     user-provided Python callable (see PyMachineSchedStrategy). emit_object
+//     selects it via its `pick` argument and installs the callable.
 //
 // This TU is deliberately separate from the nanobind bindings and is built with
 // assertions enabled (-UNDEBUG) to match the prebuilt LLVM it links against;
@@ -15,8 +20,14 @@
 #include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
 
+#include <nanobind/nanobind.h>
+
+#include <algorithm>
 #include <atomic>
+#include <utility>
 #include <vector>
+
+namespace nb = nanobind;
 
 namespace {
 // Counts pickNode invocations across all TrivialTopDownStrategy instances. It
@@ -65,7 +76,96 @@ llvm::ScheduleDAGInstrs *createTrivialSched(llvm::MachineSchedContext *C) {
 llvm::MachineSchedRegistry
     trivialSchedRegistry("trivial", "eudsl trivial first-ready scheduler.",
                          createTrivialSched);
+
+// The Python callable the python-backed strategy reads at construction. It is
+// per-thread: emit_object installs it (under the GIL) for the duration of one
+// emission pipeline run and clears it afterward, so every strategy instance the
+// run constructs (one per MachineFunction) copies the same callable, and it
+// never leaks into a later, callback-less emit. There is no lock -- this relies
+// on the GIL serializing emit_object callers, matching the process-global
+// -misched / -start-after option handling in Machine.cpp.
+thread_local nb::callable pendingPickCallback;
+
+// A pre-RA MachineScheduler strategy that hands the choice to a Python
+// callable. It keeps the trivial strategy's shape -- top-down only, no pressure
+// tracking, a single ready-set container fed by releaseTopNode -- but pickNode
+// marshals the ready SUnits to the callable and uses the node it returns. The
+// callable is stored as an nb::callable member so its refcount is managed for
+// us (as the IR-pass PyFunctionPass does), copied from pendingPickCallback at
+// construction.
+class PyMachineSchedStrategy : public llvm::MachineSchedStrategy {
+  std::vector<llvm::SUnit *> ReadyQ;
+  nb::callable pickCallback;
+
+public:
+  explicit PyMachineSchedStrategy(const llvm::MachineSchedContext *)
+      : pickCallback(pendingPickCallback) {}
+  llvm::MachineSchedPolicy getPolicy() const override {
+    llvm::MachineSchedPolicy Policy;
+    Policy.OnlyTopDown = true;
+    Policy.ShouldTrackPressure = false;
+    return Policy;
+  }
+  bool shouldTrackPressure() const override { return false; }
+  void initialize(llvm::ScheduleDAGMI *) override { ReadyQ.clear(); }
+  void releaseTopNode(llvm::SUnit *SU) override { ReadyQ.push_back(SU); }
+  void releaseBottomNode(llvm::SUnit *) override {}
+  // Present the ready set to the Python callable and schedule the node it
+  // picks. The callable receives a list[SUnit] and returns one element; we
+  // accept its choice only if it is one of the presented nodes, by pointer
+  // identity. With no callable installed (the strategy was selected by name,
+  // not via `pick`), or when the callable returns something that is not a
+  // presented node, we keep the native first-ready choice so the schedule stays
+  // legal. This PR assumes a well-behaved callable that does not raise;
+  // propagating a Python exception across LLVM's -fno-exceptions frames is
+  // handled separately.
+  llvm::SUnit *pickNode(bool &IsTopNode) override {
+    if (ReadyQ.empty())
+      return nullptr;
+    IsTopNode = true;
+    llvm::SUnit *chosen = nullptr;
+    if (pickCallback) {
+      nb::gil_scoped_acquire gil;
+      nb::list ready;
+      for (llvm::SUnit *SU : ReadyQ)
+        ready.append(nb::cast(SU, nb::rv_policy::reference));
+      nb::object choice = pickCallback(ready);
+      llvm::SUnit *returned = nullptr;
+      if (nb::try_cast<llvm::SUnit *>(choice, returned)) {
+        for (llvm::SUnit *SU : ReadyQ) {
+          if (SU == returned) {
+            chosen = returned;
+            break;
+          }
+        }
+      }
+    }
+    if (!chosen)
+      chosen = ReadyQ.front();
+    ReadyQ.erase(std::find(ReadyQ.begin(), ReadyQ.end(), chosen));
+    return chosen;
+  }
+  void schedNode(llvm::SUnit *, bool) override {}
+};
+
+llvm::ScheduleDAGInstrs *createPythonSched(llvm::MachineSchedContext *C) {
+  return llvm::createSchedLive<PyMachineSchedStrategy>(C);
+}
+
+llvm::MachineSchedRegistry
+    pythonSchedRegistry("python", "eudsl Python-callable-driven scheduler.",
+                        createPythonSched);
 } // namespace
+
+namespace eudsl {
+// Install / clear the per-thread pick callback the python strategy reads at
+// construction. Called from emit_object (a nanobind TU) around the emission
+// pipeline run; both touch Python refcounts, so the caller holds the GIL.
+void setPendingPickCallback(nb::callable cb) {
+  pendingPickCallback = std::move(cb);
+}
+void clearPendingPickCallback() { pendingPickCallback = nb::callable(); }
+} // namespace eudsl
 
 namespace eudsl {
 // Diagnostic accessors for the pickNode counter above, called from the nanobind

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -10,6 +10,14 @@ semantics-preserving, so the emitted code alone cannot tell "trivial ran" from a
 no-op; the strategy exposes a diagnostic pickNode counter, and the tests below
 assert it is non-zero exactly when scheduler="trivial" is selected and zero
 otherwise. A JIT-executed test additionally proves the result stays correct.
+
+emit_object(pick=<callable>) instead routes the pre-RA MachineScheduler's pickNode
+through a user Python callable: the callable receives the ready SUnits as a
+list[SUnit] and returns the one to schedule next. The callback here is assumed
+well-behaved (returns a presented node, does not raise); a callback that returns
+something not in the ready set falls back to the native first-ready node so the
+schedule stays legal. The callable appending to a list closed over by the test is
+the witness that Python (not the target default) actually drove pickNode.
 """
 
 import ctypes
@@ -116,6 +124,110 @@ def test_unknown_scheduler_name_raises():
         _build_selected_add(mmi)
         with pytest.raises(RuntimeError, match="scheduler"):
             mmi.emit_object(scheduler="does-not-exist")
+    assert_no_leaks()
+
+
+def test_python_scheduler_is_registered():
+    assert "python" in mir.registered_schedulers()
+    assert_no_leaks()
+
+
+def test_python_pick_callback_invoked_and_emits_object():
+    """emit_object(pick=cb) routes pickNode through the callable: it receives the
+    ready SUnits and returns one. The callable appends to `picks`, so a non-empty
+    `picks` witnesses that Python drove the scheduler (semantics-preserving
+    scheduling leaves no other trace); the emitted object is a well-formed ELF."""
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return ready[0]  # mimic the native first-ready policy
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the callable really ran
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_scheduler_without_callback_falls_back():
+    """Selecting the python strategy by name but without a callback is legal: with
+    no callback installed pickNode keeps the native first-ready choice, so a
+    well-formed object is still emitted."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="python")
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_python_pick_callback_wrong_return_falls_back():
+    """A callback that returns something that is not one of the presented SUnits
+    is a misbehaving callback: pickNode ignores it and falls back to the native
+    first-ready node, keeping the schedule legal and still emitting an object."""
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return 123  # not a SUnit -> not in the ready set -> fallback
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the callable ran even though its return was rejected
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_scheduler_and_pick_are_mutually_exclusive():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="scheduler"):
+            mmi.emit_object(scheduler="trivial", pick=lambda ready: ready[0])
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_python_scheduled_add():
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return ready[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the python callback drove pickNode
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
     assert_no_leaks()
 
 


### PR DESCRIPTION
Routes the pre-RA MachineScheduler's `pickNode` through a user Python callable, selected via `emit_object(pick=<callable>)`.

- New `PyMachineSchedStrategy` (registered `-misched=python`); the callable receives the ready `SUnit`s as a `list[SUnit]` and returns the one to schedule.
- The callable is threaded to the strategy (which is built by a no-arg factory) via a `thread_local nb::callable` installed under a `RestorePick` RAII, GIL-held, cleared after the run.
- `SUnit` bound opaque (fields added in a later PR). `scheduler=` and `pick=` are mutually exclusive.

Assumes a well-behaved callback (exception propagation lands in #629). Tests prove the callback drives the pick and the object JIT-executes correctly; leak-clean. 100% coverage.

`#600` item 2. Stacked on #627.