### PR TITLE
[eudsl-llvmpy] MIR: scheduler state marshaling + Python exception propagation (#600 item 3)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -10,11 +10,42 @@
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 
+#include <exception>
 #include <string>
 
 namespace eudsl {
+
+// A Python exception raised inside a scheduler pickNode callback is stashed here
+// instead of thrown across llvm::legacy::PassManager::run, which libLLVMCodeGen
+// compiles with -fno-exceptions: unwinding through those frames skips their
+// destructors and std::terminates on targets built without asynchronous unwind
+// tables. The pickNode trampoline stashes into this slot and returns a legal
+// ready node so the (isRequired, unskippable) codegen passes wind down normally;
+// runCodegenPipeline then re-raises after the run returns, so the throw only
+// crosses our own -fexceptions frames. Thread-local so concurrent pipelines
+// don't clobber it. Mirrors the IR-pass pendingPassError mechanism. Declared
+// extern and defined once (PythonCodegen.cpp) rather than inline: an inline
+// thread_local emits a duplicate TLS initialization routine in every including
+// TU, which the linker rejects.
+extern thread_local std::exception_ptr pendingCodegenError;
+
+// Run a codegen PassManager, then re-raise any Python exception a callback
+// (e.g. the "python" scheduler's pickNode) stashed during the run. The rethrow
+// happens before any post-run diagnostic check the caller performs, so a
+// re-raised Python error takes precedence over a captured LLVM diagnostic.
+inline void runCodegenPipeline(llvm::legacy::PassManager &pm, llvm::Module &m) {
+  pendingCodegenError = nullptr;
+  pm.run(m);
+  if (pendingCodegenError) {
+    std::exception_ptr e = pendingCodegenError;
+    pendingCodegenError = nullptr;
+    std::rethrow_exception(e);
+  }
+}
 
 // MIR parsing and codegen report failures through LLVMContext::diagnose --
 // their return values are only a bare success/failure bit, so the rich reason

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -523,11 +523,14 @@ public:
     }
     // A codegen pass reports failure through the context diagnostic handler
     // (DS_Error -> stderr + exit under the default handler), not pm->run()'s
-    // value; capture it so it surfaces as an exception.
+    // value; capture it so it surfaces as an exception. runCodegenPipeline
+    // re-raises any Python exception a pickNode callback stashed during the run
+    // (before the diagnostic check below), so a callback error takes precedence
+    // over a captured diagnostic.
     std::string diag;
     {
       eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
-      pm->run(*module_);
+      eudsl::runCodegenPipeline(*pm, *module_);
     }
     // Consume the BuildOwned into an EmittedOwned: the released wrapper now
     // lives in `pm`, and a second emit_object sees EmittedOwned and refuses.

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -10,7 +10,9 @@
 // binding and populate_python_codegen.
 
 #include "IR/Common.h"
+#include "MIR/Diagnostics.h"
 
+#include <llvm/CodeGen/MachineInstr.h>
 #include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
 
@@ -65,28 +67,51 @@ public:
   // picks. The callable receives a list[SUnit] and returns one element; we
   // accept its choice only if it is one of the presented nodes, by pointer
   // identity. With no callable installed (the strategy was selected by name,
-  // not via `pick`), or when the callable returns something that is not a
-  // presented node, we keep the first-ready choice so the schedule stays legal.
-  // This assumes a well-behaved callable that does not raise.
+  // not via `pick`) we keep the native first-ready choice. A callable that
+  // raises, or returns something that is not one of the presented ready nodes,
+  // has its exception stashed in eudsl::pendingCodegenError; we fall back to
+  // the native first-ready node so this call (and the rest of the unskippable
+  // codegen pipeline) returns a legal node, and runCodegenPipeline re-raises
+  // the stashed exception after the run.
   llvm::SUnit *pickNode(bool &IsTopNode) override {
     if (ReadyQ.empty())
       return nullptr;
     IsTopNode = true;
     llvm::SUnit *chosen = nullptr;
-    if (pickCallback) {
+    // Once a callback has stashed an error, stop invoking Python; the remaining
+    // pickNode calls just drain the ready queue in first-ready order so the
+    // required pipeline winds down to runCodegenPipeline's re-raise.
+    if (pickCallback && !eudsl::pendingCodegenError) {
+      // The GIL guard is intentionally outside the try: the catch stashes the
+      // exception with std::current_exception(), which for an nb::python_error
+      // touches Python refcounts and so must run while the GIL is held. Its
+      // construction does not raise, so nothing is lost by leaving it uncaught.
       nb::gil_scoped_acquire gil;
-      nb::list ready;
-      for (llvm::SUnit *SU : ReadyQ)
-        ready.append(nb::cast(SU, nb::rv_policy::reference));
-      nb::object choice = pickCallback(ready);
-      llvm::SUnit *returned = nullptr;
-      if (nb::try_cast<llvm::SUnit *>(choice, returned)) {
-        for (llvm::SUnit *SU : ReadyQ) {
-          if (SU == returned) {
-            chosen = returned;
-            break;
+      try {
+        nb::list ready;
+        for (llvm::SUnit *SU : ReadyQ)
+          ready.append(nb::cast(SU, nb::rv_policy::reference));
+        nb::object choice = pickCallback(ready);
+        llvm::SUnit *returned = nullptr;
+        if (nb::try_cast<llvm::SUnit *>(choice, returned)) {
+          for (llvm::SUnit *SU : ReadyQ) {
+            if (SU == returned) {
+              chosen = returned;
+              break;
+            }
           }
         }
+        if (!chosen) {
+          throw nb::value_error(
+              "scheduler pickNode returned a value that is not one of the "
+              "ready nodes");
+        }
+      } catch (...) {
+        // Do not let the exception unwind through LLVM's -fno-exceptions
+        // frames; stash it and fall through to the native first-ready node so
+        // the pipeline winds down to runCodegenPipeline's re-raise.
+        eudsl::pendingCodegenError = std::current_exception();
+        chosen = nullptr;
       }
     }
     if (!chosen)
@@ -107,6 +132,11 @@ llvm::MachineSchedRegistry
 } // namespace
 
 namespace eudsl {
+// The one definition of the codegen-error stash slot declared extern in
+// MIR/Diagnostics.h; this TU holds the scheduler's pickNode trampoline that
+// stashes into it.
+thread_local std::exception_ptr pendingCodegenError;
+
 // Install / clear the per-thread pick callback the python strategy reads at
 // construction. Called from emit_object around the emission pipeline run; both
 // touch Python refcounts, so the caller holds the GIL.
@@ -118,10 +148,27 @@ void clearPendingPickCallback() { pendingPickCallback = nb::callable(); }
 
 void populate_python_codegen(nb::module_ &m) {
   // llvm::SUnit -- one scheduling unit (a MachineInstr plus its dependency
-  // edges) the pre-RA MachineScheduler orders. Bound opaque: a python `pick`
-  // callback receives the ready SUnits as a list[SUnit] and returns the one to
-  // schedule next, matched back by pointer identity. No fields are exposed yet.
-  nb::class_<llvm::SUnit>(m, "SUnit");
+  // edges) the pre-RA MachineScheduler orders. A python `pick` callback
+  // receives the ready SUnits as a list[SUnit] and returns the one to schedule
+  // next, matched back by pointer identity. The read-only accessors below
+  // expose the node's identity and readiness so the callback can base its
+  // choice on the scheduler's state.
+  nb::class_<llvm::SUnit>(m, "SUnit")
+      .def_prop_ro(
+          "node_num", [](llvm::SUnit &su) { return su.NodeNum; },
+          "Entry number of this node in the DAG's node vector.")
+      .def_prop_ro(
+          "is_top_ready", [](llvm::SUnit &su) { return su.isTopReady(); },
+          "Whether all predecessors are scheduled (ready for top-down "
+          "scheduling).")
+      .def_prop_ro(
+          "is_bottom_ready", [](llvm::SUnit &su) { return su.isBottomReady(); },
+          "Whether all successors are scheduled (ready for bottom-up "
+          "scheduling).")
+      .def_prop_ro(
+          "instr", [](llvm::SUnit &su) { return su.getInstr(); },
+          nb::rv_policy::reference_internal,
+          "The representative MachineInstr this scheduling unit wraps.");
 
   m.def(
       "registered_schedulers",

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -5,10 +5,13 @@
 
 emit_object(pick=<callable>) selects the "python" MachineScheduler strategy and
 routes each pickNode choice through the callable: it receives the ready SUnits
-as a list[SUnit] and returns the one to schedule next. The callback here is
-assumed well-behaved (returns a presented node, does not raise); a callback that
-returns something not in the ready set falls back to the first-ready node so the
-schedule stays legal. Scheduling is semantics-preserving, so the emitted code
+as a list[SUnit] and returns the one to schedule next. A callback that raises,
+or that returns something that is not one of the presented ready SUnits, has its
+Python exception propagated out of emit_object -- stashed and re-raised after the
+(unskippable) codegen pipeline winds down, so it surfaces as a Python error
+rather than crashing across LLVM's -fno-exceptions frames; with no callback
+installed the strategy keeps the native first-ready choice. Scheduling is
+semantics-preserving, so the emitted code
 alone cannot tell "python drove pickNode" from a no-op; the callable appending
 to a list closed over by the test is the witness that Python (not the target
 default) actually drove pickNode. A JIT-executed test additionally proves the
@@ -16,8 +19,7 @@ result stays correct.
 
 emit_object(scheduler="<name>") instead selects a registered strategy by name
 (setting the process-global -misched option) so the pre-RA MachineScheduler runs
-it instead of the target's default; an unregistered name raises. Selecting
-"python" by name with no callback installed keeps the first-ready choice.
+it instead of the target's default; an unregistered name raises.
 """
 
 import ctypes
@@ -123,15 +125,64 @@ def test_python_scheduler_without_callback_falls_back():
     assert_no_leaks()
 
 
-def test_python_pick_callback_wrong_return_falls_back():
+def test_python_pick_callback_wrong_return_raises():
     """A callback that returns something that is not one of the presented SUnits
-    is a misbehaving callback: pickNode ignores it and falls back to the native
-    first-ready node, keeping the schedule legal and still emitting an object."""
+    is a misbehaving callback: pickNode stashes a ValueError and re-raises it out
+    of emit_object once the pipeline winds down, rather than silently falling
+    back. The interpreter survives (a Python error, not a crash), and no
+    Context/Module/callable leaks on the stash path."""
     picks = []
 
     def cb(ready):
         picks.append(len(ready))
-        return 123  # not a SUnit -> not in the ready set -> fallback
+        return 123  # not a SUnit -> not in the ready set -> error
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="not one of the ready nodes"):
+            mmi.emit_object(pick=cb)
+        assert picks  # the callable ran before its return was rejected
+    assert_no_leaks()
+
+
+def test_python_pick_callback_raise_propagates():
+    """A callback that raises surfaces as a Python exception out of emit_object
+    (the exception is stashed and re-raised after codegen winds down, never
+    thrown across LLVM's -fno-exceptions frames), and does not crash the
+    interpreter. No Context/Module/callable leaks on the stash path."""
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        raise ValueError("boom")
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="boom"):
+            mmi.emit_object(pick=cb)
+        assert picks  # the callable ran and raised
+    assert_no_leaks()
+
+
+def test_python_pick_callback_reads_sunit_fields():
+    """The SUnit read-only accessors return sensible values for the ready nodes
+    handed to the callback: node_num is a valid index, top-ready nodes (which is
+    what a top-down scheduler presents) report is_top_ready, and instr is the
+    wrapped MachineInstr. A legal pick still produces a well-formed object."""
+    seen = []
+
+    def cb(ready):
+        su = ready[0]
+        seen.append(
+            (su.node_num, su.is_top_ready, su.is_bottom_ready, su.instr is not None)
+        )
+        return su
 
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
@@ -139,7 +190,12 @@ def test_python_pick_callback_wrong_return_falls_back():
         mmi = mir.create_machine_function(mod, tm, "add")
         _build_selected_add(mmi)
         obj = mmi.emit_object(pick=cb)
-        assert picks  # the callable ran even though its return was rejected
+        assert seen
+        node_num, is_top_ready, is_bottom_ready, has_instr = seen[0]
+        assert node_num >= 0
+        assert is_top_ready  # a node in the top-down ready set has no preds left
+        assert isinstance(is_bottom_ready, bool)
+        assert has_instr  # every ready SUnit wraps a MachineInstr
         assert obj[:4] == b"\x7fELF"
     assert_no_leaks()
 


### PR DESCRIPTION
Makes the Python scheduler callback **exception-safe** and marshals richer schedule state.

- LLVM codegen is `-fno-exceptions`, so a Python exception must never unwind across `pm->run`. Adds `eudsl::runCodegenPipeline` + a `thread_local std::exception_ptr` (mirroring the landed IR-pass mechanism): the `pickNode` trampoline catches and stashes, returns a **legal** benign node, and the wrapper re-raises after the pipeline returns.
- **Legal-benign-return invariant:** codegen passes are `isRequired()`, so after a stash the scheduler keeps running — the benign return is always a real, not-yet-scheduled ready node (or `nullptr` when the region is empty).
- Illegal returns raise a clear `ValueError`. The GIL is acquired outside the `try` (the stash touches Python refcounts).
- `SUnit` gains read-only `node_num`, `is_top_ready`, `is_bottom_ready`, `instr`.

Tests: a raising callback surfaces as a Python error without crashing and leak-clean; illegal-return raises; a legal callback JIT-executes correctly. 100% line+function C++ coverage.

`#600` item 3. Stacked on #636.