### PR TITLE
[eudsl-llvmpy] MIR: Python-driven MachineScheduler via pickNode callable (#600 items 1-2)

### DIFF
--- a/.github/workflows/bump_llvm.yml
+++ b/.github/workflows/bump_llvm.yml
@@ -38,6 +38,18 @@ jobs:
           echo "LLVM_SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           popd
 
+      - name: "Sync vendored LLVM-internal headers"
+        run: |
+
+          set -euo pipefail
+          # These headers live under llvm/lib/ so they are not installed into the
+          # public include/ dir the prebuilt LLVM distro ships; keep verbatim
+          # in-tree copies the bindings can #include, re-synced on every bump.
+          cp third_party/llvm-project/llvm/lib/CodeGen/RegAllocBase.h \
+            projects/eudsl-llvmpy/src/MIR/RegAllocBase.h
+          cp third_party/llvm-project/llvm/lib/CodeGen/AllocationOrder.h \
+            projects/eudsl-llvmpy/src/MIR/AllocationOrder.h
+
       - name: "Regenerate Pipeline pass methods"
         run: |
           

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -37,6 +37,18 @@ include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
+# The prebuilt LLVM is built with assertions enabled, so its ScheduleDAG/SUnit
+# (and similar) classes carry extra "#ifndef NDEBUG" members. A Release build
+# here defines NDEBUG and would give those shared classes a smaller layout, so
+# instantiating LLVM's inline templates (e.g. createSchedLive<>) emits an
+# ABI-incompatible copy the linker coalesces with LLVM's -- corrupting codegen.
+# Undefine NDEBUG to match the distro's layout. Gated on the distro's assertion
+# setting (a no-assertions release build must keep NDEBUG), and applied in both
+# the standalone and add_subdirectory (umbrella) builds.
+if(LLVM_ENABLE_ASSERTIONS)
+  add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
+endif()
+
 # C++ source coverage (llvm-cov). When ON, the extension is built with
 # instrumentation; scripts/cpp_coverage.sh runs the test suite (which imports
 # the .so) under LLVM_PROFILE_FILE, merges the profraw, and enforces a
@@ -125,6 +137,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/JIT.cpp
   src/IR/Intrinsics.cpp
   src/MIR/Machine.cpp
+  src/MIR/PythonCodegen.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/src/MIR/AllocationOrder.h
+++ b/projects/eudsl-llvmpy/src/MIR/AllocationOrder.h
@@ -1,0 +1,124 @@
+//===-- llvm/CodeGen/AllocationOrder.h - Allocation Order -*- C++ -*-------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements an allocation order for virtual registers.
+//
+// The preferred allocation order for a virtual register depends on allocation
+// hints and target hooks. The AllocationOrder class encapsulates all of that.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_CODEGEN_ALLOCATIONORDER_H
+#define LLVM_LIB_CODEGEN_ALLOCATIONORDER_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/CodeGen/Register.h"
+
+namespace llvm {
+
+class RegisterClassInfo;
+class VirtRegMap;
+class LiveRegMatrix;
+
+class LLVM_LIBRARY_VISIBILITY AllocationOrder {
+  const SmallVector<MCPhysReg, 16> Hints;
+  ArrayRef<MCPhysReg> Order;
+  // How far into the Order we can iterate. This is 0 if the AllocationOrder is
+  // constructed with HardHints = true, Order.size() otherwise. While
+  // technically a size_t, it will participate in comparisons with the
+  // Iterator's Pos, which must be signed, so it's typed here as signed, too, to
+  // avoid warnings and under the assumption that the size of Order is
+  // relatively small.
+  // IterationLimit defines an invalid iterator position.
+  const int IterationLimit;
+
+public:
+  /// Forward iterator for an AllocationOrder.
+  class Iterator final {
+    const AllocationOrder &AO;
+    int Pos = 0;
+
+  public:
+    Iterator(const AllocationOrder &AO, int Pos) : AO(AO), Pos(Pos) {}
+
+    /// Return true if the current position is that of a preferred register.
+    bool isHint() const { return Pos < 0; }
+
+    /// Return the next physical register in the allocation order.
+    MCRegister operator*() const {
+      if (Pos < 0)
+        return AO.Hints.end()[Pos];
+      assert(Pos < AO.IterationLimit);
+      return AO.Order[Pos];
+    }
+
+    /// Advance the iterator to the next position. If that's past the Hints
+    /// list, advance to the first value that's not also in the Hints list.
+    Iterator &operator++() {
+      if (Pos < AO.IterationLimit)
+        ++Pos;
+      while (Pos >= 0 && Pos < AO.IterationLimit && AO.isHint(AO.Order[Pos]))
+        ++Pos;
+      return *this;
+    }
+
+    bool operator==(const Iterator &Other) const {
+      assert(&AO == &Other.AO);
+      return Pos == Other.Pos;
+    }
+
+    bool operator!=(const Iterator &Other) const { return !(*this == Other); }
+  };
+
+  /// Create a new AllocationOrder for VirtReg.
+  /// @param VirtReg      Virtual register to allocate for.
+  /// @param VRM          Virtual register map for function.
+  /// @param RegClassInfo Information about reserved and allocatable registers.
+  static AllocationOrder create(Register VirtReg, const VirtRegMap &VRM,
+                                const RegisterClassInfo &RegClassInfo,
+                                const LiveRegMatrix *Matrix);
+
+  /// Create an AllocationOrder given the Hints, Order, and HardHints values.
+  /// Use the create method above - the ctor is for unittests.
+  AllocationOrder(SmallVector<MCPhysReg, 16> &&Hints, ArrayRef<MCPhysReg> Order,
+                  bool HardHints)
+      : Hints(std::move(Hints)), Order(Order),
+        IterationLimit(HardHints ? 0 : static_cast<int>(Order.size())) {}
+
+  Iterator begin() const {
+    return Iterator(*this, -(static_cast<int>(Hints.size())));
+  }
+
+  Iterator end() const { return Iterator(*this, IterationLimit); }
+
+  Iterator getOrderLimitEnd(unsigned OrderLimit) const {
+    assert(OrderLimit <= Order.size());
+    if (OrderLimit == 0)
+      return end();
+    Iterator Ret(*this,
+                 std::min(static_cast<int>(OrderLimit) - 1, IterationLimit));
+    return ++Ret;
+  }
+
+  /// Get the allocation order without reordered hints.
+  ArrayRef<MCPhysReg> getOrder() const { return Order; }
+
+  /// Return true if Reg is a preferred physical register.
+  bool isHint(Register Reg) const {
+    assert(!Reg.isPhysical() ||
+           Reg.id() <
+               static_cast<uint32_t>(std::numeric_limits<MCPhysReg>::max()));
+    return Reg.isPhysical() && is_contained(Hints, Reg.id());
+  }
+};
+
+} // end namespace llvm
+
+#endif

--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -1,0 +1,62 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef EUDSL_MIR_DIAGNOSTICS_H
+#define EUDSL_MIR_DIAGNOSTICS_H
+
+#include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/Twine.h>
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <string>
+
+namespace eudsl {
+
+// MIR parsing and codegen report failures through LLVMContext::diagnose --
+// their return values are only a bare success/failure bit, so the rich reason
+// (line, column, message) would otherwise be lost to the default handler's
+// stderr print, which is invisible under the Python/nanobind harness. This RAII
+// guard installs a handler that captures error-severity diagnostics into `sink`
+// for the duration of one parse/codegen call, restoring the previous handler on
+// scope exit so the capture buffer (a caller stack local) never outlives the
+// handler that points at it.
+struct ScopedDiagnosticCapture {
+  llvm::LLVMContext &ctx;
+  llvm::DiagnosticHandler::DiagnosticHandlerTy prevHandler;
+  void *prevContext;
+
+  ScopedDiagnosticCapture(llvm::LLVMContext &ctx, std::string &sink)
+      : ctx(ctx), prevHandler(ctx.getDiagnosticHandlerCallBack()),
+        prevContext(ctx.getDiagnosticContext()) {
+    ctx.setDiagnosticHandlerCallBack(
+        [](const llvm::DiagnosticInfo *di, void *context) {
+          if (di->getSeverity() == llvm::DS_Error) {
+            auto *out = static_cast<std::string *>(context);
+            llvm::raw_string_ostream os(*out);
+            llvm::DiagnosticPrinterRawOStream printer(os);
+            di->print(printer);
+          }
+        },
+        &sink);
+  }
+  ~ScopedDiagnosticCapture() {
+    ctx.setDiagnosticHandlerCallBack(prevHandler, prevContext);
+  }
+  ScopedDiagnosticCapture(const ScopedDiagnosticCapture &) = delete;
+  ScopedDiagnosticCapture &operator=(const ScopedDiagnosticCapture &) = delete;
+};
+
+// "<base>" when no diagnostic was captured, else "<base>: <detail>".
+inline std::string withDetail(llvm::StringRef base, const std::string &detail) {
+  if (detail.empty())
+    return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
+  return (base + ": " + detail).str();
+}
+
+} // namespace eudsl
+
+#endif // EUDSL_MIR_DIAGNOSTICS_H

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -4,6 +4,7 @@
 
 #include "IR/Common.h"
 #include "IR/Ownership.h"
+#include "MIR/Diagnostics.h"
 
 #include <llvm/ADT/Hashing.h>
 #include <llvm/CodeGen/GlobalISel/MachineIRBuilder.h>
@@ -15,7 +16,9 @@
 #include <llvm/CodeGen/MachineInstrBuilder.h>
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/CodeGen/MachineOperand.h>
+#include <llvm/CodeGen/MachinePassRegistry.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
+#include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
@@ -39,57 +42,26 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/variant.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <variant>
 #include <vector>
 
+namespace eudsl {
+// Defined in PythonScheduler.cpp: install / clear the per-thread Python pick
+// callback the "python" MachineScheduler strategy reads at construction. Called
+// under the GIL around the emission pipeline run below.
+void setPendingPickCallback(nb::callable cb);
+void clearPendingPickCallback();
+} // namespace eudsl
+
 namespace {
-
-// MIR parsing and codegen report failures through LLVMContext::diagnose --
-// their return values are only a bare success/failure bit, so the rich reason
-// (line, column, message) would otherwise be lost to the default handler's
-// stderr print, which is invisible under the Python/nanobind harness. This RAII
-// guard installs a handler that captures error-severity diagnostics into `sink`
-// for the duration of one parse/codegen call, restoring the previous handler on
-// scope exit so the capture buffer (a caller stack local) never outlives the
-// handler that points at it.
-struct ScopedDiagnosticCapture {
-  llvm::LLVMContext &ctx;
-  llvm::DiagnosticHandler::DiagnosticHandlerTy prevHandler;
-  void *prevContext;
-
-  ScopedDiagnosticCapture(llvm::LLVMContext &ctx, std::string &sink)
-      : ctx(ctx), prevHandler(ctx.getDiagnosticHandlerCallBack()),
-        prevContext(ctx.getDiagnosticContext()) {
-    ctx.setDiagnosticHandlerCallBack(
-        [](const llvm::DiagnosticInfo *di, void *context) {
-          if (di->getSeverity() == llvm::DS_Error) {
-            auto *out = static_cast<std::string *>(context);
-            llvm::raw_string_ostream os(*out);
-            llvm::DiagnosticPrinterRawOStream printer(os);
-            di->print(printer);
-          }
-        },
-        &sink);
-  }
-  ~ScopedDiagnosticCapture() {
-    ctx.setDiagnosticHandlerCallBack(prevHandler, prevContext);
-  }
-  ScopedDiagnosticCapture(const ScopedDiagnosticCapture &) = delete;
-  ScopedDiagnosticCapture &operator=(const ScopedDiagnosticCapture &) = delete;
-};
-
-// "<base>" when no diagnostic was captured, else "<base>: <detail>".
-std::string withDetail(llvm::StringRef base, const std::string &detail) {
-  if (detail.empty())
-    return base.str(); // LCOV_EXCL_LINE -- MIRParser always diagnoses on error
-  return (base + ": " + detail).str();
-}
 
 // A machine register paired with the MachineFunction that owns it. A virtual
 // register's numeric id is only an index into its own function's
@@ -390,8 +362,18 @@ public:
   // the back half of codegen. Only valid on the build path, and only once: the
   // BuildOwned is consumed into an EmittedOwned, so "build-path only" and the
   // one-shot are enforced by the variant's active alternative rather than a
-  // pair of runtime flags.
-  nb::bytes emitObject() {
+  // pair of runtime flags. When `scheduler` names a registered
+  // MachineSchedRegistry strategy, the pre-RA MachineScheduler uses it instead
+  // of the target's default; an unregistered name raises. When `pick` is a
+  // Python callable, the "python" strategy is selected instead and routes each
+  // pickNode choice through the callable (see PyMachineSchedStrategy);
+  // `scheduler` and `pick` are mutually exclusive.
+  nb::bytes emitObject(std::optional<std::string> scheduler,
+                       std::optional<nb::callable> pick) {
+    if (scheduler && pick) {
+      throw nb::value_error(
+          "emit_object accepts at most one of scheduler= and pick=");
+    }
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
     BuildOwned *build = std::get_if<BuildOwned>(&state_);
@@ -401,6 +383,27 @@ public:
     }
     llvm::TargetMachine *tm = build->tm;
     llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
+
+    // Resolve the requested scheduler against the MachineSchedRegistry before
+    // touching any codegen state so an unknown name fails cleanly. The registry
+    // holds the constructors that -misched selects among; `pick` selects the
+    // "python" strategy by that name and additionally installs the callable.
+    std::optional<std::string> schedName = scheduler;
+    if (pick)
+      schedName = "python";
+    llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
+    if (schedName) {
+      for (llvm::MachineSchedRegistry *node =
+               llvm::MachineSchedRegistry::getList();
+           node; node = node->getNext()) {
+        if (node->getName() == *schedName) {
+          schedCtor = node->getCtor();
+          break;
+        }
+      }
+      if (!schedCtor)
+        throw std::runtime_error("unknown scheduler: " + *schedName);
+    }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
     // unchecked primitives can produce it: bogus properties, undefined vregs,
@@ -419,7 +422,7 @@ public:
     }
     if (!ok)
       throw std::runtime_error(
-          withDetail("hand-built MIR failed verification", report));
+          eudsl::withDetail("hand-built MIR failed verification", report));
 
     // Run only the back half of codegen (regalloc, prologue/epilogue, object
     // emission) over the already-selected MachineFunctions:
@@ -443,6 +446,54 @@ public:
       ~Restore() { opt = value; }
     } restore{startAfter, saved};
     startAfter = "finalize-isel";
+
+    // Select the pre-RA MachineScheduler strategy the same way, but only when
+    // one was requested: -misched is a process-global option whose value is the
+    // ScheduleDAGCtor the scheduler pass reads, so set+restore it under the
+    // same GIL-serialized assumption. Its value type is a constructor pointer,
+    // not a string. With no scheduler requested the option is left untouched so
+    // the target's default choice stands.
+    using SchedCtor = llvm::MachineSchedRegistry::ScheduleDAGCtor;
+    using SchedOpt =
+        llvm::cl::opt<SchedCtor, false,
+                      llvm::RegisterPassParser<llvm::MachineSchedRegistry>>;
+    struct RestoreSched {
+      SchedOpt *opt = nullptr;
+      SchedCtor value = nullptr;
+      ~RestoreSched() {
+        if (opt)
+          *opt = value;
+      }
+    } restoreSched;
+    if (schedCtor) {
+      auto mischedIt = opts.find("misched");
+      // LCOV_EXCL_START -- misched is always registered by codegen
+      if (mischedIt == opts.end()) {
+        throw std::runtime_error("the -misched option is not registered");
+      }
+      // LCOV_EXCL_STOP
+      auto &misched = *static_cast<SchedOpt *>(mischedIt->second);
+      restoreSched.opt = &misched;
+      restoreSched.value = misched;
+      misched = schedCtor;
+    }
+
+    // Install the Python pick callback for the "python" strategy, if one was
+    // given, and clear it once the pipeline has run so it never leaks into a
+    // later emit. The strategy is constructed inside pm->run() below, on this
+    // thread, and copies the callback then; both the install and the clear
+    // touch Python refcounts and run under the GIL (held throughout emit).
+    struct RestorePick {
+      bool active = false;
+      ~RestorePick() {
+        if (active)
+          eudsl::clearPendingPickCallback();
+      }
+    } restorePick;
+    if (pick) {
+      eudsl::setPendingPickCallback(*pick);
+      restorePick.active = true;
+    }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
     // no deferred flush surprises when `pm` outlives here).
@@ -475,7 +526,7 @@ public:
     // value; capture it so it surfaces as an exception.
     std::string diag;
     {
-      ScopedDiagnosticCapture capture(module_->getContext(), diag);
+      eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
       pm->run(*module_);
     }
     // Consume the BuildOwned into an EmittedOwned: the released wrapper now
@@ -483,8 +534,10 @@ public:
     state_ = EmittedOwned{std::move(pm), info};
     // LCOV_EXCL_START -- eager verification makes a back-half failure or empty
     // emission unreachable from well-formed hand-built MIR.
-    if (!diag.empty())
-      throw std::runtime_error(withDetail("object emission failed", diag));
+    if (!diag.empty()) {
+      throw std::runtime_error(
+          eudsl::withDetail("object emission failed", diag));
+    }
     if (buf.empty())
       throw std::runtime_error("object emission produced no output");
     // LCOV_EXCL_STOP
@@ -505,6 +558,10 @@ private:
 };
 
 } // namespace
+
+// Defined in PythonCodegen.cpp: binds the scheduling-unit type and the
+// scheduler-registry introspection into the same `mir` submodule.
+void populate_python_codegen(nb::module_ &m);
 
 // LowLevelType (LLT) is the generic-MIR type: a target-independent "bag of
 // bits" describing a scalar/pointer/vector operand, distinct from the uniqued
@@ -1242,10 +1299,17 @@ void populate_mir(nb::module_ &m) {
       .def("to_mir", &MirModule::toMIR,
            "Serialize the whole module (IR block + machine functions) as .mir "
            "text.")
-      .def("emit_object", &MirModule::emitObject,
-           "Emit a relocatable object file for the built (already-selected) "
-           "MIR by running the back half of codegen (regalloc, emission). "
-           "Verifies the MIR first, raising if it is malformed.");
+      .def(
+          "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
+          "pick"_a = nb::none(),
+          "Emit a relocatable object file for the built (already-selected) "
+          "MIR by running the back half of codegen (regalloc, emission). "
+          "Verifies the MIR first, raising if it is malformed. `scheduler` "
+          "selects a registered pre-RA MachineScheduler strategy by name; an "
+          "unknown name raises. `pick` is a Python callable that drives the "
+          "scheduler's pickNode: it receives the ready SUnits as a list[SUnit] "
+          "and returns the one to schedule next. `scheduler` and `pick` are "
+          "mutually exclusive.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the
@@ -1294,13 +1358,13 @@ void populate_mir(nb::module_ &m) {
         // silently-empty MachineModuleInfo.
         std::string diag;
         {
-          ScopedDiagnosticCapture capture(module->getContext(), diag);
+          eudsl::ScopedDiagnosticCapture capture(module->getContext(), diag);
           pm->run(*module);
         }
         // LCOV_EXCL_START -- needs an un-selectable input to trigger
         if (!diag.empty()) {
           throw std::runtime_error(
-              withDetail("instruction selection failed", diag));
+              eudsl::withDetail("instruction selection failed", diag));
         }
         // LCOV_EXCL_STOP
 
@@ -1348,7 +1412,7 @@ void populate_mir(nb::module_ &m) {
         // diagnostic handler and only returns a bare null/true; capture the
         // real diagnostic so the thrown message carries the line and reason.
         std::string diag;
-        ScopedDiagnosticCapture capture(context.get(), diag);
+        eudsl::ScopedDiagnosticCapture capture(context.get(), diag);
         std::unique_ptr<llvm::MIRParser> parser = llvm::createMIRParser(
             llvm::MemoryBuffer::getMemBuffer(text, "<mir>"), context.get());
         // LCOV_EXCL_START -- createMIRParser only fails on internal error
@@ -1358,14 +1422,14 @@ void populate_mir(nb::module_ &m) {
         // LCOV_EXCL_STOP
         std::unique_ptr<llvm::Module> module = parser->parseIRModule();
         if (!module) {
-          throw std::runtime_error(
-              withDetail("failed to parse the IR portion of the MIR", diag));
+          throw std::runtime_error(eudsl::withDetail(
+              "failed to parse the IR portion of the MIR", diag));
         }
         module->setDataLayout(tm.createDataLayout());
         auto ownedMmi = std::make_unique<llvm::MachineModuleInfo>(&tm);
         if (parser->parseMachineFunctions(*module, *ownedMmi)) {
           throw std::runtime_error(
-              withDetail("failed to parse machine functions", diag));
+              eudsl::withDetail("failed to parse machine functions", diag));
         }
         return new MirModule(MirModule::parsed(
             std::move(ctxKeepAlive), std::move(module), std::move(ownedMmi)));
@@ -1751,4 +1815,8 @@ void populate_mir(nb::module_ &m) {
       },
       nb::rv_policy::reference,
       "The innermost MachineIRBuilder on the thread-local stack.");
+
+  // Scheduling-unit type and scheduler-registry introspection (SUnit,
+  // registered_schedulers) bound into the same submodule.
+  populate_python_codegen(m);
 }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -1,0 +1,138 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// A pre-RA MachineScheduler strategy that hands the pickNode choice to a Python
+// callable, registered in the MachineSchedRegistry as "python" so it can be
+// chosen with -misched=python (which MirModule::emit_object drives from its
+// `pick` argument): the strategy schedules top-down and, for each ready set,
+// asks the callable which node to schedule next. This TU also holds the SUnit
+// binding and populate_python_codegen.
+
+#include "IR/Common.h"
+
+#include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/ScheduleDAG.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nb = nanobind;
+
+namespace {
+// The Python callable the python-backed strategy reads at construction. It is
+// per-thread: emit_object installs it (under the GIL) for the duration of one
+// emission pipeline run and clears it afterward, so every strategy instance the
+// run constructs (one per MachineFunction) copies the same callable, and it
+// never leaks into a later, callback-less emit. There is no lock -- this relies
+// on the GIL serializing emit_object callers, matching the process-global
+// -misched / -start-after option handling in Machine.cpp.
+thread_local nb::callable pendingPickCallback;
+
+// A pre-RA MachineScheduler strategy that hands the choice to a Python
+// callable. It is top-down only with no pressure tracking, a single ready-set
+// container fed by releaseTopNode; pickNode marshals the ready SUnits to the
+// callable and uses the node it returns. The callable is stored as an
+// nb::callable member so its refcount is managed for us (as the IR-pass
+// PyFunctionPass does), copied from pendingPickCallback at construction.
+class PyMachineSchedStrategy : public llvm::MachineSchedStrategy {
+  std::vector<llvm::SUnit *> ReadyQ;
+  nb::callable pickCallback;
+
+public:
+  explicit PyMachineSchedStrategy(const llvm::MachineSchedContext *)
+      : pickCallback(pendingPickCallback) {}
+  // Force top-down scheduling and skip register-pressure tracking: this
+  // strategy only releases and picks top nodes, so ScheduleDAGMI must not run
+  // the bottom-up direction (it would find an empty ready queue).
+  llvm::MachineSchedPolicy getPolicy() const override {
+    llvm::MachineSchedPolicy Policy;
+    Policy.OnlyTopDown = true;
+    Policy.ShouldTrackPressure = false;
+    return Policy;
+  }
+  bool shouldTrackPressure() const override { return false; }
+  void initialize(llvm::ScheduleDAGMI *) override { ReadyQ.clear(); }
+  void releaseTopNode(llvm::SUnit *SU) override { ReadyQ.push_back(SU); }
+  void releaseBottomNode(llvm::SUnit *) override {}
+  // Present the ready set to the Python callable and schedule the node it
+  // picks. The callable receives a list[SUnit] and returns one element; we
+  // accept its choice only if it is one of the presented nodes, by pointer
+  // identity. With no callable installed (the strategy was selected by name,
+  // not via `pick`), or when the callable returns something that is not a
+  // presented node, we keep the first-ready choice so the schedule stays legal.
+  // This assumes a well-behaved callable that does not raise.
+  llvm::SUnit *pickNode(bool &IsTopNode) override {
+    if (ReadyQ.empty())
+      return nullptr;
+    IsTopNode = true;
+    llvm::SUnit *chosen = nullptr;
+    if (pickCallback) {
+      nb::gil_scoped_acquire gil;
+      nb::list ready;
+      for (llvm::SUnit *SU : ReadyQ)
+        ready.append(nb::cast(SU, nb::rv_policy::reference));
+      nb::object choice = pickCallback(ready);
+      llvm::SUnit *returned = nullptr;
+      if (nb::try_cast<llvm::SUnit *>(choice, returned)) {
+        for (llvm::SUnit *SU : ReadyQ) {
+          if (SU == returned) {
+            chosen = returned;
+            break;
+          }
+        }
+      }
+    }
+    if (!chosen)
+      chosen = ReadyQ.front();
+    ReadyQ.erase(std::find(ReadyQ.begin(), ReadyQ.end(), chosen));
+    return chosen;
+  }
+  void schedNode(llvm::SUnit *, bool) override {}
+};
+
+llvm::ScheduleDAGInstrs *createPythonSched(llvm::MachineSchedContext *C) {
+  return llvm::createSchedLive<PyMachineSchedStrategy>(C);
+}
+
+llvm::MachineSchedRegistry
+    pythonSchedRegistry("python", "eudsl Python-callable-driven scheduler.",
+                        createPythonSched);
+} // namespace
+
+namespace eudsl {
+// Install / clear the per-thread pick callback the python strategy reads at
+// construction. Called from emit_object around the emission pipeline run; both
+// touch Python refcounts, so the caller holds the GIL.
+void setPendingPickCallback(nb::callable cb) {
+  pendingPickCallback = std::move(cb);
+}
+void clearPendingPickCallback() { pendingPickCallback = nb::callable(); }
+} // namespace eudsl
+
+void populate_python_codegen(nb::module_ &m) {
+  // llvm::SUnit -- one scheduling unit (a MachineInstr plus its dependency
+  // edges) the pre-RA MachineScheduler orders. Bound opaque: a python `pick`
+  // callback receives the ready SUnits as a list[SUnit] and returns the one to
+  // schedule next, matched back by pointer identity. No fields are exposed yet.
+  nb::class_<llvm::SUnit>(m, "SUnit");
+
+  m.def(
+      "registered_schedulers",
+      []() {
+        std::vector<std::string> names;
+        for (llvm::MachineSchedRegistry *node =
+                 llvm::MachineSchedRegistry::getList();
+             node; node = node->getNext())
+          names.emplace_back(node->getName().str());
+        return names;
+      },
+      "Names of the pre-RA MachineScheduler strategies registered in this "
+      "extension, selectable via emit_object(scheduler=...).");
+}

--- a/projects/eudsl-llvmpy/src/MIR/RegAllocBase.h
+++ b/projects/eudsl-llvmpy/src/MIR/RegAllocBase.h
@@ -1,0 +1,156 @@
+//===- RegAllocBase.h - basic regalloc interface and driver -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the RegAllocBase class, which is the skeleton of a basic
+// register allocation algorithm and interface for extending it. It provides the
+// building blocks on which to construct other experimental allocators and test
+// the validity of two principles:
+//
+// - If virtual and physical register liveness is modeled using intervals, then
+// on-the-fly interference checking is cheap. Furthermore, interferences can be
+// lazily cached and reused.
+//
+// - Register allocation complexity, and generated code performance is
+// determined by the effectiveness of live range splitting rather than optimal
+// coloring.
+//
+// Following the first principle, interfering checking revolves around the
+// LiveIntervalUnion data structure.
+//
+// To fulfill the second principle, the basic allocator provides a driver for
+// incremental splitting. It essentially punts on the problem of register
+// coloring, instead driving the assignment of virtual to physical registers by
+// the cost of splitting. The basic allocator allows for heuristic reassignment
+// of registers, if a more sophisticated allocator chooses to do that.
+//
+// This framework provides a way to engineer the compile time vs. code
+// quality trade-off without relying on a particular theoretical solver.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_CODEGEN_REGALLOCBASE_H
+#define LLVM_LIB_CODEGEN_REGALLOCBASE_H
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/CodeGen/MachineRegisterInfo.h"
+#include "llvm/CodeGen/RegAllocCommon.h"
+#include "llvm/CodeGen/RegisterClassInfo.h"
+
+namespace llvm {
+
+class LiveInterval;
+class LiveIntervals;
+class LiveRegMatrix;
+class MachineInstr;
+class MachineRegisterInfo;
+template<typename T> class SmallVectorImpl;
+class Spiller;
+class TargetRegisterInfo;
+class VirtRegMap;
+
+/// RegAllocBase provides the register allocation driver and interface that can
+/// be extended to add interesting heuristics.
+///
+/// Register allocators must override the selectOrSplit() method to implement
+/// live range splitting. They must also override enqueue/dequeue to provide an
+/// assignment order.
+class RegAllocBase {
+  virtual void anchor();
+
+protected:
+  const TargetRegisterInfo *TRI = nullptr;
+  MachineRegisterInfo *MRI = nullptr;
+  VirtRegMap *VRM = nullptr;
+  LiveIntervals *LIS = nullptr;
+  LiveRegMatrix *Matrix = nullptr;
+  RegisterClassInfo RegClassInfo;
+
+private:
+  /// Private, callees should go through shouldAllocateRegister
+  const RegAllocFilterFunc shouldAllocateRegisterImpl;
+
+protected:
+  /// Inst which is a def of an original reg and whose defs are already all
+  /// dead after remat is saved in DeadRemats. The deletion of such inst is
+  /// postponed till all the allocations are done, so its remat expr is
+  /// always available for the remat of all the siblings of the original reg.
+  SmallPtrSet<MachineInstr *, 32> DeadRemats;
+
+  SmallSet<Register, 2> FailedVRegs;
+  RegAllocBase(const RegAllocFilterFunc F = nullptr)
+      : shouldAllocateRegisterImpl(F) {}
+
+  virtual ~RegAllocBase() = default;
+
+  // A RegAlloc pass should call this before allocatePhysRegs.
+  void init(VirtRegMap &vrm, LiveIntervals &lis, LiveRegMatrix &mat);
+
+  /// Get whether a given register should be allocated
+  bool shouldAllocateRegister(Register Reg) {
+    if (!shouldAllocateRegisterImpl)
+      return true;
+    return shouldAllocateRegisterImpl(*TRI, *MRI, Reg);
+  }
+
+  // The top-level driver. The output is a VirtRegMap that us updated with
+  // physical register assignments.
+  void allocatePhysRegs();
+
+  // Include spiller post optimization and removing dead defs left because of
+  // rematerialization.
+  virtual void postOptimization();
+
+  /// Perform cleanups on registers that failed to allocate. This hacks on the
+  /// liveness in order to avoid spurious verifier errors in later passes.
+  void cleanupFailedVReg(Register FailedVReg, MCRegister PhysReg,
+                         SmallVectorImpl<Register> &SplitRegs);
+
+  // Get a temporary reference to a Spiller instance.
+  virtual Spiller &spiller() = 0;
+
+  /// enqueue - Add VirtReg to the priority queue of unassigned registers.
+  virtual void enqueueImpl(const LiveInterval *LI) = 0;
+
+  /// enqueue - Add VirtReg to the priority queue of unassigned registers.
+  void enqueue(const LiveInterval *LI);
+
+  /// dequeue - Return the next unassigned register, or NULL.
+  virtual const LiveInterval *dequeue() = 0;
+
+  // A RegAlloc pass should override this to provide the allocation heuristics.
+  // Each call must guarantee forward progess by returning an available PhysReg
+  // or new set of split live virtual registers. It is up to the splitter to
+  // converge quickly toward fully spilled live ranges.
+  virtual MCRegister selectOrSplit(const LiveInterval &VirtReg,
+                                   SmallVectorImpl<Register> &splitLVRs) = 0;
+
+  /// Query a physical register to use as a filler in contexts where the
+  /// allocation has failed. This will raise an error, but not abort the
+  /// compilation.
+  MCPhysReg getErrorAssignment(const TargetRegisterClass &RC,
+                               const MachineInstr *CtxMI = nullptr);
+
+  // Use this group name for NamedRegionTimer.
+  static const char TimerGroupName[];
+  static const char TimerGroupDescription[];
+
+  /// Method called when the allocator is about to remove a LiveInterval.
+  virtual void aboutToRemoveInterval(const LiveInterval &LI) {}
+
+public:
+  /// VerifyEnabled - True when -verify-regalloc is given.
+  static bool VerifyEnabled;
+
+private:
+  void seedLiveRegs();
+};
+
+} // end namespace llvm
+
+#endif // LLVM_LIB_CODEGEN_REGALLOCBASE_H

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -1,0 +1,185 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Drive the pre-RA MachineScheduler's pickNode through a Python callable.
+
+emit_object(pick=<callable>) selects the "python" MachineScheduler strategy and
+routes each pickNode choice through the callable: it receives the ready SUnits
+as a list[SUnit] and returns the one to schedule next. The callback here is
+assumed well-behaved (returns a presented node, does not raise); a callback that
+returns something not in the ready set falls back to the first-ready node so the
+schedule stays legal. Scheduling is semantics-preserving, so the emitted code
+alone cannot tell "python drove pickNode" from a no-op; the callable appending
+to a list closed over by the test is the witness that Python (not the target
+default) actually drove pickNode. A JIT-executed test additionally proves the
+result stays correct.
+
+emit_object(scheduler="<name>") instead selects a registered strategy by name
+(setting the process-global -misched option) so the pre-RA MachineScheduler runs
+it instead of the target's default; an unregistered name raises. Selecting
+"python" by name with no callback installed keeps the first-ready choice.
+"""
+
+import ctypes
+import platform
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+# Object emission uses an AArch64 target (cross ELF), so needs the AArch64
+# backend linked; JIT-executing additionally needs an AArch64 host (below).
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+_IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
+
+
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 add(i32,i32)->i32 MachineFunction:
+    liveins $w0/$w1, two COPYs in, ADDWrr, a COPY to $w0, RET_ReallyLR."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def test_unknown_scheduler_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="scheduler"):
+            mmi.emit_object(scheduler="does-not-exist")
+    assert_no_leaks()
+
+
+def test_python_scheduler_is_registered():
+    assert "python" in mir.registered_schedulers()
+    assert_no_leaks()
+
+
+def test_python_pick_callback_invoked_and_emits_object():
+    """emit_object(pick=cb) routes pickNode through the callable: it receives the
+    ready SUnits and returns one. The callable appends to `picks`, so a non-empty
+    `picks` witnesses that Python drove the scheduler (semantics-preserving
+    scheduling leaves no other trace); the emitted object is a well-formed ELF."""
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return ready[0]  # mimic the native first-ready policy
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the callable really ran
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_scheduler_without_callback_falls_back():
+    """Selecting the python strategy by name but without a callback is legal: with
+    no callback installed pickNode keeps the native first-ready choice, so a
+    well-formed object is still emitted."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="python")
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_python_pick_callback_wrong_return_falls_back():
+    """A callback that returns something that is not one of the presented SUnits
+    is a misbehaving callback: pickNode ignores it and falls back to the native
+    first-ready node, keeping the schedule legal and still emitting an object."""
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return 123  # not a SUnit -> not in the ready set -> fallback
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the callable ran even though its return was rejected
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_scheduler_and_pick_are_mutually_exclusive():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="scheduler"):
+            mmi.emit_object(scheduler="python", pick=lambda ready: ready[0])
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_python_scheduled_add():
+    picks = []
+
+    def cb(ready):
+        picks.append(len(ready))
+        return ready[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(pick=cb)
+        assert picks  # the python callback drove pickNode
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()


### PR DESCRIPTION
Adds a Python-driven pre-RA instruction scheduler (foundation + callback folded into one commit). A `MachineSchedStrategy` registered as `-misched=python` routes its `pickNode` decision through a user Python callable, selected via `emit_object(pick=<callable>)`; `emit_object(scheduler="<name>")` selects any registered strategy by name (e.g. LLVM's `converge`), listed by `mir.registered_schedulers()`.

- New TU `src/MIR/PythonCodegen.cpp` (`populate_python_codegen` into the `llvm.mir` submodule) holds the strategy, the `SUnit` binding, and the callback plumbing. `ScopedDiagnosticCapture`/`withDetail` lifted into a shared `src/MIR/Diagnostics.h`.
- The callable receives the ready `SUnit`s as a `list[SUnit]` and returns one, matched back by pointer identity; with no callable installed it keeps a native first-ready choice. Threaded via a `thread_local` installed under a set+restore RAII, GIL-held (mirrors the `-start-after` process-global option handling in `Machine.cpp`).
- Selection sets the process-global `-misched` cl::opt under a set+restore RAII; an unknown name raises.
- The build undefines `NDEBUG` (`-UNDEBUG`, gated on `LLVM_ENABLE_ASSERTIONS`, in both the standalone and umbrella builds) to match the assertions-on prebuilt LLVM ABI — otherwise instantiating LLVM inline codegen templates (`createSchedLive<>`) emits an ABI-incompatible copy and corrupts codegen.

Test JIT-executes the scheduled `add` and proves the callback actually drove `pickNode` (its recording list is non-empty; a no-op scheduler could not produce that). 100% line+function C++ coverage.

`#600` items 1-2. Base of the scheduler track; stacked on #626.