### PR TITLE
[eudsl-llvmpy] MIR: route selectOrSplit through a Python callable (#600 item 5)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -60,6 +60,11 @@ namespace eudsl {
 // under the GIL around the emission pipeline run below.
 void setPendingPickCallback(nb::callable cb);
 void clearPendingPickCallback();
+// Defined in TrivialRegAlloc.cpp: install / clear the per-thread Python select
+// callback the "eudsl-trivial" allocator reads at construction. Called under
+// the GIL around the same pipeline run.
+void setPendingSelectCallback(nb::callable cb);
+void clearPendingSelectCallback();
 } // namespace eudsl
 
 namespace {
@@ -372,14 +377,22 @@ public:
   // registered RegisterRegAlloc allocator, RegisterRegAlloc's default is
   // pointed at it (via setDefault) for the run so the codegen pipeline
   // allocates with it instead of the target default; an unregistered name
-  // raises. `regalloc` is independent of `scheduler`/`pick` -- a caller may set
-  // both.
+  // raises. When `select` is a Python callable, the "eudsl-trivial" allocator
+  // is selected the same way and routes each selectOrSplit choice through the
+  // callable; `regalloc` and `select` are mutually exclusive ways of choosing
+  // the allocator. `regalloc` / `select` are independent of `scheduler`/`pick`
+  // -- a caller may set both.
   nb::bytes emitObject(std::optional<std::string> scheduler,
                        std::optional<nb::callable> pick,
-                       std::optional<std::string> regalloc) {
+                       std::optional<std::string> regalloc,
+                       std::optional<nb::callable> select) {
     if (scheduler && pick) {
       throw nb::value_error(
           "emit_object accepts at most one of scheduler= and pick=");
+    }
+    if (regalloc && select) {
+      throw nb::value_error(
+          "emit_object accepts at most one of regalloc= and select=");
     }
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
@@ -416,22 +429,26 @@ public:
     // registry the same way (walking its list by name), before touching codegen
     // state so an unknown name fails cleanly. The registry holds the allocator
     // pass constructors; a resolved one is installed as RegisterRegAlloc's
-    // default below so TargetPassConfig::createRegAllocPass picks it up. Also
-    // capture the ctor registered under "default" (LLVM's
-    // useDefaultRegisterAllocator sentinel): it is the valid baseline to
-    // restore to (see the RAII below).
+    // default below so TargetPassConfig::createRegAllocPass picks it up.
+    // `select` selects the "eudsl-trivial" allocator by that name and
+    // additionally installs the callable. Also capture the ctor registered
+    // under "default" (LLVM's useDefaultRegisterAllocator sentinel): it is the
+    // valid baseline to restore to (see the RAII below).
+    std::optional<std::string> allocName = regalloc;
+    if (select)
+      allocName = "eudsl-trivial";
     llvm::RegisterRegAlloc::FunctionPassCtor regAllocCtor = nullptr;
     llvm::RegisterRegAlloc::FunctionPassCtor defaultRegAllocCtor = nullptr;
-    if (regalloc) {
+    if (allocName) {
       for (llvm::RegisterRegAlloc *node = llvm::RegisterRegAlloc::getList();
            node; node = node->getNext()) {
-        if (node->getName() == *regalloc)
+        if (node->getName() == *allocName)
           regAllocCtor = node->getCtor();
         if (node->getName() == "default")
           defaultRegAllocCtor = node->getCtor();
       }
       if (!regAllocCtor)
-        throw std::runtime_error("unknown register allocator: " + *regalloc);
+        throw std::runtime_error("unknown register allocator: " + *allocName);
     }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
@@ -555,6 +572,24 @@ public:
     if (pick) {
       eudsl::setPendingPickCallback(*pick);
       restorePick.active = true;
+    }
+
+    // Install the Python select callback for the "eudsl-trivial" allocator, if
+    // one was given, and clear it once the pipeline has run so it never leaks
+    // into a later emit. The allocator pass is constructed while
+    // addPassesToEmitFile builds the pipeline below, on this thread, and copies
+    // the callback then; both the install and the clear touch Python refcounts
+    // and run under the GIL (held throughout emit).
+    struct RestoreSelect {
+      bool active = false;
+      ~RestoreSelect() {
+        if (active)
+          eudsl::clearPendingSelectCallback();
+      }
+    } restoreSelect;
+    if (select) {
+      eudsl::setPendingSelectCallback(*select);
+      restoreSelect.active = true;
     }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
@@ -1363,6 +1398,7 @@ void populate_mir(nb::module_ &m) {
       .def(
           "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
           "pick"_a = nb::none(), "regalloc"_a = nb::none(),
+          "select"_a = nb::none(),
           "Emit a relocatable object file for the built (already-selected) "
           "MIR by running the back half of codegen (regalloc, emission). "
           "Verifies the MIR first, raising if it is malformed. `scheduler` "
@@ -1372,7 +1408,11 @@ void populate_mir(nb::module_ &m) {
           "and returns the one to schedule next. `scheduler` and `pick` are "
           "mutually exclusive. `regalloc` selects a registered register "
           "allocator by name (e.g. \"eudsl-trivial\") for the run; an unknown "
-          "name raises. `regalloc` is independent of `scheduler`/`pick`.");
+          "name raises. `select` is a Python callable that drives the trivial "
+          "allocator's selectOrSplit: it receives the legal candidate physreg "
+          "ids as a list[int] and returns an id to assign or None to spill. "
+          "`regalloc` and `select` are mutually exclusive. `regalloc`/`select` "
+          "are independent of `scheduler`/`pick`.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/TrivialRegAlloc.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/TrivialRegAlloc.cpp
@@ -46,6 +46,8 @@
 #include <llvm/Pass.h>
 #include <llvm/PassRegistry.h>
 
+#include <nanobind/nanobind.h>
+
 #include <atomic>
 #include <memory>
 #include <queue>
@@ -58,6 +60,8 @@ namespace llvm {
 // so the legacy pass manager can resolve the analyses selectOrSplit reads.
 void initializePyRegAllocPass(PassRegistry &);
 } // namespace llvm
+
+namespace nb = nanobind;
 
 namespace {
 // Counts selectOrSplit invocations across all PyRegAlloc instances. It exists
@@ -73,6 +77,15 @@ std::atomic<unsigned> selectOrSplitCount{0};
 // prove the spill path -- authored logic here, not in the driver -- actually
 // runs when register pressure exceeds the allocatable set.
 std::atomic<unsigned> spillCount{0};
+
+// The Python callable the allocator routes selectOrSplit through, when one is
+// installed. It is per-thread: emit_object installs it (under the GIL) for the
+// duration of one emission pipeline run and clears it afterward, so every
+// PyRegAlloc instance the run constructs copies the same callable and it never
+// leaks into a later, callback-less emit. There is no lock -- this relies on
+// the GIL serializing emit_object callers, matching the process-global
+// RegisterRegAlloc default handling in Machine.cpp.
+thread_local nb::callable pendingSelectCallback;
 
 // Order the priority queue by ascending spill weight, with the register number
 // as a stable tie-breaker for deterministic ordering (copied from RABasic's
@@ -107,10 +120,19 @@ class PyRegAlloc
                       std::vector<const llvm::LiveInterval *>, CompSpillWeight>
       Queue;
 
+  // The Python callable driving selectOrSplit, copied from
+  // pendingSelectCallback at construction so its refcount is managed for us (as
+  // the IR-pass PyFunctionPass and the python scheduler strategy do). Empty
+  // when no callback is installed, in which case selectOrSplit uses the native
+  // first-free policy.
+  nb::callable selectCallback;
+
 public:
   static char ID;
 
-  PyRegAlloc() : llvm::MachineFunctionPass(ID), llvm::RegAllocBase() {
+  PyRegAlloc()
+      : llvm::MachineFunctionPass(ID), llvm::RegAllocBase(),
+        selectCallback(pendingSelectCallback) {
     llvm::initializePyRegAllocPass(*llvm::PassRegistry::getPassRegistry());
   }
 
@@ -138,6 +160,13 @@ public:
   selectOrSplit(const llvm::LiveInterval &VirtReg,
                 llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) override;
 
+  // Spill VirtReg itself (the native no-reassignment policy), returning 0 to
+  // tell the driver the vreg was replaced by the spill/reload vregs appended to
+  // SplitVRegs. Shared by the native path and the callback's spill signal.
+  llvm::MCRegister
+  spillVirtReg(const llvm::LiveInterval &VirtReg,
+               llvm::SmallVectorImpl<llvm::Register> &SplitVRegs);
+
   bool runOnMachineFunction(llvm::MachineFunction &mf) override;
 
   // Mirror RABasic: the incoming MIR is post-selection (no PHIs) and the
@@ -154,17 +183,54 @@ public:
 
 char PyRegAlloc::ID = 0;
 
-// The allocation heuristic. Assign the first physical register in VirtReg's
-// allocation order that does not interfere; if none is free, spill VirtReg
-// (unless it is unspillable, which is an allocation failure). The driver
-// (allocatePhysRegs) calls Matrix->assign for a returned physreg, and
-// re-enqueues any new virtual registers appended to SplitVRegs.
+// The allocation heuristic. When a Python callback is installed, present the
+// legal (non-interfering) candidate physregs for VirtReg to it as a list[int]
+// of physreg ids and honor its return: an id from that set is assigned; None
+// (or any non-id value that is not a candidate) is treated below. This step
+// assumes a well-behaved callback -- a return that is neither a candidate id
+// nor None falls back to the native policy rather than raising. With no
+// callback, or on that fallback, assign the first physical register in
+// VirtReg's allocation order that does not interfere; if none is free, spill
+// VirtReg. The driver (allocatePhysRegs) calls Matrix->assign for a returned
+// physreg, and re-enqueues any new virtual registers appended to SplitVRegs.
 llvm::MCRegister
 PyRegAlloc::selectOrSplit(const llvm::LiveInterval &VirtReg,
                           llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) {
   selectOrSplitCount.fetch_add(1, std::memory_order_relaxed);
   auto Order =
       llvm::AllocationOrder::create(VirtReg.reg(), *VRM, RegClassInfo, Matrix);
+
+  if (selectCallback) {
+    // Marshal and dispatch under the GIL: building the candidate list and
+    // calling the callable both touch Python refcounts. Returning from inside
+    // this scope releases the GIL; the native fallback below does not need it.
+    nb::gil_scoped_acquire gil;
+    nb::list candidates;
+    llvm::SmallVector<llvm::MCRegister, 16> candidateRegs;
+    for (llvm::MCRegister PhysReg : Order) {
+      assert(PhysReg.isValid());
+      if (Matrix->checkInterference(VirtReg, PhysReg) ==
+          llvm::LiveRegMatrix::IK_Free) {
+        candidateRegs.push_back(PhysReg);
+        candidates.append(PhysReg.id());
+      }
+    }
+    nb::object choice = selectCallback(candidates);
+    unsigned chosenId = 0;
+    if (nb::try_cast<unsigned>(choice, chosenId)) {
+      // A chosen physreg id: honor it only if it is one of the presented
+      // candidates (the driver assigns it for us).
+      for (llvm::MCRegister PhysReg : candidateRegs) {
+        if (PhysReg.id() == chosenId)
+          return PhysReg;
+      }
+    } else if (choice.is_none()) {
+      return spillVirtReg(VirtReg, SplitVRegs);
+    }
+    // Uninterpretable return, or an id not among the candidates: fall through
+    // to the native policy so this call still returns a legal choice.
+  }
+
   for (llvm::MCRegister PhysReg : Order) {
     assert(PhysReg.isValid());
     if (Matrix->checkInterference(VirtReg, PhysReg) ==
@@ -172,11 +238,17 @@ PyRegAlloc::selectOrSplit(const llvm::LiveInterval &VirtReg,
       return PhysReg;
     }
   }
-  // No free physreg: spill VirtReg itself (never an interfering vreg -- this
-  // trivial policy does no reassignment), which the driver replaces with the
-  // new spill/reload vregs appended to SplitVRegs. Only an unspillable vreg
-  // (infinite spill weight) fails to allocate; a spillable one always spills to
-  // make forward progress.
+  return spillVirtReg(VirtReg, SplitVRegs);
+}
+
+// No free physreg (or the callback asked to spill): spill VirtReg itself (never
+// an interfering vreg -- this trivial policy does no reassignment), which the
+// driver replaces with the new spill/reload vregs appended to SplitVRegs. Only
+// an unspillable vreg (infinite spill weight) fails to allocate; a spillable
+// one always spills to make forward progress.
+llvm::MCRegister
+PyRegAlloc::spillVirtReg(const llvm::LiveInterval &VirtReg,
+                         llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) {
   if (!VirtReg.isSpillable())
     return llvm::MCRegister(~0u); // LCOV_EXCL_LINE -- test vregs are spillable
   spillCount.fetch_add(1, std::memory_order_relaxed);
@@ -269,6 +341,16 @@ INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
 INITIALIZE_PASS_END(PyRegAlloc, "eudsl-regalloc-trivial",
                     "eudsl trivial register allocator", false, false)
+
+namespace eudsl {
+// Install / clear the per-thread select callback the allocator reads at
+// construction. Called from emit_object (a nanobind TU) around the emission
+// pipeline run; both touch Python refcounts, so the caller holds the GIL.
+void setPendingSelectCallback(nb::callable cb) {
+  pendingSelectCallback = std::move(cb);
+}
+void clearPendingSelectCallback() { pendingSelectCallback = nb::callable(); }
+} // namespace eudsl
 
 namespace eudsl {
 // Diagnostic accessors for the selectOrSplit counter above, called from the

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -13,6 +13,16 @@ pass exposes a diagnostic selectOrSplit counter, and the tests below assert it
 is non-zero exactly when regalloc="eudsl-trivial" is selected and zero otherwise
 (the fail-if-no-op witness that setDefault actually takes effect). A
 JIT-executed test additionally proves the allocated code stays correct.
+
+emit_object(select=<callable>) instead routes the allocator's selectOrSplit
+through a user Python callable: the callable receives the legal (non-interfering)
+candidate physregs for a virtual register as a list[int] of physreg ids and
+returns either an id from that set (assign it) or None (spill). This step assumes
+a well-behaved callback -- one that returns something uninterpretable falls back
+to the native first-free policy rather than raising. The callable appending to a
+list closed over by the test is the witness that Python (not the target default)
+actually drove selectOrSplit. select and regalloc name mutually exclusive ways of
+choosing the allocator; select is independent of the scheduler pick/scheduler.
 """
 
 import ctypes
@@ -242,6 +252,154 @@ def test_regalloc_and_scheduler_are_independent():
         assert _mir_ext._trivial_scheduler_pick_count() > 0
         assert _mir_ext._regalloc_select_count() > 0
         assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_python_select_callback_invoked_and_emits_object():
+    """emit_object(select=cb) routes selectOrSplit through the callable: it
+    receives the legal candidate physreg ids as a list[int] and returns the one
+    to assign. The callable records into `picks`, so a non-empty `picks`
+    witnesses that Python drove the allocator (semantics-preserving allocation
+    leaves no other trace); the emitted object is a well-formed ELF."""
+    picks = []
+
+    def cb(candidates):
+        picks.append(list(candidates))
+        return candidates[0]  # mimic the native first-free policy
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the callable really ran
+        assert all(cands for cands in picks)  # legal candidates were presented
+        assert all(isinstance(r, int) for cands in picks for r in cands)
+        assert _mir_ext._regalloc_select_count() > 0
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_select_callback_spills_via_none():
+    """A callable that returns None when no candidate is free signals a spill,
+    running the allocator's native spill path; when a candidate is free it
+    returns the first, mimicking the native first-free policy. Under high
+    register pressure this drives both the assign and the spill branch, and the
+    object is a well-formed ELF."""
+    selects = []
+
+    def cb(candidates):
+        selects.append(len(candidates))
+        return candidates[0] if candidates else None
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "hot")
+        _build_high_pressure(mmi)
+        _mir_ext._reset_regalloc_spill_count()
+        obj = mmi.emit_object(select=cb)
+        assert selects  # the callable ran
+        assert 0 in selects  # at least once no candidate was free
+        assert _mir_ext._regalloc_spill_count() > 0  # the None spill path ran
+        assert obj[:4] == b"\x7fELF"
+        assert b"hot\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_select_callback_bad_return_falls_back():
+    """A well-behaved-only contract for this step: a callable that returns
+    something uninterpretable (an id not among the presented candidates) does not
+    raise -- selectOrSplit falls back to the native first-free policy so the run
+    still produces a legal, well-formed object."""
+    picks = []
+
+    def cb(candidates):
+        picks.append(list(candidates))
+        return 999999  # not one of the presented candidate physreg ids
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the callable ran, its return was rejected
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_select_and_pick_drive_one_emit():
+    """select (Python allocator) is independent of pick (Python scheduler): a
+    caller may drive both in one emission. Both callables run (each records into
+    its own list) and the allocator counter fires; the object is a well-formed
+    ELF."""
+    picks = []
+    selects = []
+
+    def pick_cb(ready):
+        picks.append(len(ready))
+        return ready[0]
+
+    def select_cb(candidates):
+        selects.append(list(candidates))
+        return candidates[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(pick=pick_cb, select=select_cb)
+        assert picks and selects  # both Python callbacks ran
+        assert _mir_ext._regalloc_select_count() > 0
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_regalloc_and_select_are_mutually_exclusive():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="regalloc"):
+            mmi.emit_object(regalloc="eudsl-trivial", select=lambda c: c[0])
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_python_selected_add():
+    picks = []
+
+    def cb(candidates):
+        picks.append(len(candidates))
+        return candidates[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the python callback drove selectOrSplit
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
     assert_no_leaks()
 
 


### PR DESCRIPTION
Routes `selectOrSplit` through a user Python callable, selected via `emit_object(select=<callable>)` (mirrors the scheduler `pick=` pattern).

- The callable receives the legal (non-interfering) candidate physregs as a `list[int]` of `MCRegister` ids and returns a chosen id (assign) or `None` (spill). A returned id is honored **only if it is in the presented candidate set** — an out-of-set/wrong-type return falls back to the native policy (no raise; raising lands in #634).
- Callable threaded via a `thread_local` installed under a `RestoreSelect` RAII (GIL-held, cleared after the run). Shared spill logic extracted into a `spillVirtReg` helper.
- `regalloc=` and `select=` are mutually exclusive; a scheduler-side option (`scheduler`/`pick`) may be combined with an allocator-side option (`regalloc`/`select`) in one emit.

Tests prove the callback drives the register choice (recording list + `select_count`), the `None`→spill branch runs, bad-return falls back, `select`+`pick` drive one emit, and the object JIT-executes correctly. 100% coverage.

`#600` item 5. Stacked on #632.