### PR TITLE
[eudsl-llvmpy] MIR: Python-driven register allocator via selectOrSplit callable (#600 items 4-5)

### DIFF
--- a/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
+++ b/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
@@ -67,9 +67,16 @@ if [[ -z "$SO" || ! -f "$SO" ]]; then
 fi
 
 echo ">> checking src/IR + src/MIR coverage (threshold=${THRESHOLD}%)"
+# RegAllocBase.h and AllocationOrder.h under src/MIR are verbatim upstream LLVM
+# private CodeGen headers, vendored only so TrivialRegAlloc.cpp can reach their
+# declarations (they are not installed with the LLVM distro). We do not author
+# them and exercise them only incidentally through the allocator, so their
+# inline accessors (getOrder, getOrderLimitEnd, the hint iterator, ...) are not
+# all reachable from our code; exclude them from our authored-code gate.
 "$PY" "${PROJ_DIR}/scripts/check_coverage.py" \
   --llvm-cov "$LLVM_COV" \
   --profdata "${COV_DIR}/eudslllvm.profdata" \
   --objects "$SO" \
   --sources "${PROJ_DIR}/src/IR" "${PROJ_DIR}/src/MIR" \
+  --ignore-filename-regex 'src/MIR/(RegAllocBase|AllocationOrder)\.h$' \
   --threshold="${THRESHOLD}"

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -19,6 +19,7 @@
 #include <llvm/CodeGen/MachinePassRegistry.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/RegAllocRegistry.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
@@ -59,6 +60,11 @@ namespace eudsl {
 // under the GIL around the emission pipeline run below.
 void setPendingPickCallback(nb::callable cb);
 void clearPendingPickCallback();
+// Defined in PythonRegAlloc.cpp: install / clear the per-thread Python select
+// callback the "eudsl-python" allocator reads at construction. Called under
+// the GIL around the same pipeline run.
+void setPendingSelectCallback(nb::callable cb);
+void clearPendingSelectCallback();
 } // namespace eudsl
 
 namespace {
@@ -367,12 +373,26 @@ public:
   // of the target's default; an unregistered name raises. When `pick` is a
   // Python callable, the "python" strategy is selected instead and routes each
   // pickNode choice through the callable (see PyMachineSchedStrategy);
-  // `scheduler` and `pick` are mutually exclusive.
+  // `scheduler` and `pick` are mutually exclusive. When `regalloc` names a
+  // registered RegisterRegAlloc allocator, RegisterRegAlloc's default is
+  // pointed at it (via setDefault) for the run so the codegen pipeline
+  // allocates with it instead of the target default; an unregistered name
+  // raises. When `select` is a Python callable, the "eudsl-python" allocator
+  // is selected the same way and routes each selectOrSplit choice through the
+  // callable; `regalloc` and `select` are mutually exclusive ways of choosing
+  // the allocator. `regalloc` / `select` are independent of `scheduler`/`pick`
+  // -- a caller may set both.
   nb::bytes emitObject(std::optional<std::string> scheduler,
-                       std::optional<nb::callable> pick) {
+                       std::optional<nb::callable> pick,
+                       std::optional<std::string> regalloc,
+                       std::optional<nb::callable> select) {
     if (scheduler && pick) {
       throw nb::value_error(
           "emit_object accepts at most one of scheduler= and pick=");
+    }
+    if (regalloc && select) {
+      throw nb::value_error(
+          "emit_object accepts at most one of regalloc= and select=");
     }
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
@@ -403,6 +423,32 @@ public:
       }
       if (!schedCtor)
         throw std::runtime_error("unknown scheduler: " + *schedName);
+    }
+
+    // Resolve the requested register allocator against the RegisterRegAlloc
+    // registry the same way (walking its list by name), before touching codegen
+    // state so an unknown name fails cleanly. The registry holds the allocator
+    // pass constructors; a resolved one is installed as RegisterRegAlloc's
+    // default below so TargetPassConfig::createRegAllocPass picks it up.
+    // `select` selects the "eudsl-python" allocator by that name and
+    // additionally installs the callable. Also capture the ctor registered
+    // under "default" (LLVM's useDefaultRegisterAllocator sentinel): it is the
+    // valid baseline to restore to (see the RAII below).
+    std::optional<std::string> allocName = regalloc;
+    if (select)
+      allocName = "eudsl-python";
+    llvm::RegisterRegAlloc::FunctionPassCtor regAllocCtor = nullptr;
+    llvm::RegisterRegAlloc::FunctionPassCtor defaultRegAllocCtor = nullptr;
+    if (allocName) {
+      for (llvm::RegisterRegAlloc *node = llvm::RegisterRegAlloc::getList();
+           node; node = node->getNext()) {
+        if (node->getName() == *allocName)
+          regAllocCtor = node->getCtor();
+        if (node->getName() == "default")
+          defaultRegAllocCtor = node->getCtor();
+      }
+      if (!regAllocCtor)
+        throw std::runtime_error("unknown register allocator: " + *allocName);
     }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
@@ -478,6 +524,39 @@ public:
       misched = schedCtor;
     }
 
+    // Select the register allocator by pointing RegisterRegAlloc's process-
+    // global default at the resolved constructor:
+    // TargetPassConfig::createRegAllocPass reads getDefault() when
+    // addPassesToEmitFile builds the pipeline below, so this must be in effect
+    // then. Save and restore the previous default under the same GIL-serialized
+    // assumption as the options above. With no allocator requested the default
+    // is left untouched so the target's choice stands.
+    //
+    // The restore value needs care: TargetPassConfig lazily initializes
+    // getDefault() to useDefaultRegisterAllocator exactly once per process
+    // (guarded by a once_flag). If our override is installed before that lazy
+    // init fires, the init sees a non-null default and no-ops -- permanently --
+    // so a plain save/restore would put back the pre-override value, which is
+    // null on a fresh process, and a later default emit would call that null
+    // ctor and crash. Restore to the captured "default" ctor
+    // (useDefaultRegisterAllocator) whenever the saved default was null, which
+    // is exactly the value the lazy init would otherwise have set.
+    struct RestoreRegAlloc {
+      bool active = false;
+      llvm::RegisterRegAlloc::FunctionPassCtor value = nullptr;
+      ~RestoreRegAlloc() {
+        if (active)
+          llvm::RegisterRegAlloc::setDefault(value);
+      }
+    } restoreRegAlloc;
+    if (regAllocCtor) {
+      llvm::RegisterRegAlloc::FunctionPassCtor prev =
+          llvm::RegisterRegAlloc::getDefault();
+      restoreRegAlloc.value = prev ? prev : defaultRegAllocCtor;
+      restoreRegAlloc.active = true;
+      llvm::RegisterRegAlloc::setDefault(regAllocCtor);
+    }
+
     // Install the Python pick callback for the "python" strategy, if one was
     // given, and clear it once the pipeline has run so it never leaks into a
     // later emit. The strategy is constructed inside pm->run() below, on this
@@ -493,6 +572,24 @@ public:
     if (pick) {
       eudsl::setPendingPickCallback(*pick);
       restorePick.active = true;
+    }
+
+    // Install the Python select callback for the "eudsl-python" allocator, if
+    // one was given, and clear it once the pipeline has run so it never leaks
+    // into a later emit. The allocator pass is constructed while
+    // addPassesToEmitFile builds the pipeline below, on this thread, and copies
+    // the callback then; both the install and the clear touch Python refcounts
+    // and run under the GIL (held throughout emit).
+    struct RestoreSelect {
+      bool active = false;
+      ~RestoreSelect() {
+        if (active)
+          eudsl::clearPendingSelectCallback();
+      }
+    } restoreSelect;
+    if (select) {
+      eudsl::setPendingSelectCallback(*select);
+      restoreSelect.active = true;
     }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
@@ -1304,7 +1401,8 @@ void populate_mir(nb::module_ &m) {
            "text.")
       .def(
           "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
-          "pick"_a = nb::none(),
+          "pick"_a = nb::none(), "regalloc"_a = nb::none(),
+          "select"_a = nb::none(),
           "Emit a relocatable object file for the built (already-selected) "
           "MIR by running the back half of codegen (regalloc, emission). "
           "Verifies the MIR first, raising if it is malformed. `scheduler` "
@@ -1312,7 +1410,13 @@ void populate_mir(nb::module_ &m) {
           "unknown name raises. `pick` is a Python callable that drives the "
           "scheduler's pickNode: it receives the ready SUnits as a list[SUnit] "
           "and returns the one to schedule next. `scheduler` and `pick` are "
-          "mutually exclusive.");
+          "mutually exclusive. `regalloc` selects a registered register "
+          "allocator by name (e.g. \"eudsl-python\") for the run; an unknown "
+          "name raises. `select` is a Python callable that drives the eudsl "
+          "allocator's selectOrSplit: it receives the legal candidate physreg "
+          "ids as a list[int] and returns an id to assign or None to spill. "
+          "`regalloc` and `select` are mutually exclusive. `regalloc`/`select` "
+          "are independent of `scheduler`/`pick`.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -2,28 +2,79 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// A pre-RA MachineScheduler strategy that hands the pickNode choice to a Python
-// callable, registered in the MachineSchedRegistry as "python" so it can be
-// chosen with -misched=python (which MirModule::emit_object drives from its
-// `pick` argument): the strategy schedules top-down and, for each ready set,
-// asks the callable which node to schedule next. This TU also holds the SUnit
-// binding and populate_python_codegen.
+// The Python-driven codegen bindings and the passes they expose: a pre-RA
+// MachineScheduler strategy and a register allocator that hand their choices to
+// Python callables, the SUnit binding those callbacks receive, and
+// populate_python_codegen which wires the bindings into the module.
+//
+// PyMachineSchedStrategy is registered in the MachineSchedRegistry as "python"
+// so it can be chosen with -misched=python (which MirModule::emit_object drives
+// from its `scheduler`/`pick` arguments): the strategy schedules top-down and,
+// for each ready set, asks the callable which node to schedule next.
+//
+// PyRegAlloc is the register allocator, selectable through
+// emit_object(regalloc="eudsl-python"). It is a MachineFunctionPass built on
+// LLVM's RegAllocBase driver (the same skeleton RABasic uses): the driver seeds
+// the priority queue with the live intervals to allocate and repeatedly calls
+// selectOrSplit. When a Python select callable is installed, selectOrSplit
+// routes each choice through it; otherwise it assigns the first physical
+// register in the allocation order that does not interfere, spilling only when
+// none is free. That native first-free/spill policy is also the callable's
+// required legal fallback. It is registered in the RegisterRegAlloc registry
+// under "eudsl-python", which emit_object selects with
+// RegisterRegAlloc::setDefault -- read by TargetPassConfig::createRegAllocPass
+// when addPassesToEmitFile builds the codegen pipeline. The allocator pulls in
+// the two vendored private CodeGen headers (RegAllocBase.h, AllocationOrder.h)
+// that RABasic depends on but that the LLVM distro does not ship.
 
 #include "IR/Common.h"
+#include "MIR/AllocationOrder.h"
 #include "MIR/Diagnostics.h"
+#include "MIR/RegAllocBase.h"
 
+#include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/ProfileSummaryInfo.h>
+#include <llvm/CodeGen/CalcSpillWeights.h>
+#include <llvm/CodeGen/LiveDebugVariables.h>
+#include <llvm/CodeGen/LiveIntervals.h>
+#include <llvm/CodeGen/LiveRangeEdit.h>
+#include <llvm/CodeGen/LiveRegMatrix.h>
+#include <llvm/CodeGen/LiveStacks.h>
+#include <llvm/CodeGen/MachineBlockFrequencyInfo.h>
+#include <llvm/CodeGen/MachineDominators.h>
+#include <llvm/CodeGen/MachineFunctionPass.h>
 #include <llvm/CodeGen/MachineInstr.h>
+#include <llvm/CodeGen/MachineLoopInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/Passes.h>
+#include <llvm/CodeGen/RegAllocRegistry.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
+#include <llvm/CodeGen/SlotIndexes.h>
+#include <llvm/CodeGen/Spiller.h>
+#include <llvm/CodeGen/VirtRegMap.h>
+#include <llvm/InitializePasses.h>
+#include <llvm/Pass.h>
+#include <llvm/PassRegistry.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
 #include <algorithm>
+#include <atomic>
+#include <memory>
+#include <queue>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
+
+namespace llvm {
+// Defined by the INITIALIZE_PASS block below; declared here so the constructor
+// can register the pass's PassInfo (idempotently) when an instance is created,
+// so the legacy pass manager can resolve the analyses selectOrSplit reads.
+void initializePyRegAllocPass(PassRegistry &);
+} // namespace llvm
 
 namespace nb = nanobind;
 
@@ -129,7 +180,283 @@ llvm::ScheduleDAGInstrs *createPythonSched(llvm::MachineSchedContext *C) {
 llvm::MachineSchedRegistry
     pythonSchedRegistry("python", "eudsl Python-callable-driven scheduler.",
                         createPythonSched);
+
+// Counts selectOrSplit invocations across all PyRegAlloc instances. It exists
+// purely so a test can assert the allocator is actually exercised when selected
+// (and not when it is not) -- register allocation is semantics-preserving, so
+// the emitted code alone cannot distinguish "the eudsl allocator ran" from
+// the target default having run. It is also the fail-if-no-op witness that
+// RegisterRegAlloc::setDefault took effect when the pipeline was built.
+std::atomic<unsigned> selectOrSplitCount{0};
+
+// Counts the times selectOrSplit takes the spill branch (a vreg could not be
+// assigned a free physreg). A companion to selectOrSplitCount so a test can
+// prove the spill path -- authored logic here, not in the driver -- actually
+// runs when register pressure exceeds the allocatable set.
+std::atomic<unsigned> spillCount{0};
+
+// The Python callable the allocator routes selectOrSplit through, when one is
+// installed. It is per-thread: emit_object installs it (under the GIL) for the
+// duration of one emission pipeline run and clears it afterward, so every
+// PyRegAlloc instance the run constructs copies the same callable and it never
+// leaks into a later, callback-less emit. There is no lock -- this relies on
+// the GIL serializing emit_object callers, matching the process-global
+// RegisterRegAlloc default handling in Machine.cpp.
+thread_local nb::callable pendingSelectCallback;
+
+// Order the priority queue by ascending spill weight, with the register number
+// as a stable tie-breaker for deterministic ordering (copied from RABasic's
+// CompSpillWeight).
+struct CompSpillWeight {
+  bool operator()(const llvm::LiveInterval *A,
+                  const llvm::LiveInterval *B) const {
+    return std::tuple(A->weight(), A->reg()) <
+           std::tuple(B->weight(), B->reg());
+  }
+};
+
+class PyRegAlloc : public llvm::MachineFunctionPass,
+                   public llvm::RegAllocBase,
+                   // LiveRangeEdit needs a delegate to notify on erase/shrink
+                   // of a vreg during spilling. We inherit it but keep the
+                   // base's no-op defaults (unlike RABasic, which overrides
+                   // them): RABasic reassigns interfering vregs, so it must
+                   // unassign them from the Matrix and re-enqueue shrunk ones.
+                   // This policy only ever spills VirtReg itself (it never
+                   // touches interferences), so no already-assigned interval is
+                   // erased or shrunk and the Matrix/Queue never hold stale
+                   // entries -- the spill test JIT-executes correctly with the
+                   // defaults, confirming the overrides are unnecessary here.
+                   private llvm::LiveRangeEdit::Delegate {
+  // The function currently being allocated (set in runOnMachineFunction).
+  llvm::MachineFunction *MF = nullptr;
+
+  std::unique_ptr<llvm::Spiller> SpillerInstance;
+  std::priority_queue<const llvm::LiveInterval *,
+                      std::vector<const llvm::LiveInterval *>, CompSpillWeight>
+      Queue;
+
+  // The Python callable driving selectOrSplit, copied from
+  // pendingSelectCallback at construction so its refcount is managed for us (as
+  // the IR-pass PyFunctionPass and the python scheduler strategy do). Empty
+  // when no callback is installed, in which case selectOrSplit uses the native
+  // first-free policy.
+  nb::callable selectCallback;
+
+public:
+  static char ID;
+
+  PyRegAlloc()
+      : llvm::MachineFunctionPass(ID), llvm::RegAllocBase(),
+        selectCallback(pendingSelectCallback) {
+    llvm::initializePyRegAllocPass(*llvm::PassRegistry::getPassRegistry());
+  }
+
+  llvm::StringRef getPassName() const override {
+    return "eudsl register allocator";
+  }
+
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+
+  void releaseMemory() override { SpillerInstance.reset(); }
+
+  llvm::Spiller &spiller() override { return *SpillerInstance; }
+
+  void enqueueImpl(const llvm::LiveInterval *LI) override { Queue.push(LI); }
+
+  const llvm::LiveInterval *dequeue() override {
+    if (Queue.empty())
+      return nullptr;
+    const llvm::LiveInterval *LI = Queue.top();
+    Queue.pop();
+    return LI;
+  }
+
+  llvm::MCRegister
+  selectOrSplit(const llvm::LiveInterval &VirtReg,
+                llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) override;
+
+  // Spill VirtReg itself (the native no-reassignment policy), returning 0 to
+  // tell the driver the vreg was replaced by the spill/reload vregs appended to
+  // SplitVRegs. Shared by the native path and the callback's spill signal.
+  llvm::MCRegister
+  spillVirtReg(const llvm::LiveInterval &VirtReg,
+               llvm::SmallVectorImpl<llvm::Register> &SplitVRegs);
+
+  bool runOnMachineFunction(llvm::MachineFunction &mf) override;
+
+  // Mirror RABasic: the incoming MIR is post-selection (no PHIs) and the
+  // allocator materializes physical registers, clearing SSA form.
+  llvm::MachineFunctionProperties getRequiredProperties() const override {
+    return llvm::MachineFunctionProperties().set(
+        llvm::MachineFunctionProperties::Property::NoPHIs);
+  }
+  llvm::MachineFunctionProperties getClearedProperties() const override {
+    return llvm::MachineFunctionProperties().set(
+        llvm::MachineFunctionProperties::Property::IsSSA);
+  }
+};
+
+char PyRegAlloc::ID = 0;
+
+// The allocation heuristic. When a Python callback is installed, present the
+// legal (non-interfering) candidate physregs for VirtReg to it as a list[int]
+// of physreg ids and honor its return: an id from that set is assigned; None
+// (or any non-id value that is not a candidate) is treated below. This step
+// assumes a well-behaved callback -- a return that is neither a candidate id
+// nor None falls back to the native policy rather than raising. With no
+// callback, or on that fallback, assign the first physical register in
+// VirtReg's allocation order that does not interfere; if none is free, spill
+// VirtReg. The driver (allocatePhysRegs) calls Matrix->assign for a returned
+// physreg, and re-enqueues any new virtual registers appended to SplitVRegs.
+llvm::MCRegister
+PyRegAlloc::selectOrSplit(const llvm::LiveInterval &VirtReg,
+                          llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) {
+  selectOrSplitCount.fetch_add(1, std::memory_order_relaxed);
+  auto Order =
+      llvm::AllocationOrder::create(VirtReg.reg(), *VRM, RegClassInfo, Matrix);
+
+  if (selectCallback) {
+    // Marshal and dispatch under the GIL: building the candidate list and
+    // calling the callable both touch Python refcounts. Returning from inside
+    // this scope releases the GIL; the native fallback below does not need it.
+    nb::gil_scoped_acquire gil;
+    nb::list candidates;
+    llvm::SmallVector<llvm::MCRegister, 16> candidateRegs;
+    for (llvm::MCRegister PhysReg : Order) {
+      assert(PhysReg.isValid());
+      if (Matrix->checkInterference(VirtReg, PhysReg) ==
+          llvm::LiveRegMatrix::IK_Free) {
+        candidateRegs.push_back(PhysReg);
+        candidates.append(PhysReg.id());
+      }
+    }
+    nb::object choice = selectCallback(candidates);
+    unsigned chosenId = 0;
+    if (nb::try_cast<unsigned>(choice, chosenId)) {
+      // A chosen physreg id: honor it only if it is one of the presented
+      // candidates (the driver assigns it for us).
+      for (llvm::MCRegister PhysReg : candidateRegs) {
+        if (PhysReg.id() == chosenId)
+          return PhysReg;
+      }
+    } else if (choice.is_none()) {
+      return spillVirtReg(VirtReg, SplitVRegs);
+    }
+    // Uninterpretable return, or an id not among the candidates: fall through
+    // to the native policy so this call still returns a legal choice.
+  }
+
+  for (llvm::MCRegister PhysReg : Order) {
+    assert(PhysReg.isValid());
+    if (Matrix->checkInterference(VirtReg, PhysReg) ==
+        llvm::LiveRegMatrix::IK_Free) {
+      return PhysReg;
+    }
+  }
+  return spillVirtReg(VirtReg, SplitVRegs);
+}
+
+// No free physreg (or the callback asked to spill): spill VirtReg itself (never
+// an interfering vreg -- this policy does no reassignment), which the
+// driver replaces with the new spill/reload vregs appended to SplitVRegs. Only
+// an unspillable vreg (infinite spill weight) fails to allocate; a spillable
+// one always spills to make forward progress.
+llvm::MCRegister
+PyRegAlloc::spillVirtReg(const llvm::LiveInterval &VirtReg,
+                         llvm::SmallVectorImpl<llvm::Register> &SplitVRegs) {
+  if (!VirtReg.isSpillable())
+    return llvm::MCRegister(~0u); // LCOV_EXCL_LINE -- test vregs are spillable
+  spillCount.fetch_add(1, std::memory_order_relaxed);
+  llvm::LiveRangeEdit LRE(&VirtReg, SplitVRegs, *MF, *LIS, VRM, this,
+                          &DeadRemats);
+  spiller().spill(LRE);
+  return llvm::MCRegister();
+}
+
+// The analysis dependency set, copied verbatim from RABasic's getAnalysisUsage
+// (omitting one yields a null-analysis crash when selectOrSplit / the driver
+// reads it). setPreservesCFG and the MachineFunctionPass chain-up are required.
+void PyRegAlloc::getAnalysisUsage(llvm::AnalysisUsage &AU) const {
+  AU.setPreservesCFG();
+  AU.addRequired<llvm::AAResultsWrapperPass>();
+  AU.addPreserved<llvm::AAResultsWrapperPass>();
+  AU.addRequired<llvm::LiveIntervalsWrapperPass>();
+  AU.addPreserved<llvm::LiveIntervalsWrapperPass>();
+  AU.addPreserved<llvm::SlotIndexesWrapperPass>();
+  AU.addRequired<llvm::LiveDebugVariablesWrapperLegacy>();
+  AU.addPreserved<llvm::LiveDebugVariablesWrapperLegacy>();
+  AU.addRequired<llvm::LiveStacksWrapperLegacy>();
+  AU.addPreserved<llvm::LiveStacksWrapperLegacy>();
+  AU.addRequired<llvm::ProfileSummaryInfoWrapperPass>();
+  AU.addRequired<llvm::MachineBlockFrequencyInfoWrapperPass>();
+  AU.addRequired<llvm::MachineDominatorTreeWrapperPass>();
+  AU.addRequiredID(llvm::MachineDominatorsID);
+  AU.addRequired<llvm::MachineLoopInfoWrapperPass>();
+  AU.addRequired<llvm::VirtRegMapWrapperLegacy>();
+  AU.addPreserved<llvm::VirtRegMapWrapperLegacy>();
+  AU.addRequired<llvm::LiveRegMatrixWrapperLegacy>();
+  AU.addPreserved<llvm::LiveRegMatrixWrapperLegacy>();
+  llvm::MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+// Wire up the RegAllocBase driver, copied from RABasic::runOnMachineFunction
+// (analysis-wrapper accessor names as spelled in this LLVM): fetch the
+// analyses, init the base, compute spill weights, build the inline spiller,
+// then run the allocation driver and clean up.
+bool PyRegAlloc::runOnMachineFunction(llvm::MachineFunction &mf) {
+  MF = &mf;
+  auto &MBFI =
+      getAnalysis<llvm::MachineBlockFrequencyInfoWrapperPass>().getMBFI();
+  auto &LiveStks = getAnalysis<llvm::LiveStacksWrapperLegacy>().getLS();
+  auto &MDT = getAnalysis<llvm::MachineDominatorTreeWrapperPass>().getDomTree();
+
+  RegAllocBase::init(getAnalysis<llvm::VirtRegMapWrapperLegacy>().getVRM(),
+                     getAnalysis<llvm::LiveIntervalsWrapperPass>().getLIS(),
+                     getAnalysis<llvm::LiveRegMatrixWrapperLegacy>().getLRM());
+  llvm::VirtRegAuxInfo VRAI(
+      *MF, *LIS, *VRM, getAnalysis<llvm::MachineLoopInfoWrapperPass>().getLI(),
+      MBFI, &getAnalysis<llvm::ProfileSummaryInfoWrapperPass>().getPSI());
+  VRAI.calculateSpillWeightsAndHints();
+
+  SpillerInstance.reset(
+      createInlineSpiller({*LIS, LiveStks, MDT, MBFI}, *MF, *VRM, VRAI));
+
+  allocatePhysRegs();
+  postOptimization();
+  releaseMemory();
+  return true;
+}
+
+llvm::FunctionPass *createPyRegAlloc() { return new PyRegAlloc(); }
+
+llvm::RegisterRegAlloc pythonRegAlloc("eudsl-python",
+                                      "eudsl register allocator",
+                                      createPyRegAlloc);
 } // namespace
+
+// Register the pass and its analysis dependencies (verbatim from RABasic's
+// INITIALIZE_PASS block, dependency wrapper names as spelled in this LLVM). The
+// INITIALIZE_PASS macros spell their helper names (PassInfo, callDefaultCtor,
+// ...) unqualified, matching RegAllocBasic.cpp's file-scope `using namespace
+// llvm`, so pull the namespace in here for the macro expansion.
+using namespace llvm;
+INITIALIZE_PASS_BEGIN(PyRegAlloc, "eudsl-regalloc-python",
+                      "eudsl register allocator", false, false)
+INITIALIZE_PASS_DEPENDENCY(LiveDebugVariablesWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(SlotIndexesWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(LiveIntervalsWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(RegisterCoalescerLegacy)
+INITIALIZE_PASS_DEPENDENCY(MachineSchedulerLegacy)
+INITIALIZE_PASS_DEPENDENCY(LiveStacksWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
+INITIALIZE_PASS_END(PyRegAlloc, "eudsl-regalloc-python",
+                    "eudsl register allocator", false, false)
 
 namespace eudsl {
 // The one definition of the codegen-error stash slot declared extern in
@@ -144,6 +471,29 @@ void setPendingPickCallback(nb::callable cb) {
   pendingPickCallback = std::move(cb);
 }
 void clearPendingPickCallback() { pendingPickCallback = nb::callable(); }
+
+// Install / clear the per-thread select callback the allocator reads at
+// construction. Called from emit_object around the emission pipeline run; both
+// touch Python refcounts, so the caller holds the GIL.
+void setPendingSelectCallback(nb::callable cb) {
+  pendingSelectCallback = std::move(cb);
+}
+void clearPendingSelectCallback() { pendingSelectCallback = nb::callable(); }
+
+// Diagnostic accessors for the selectOrSplit / spill counters above, called
+// from the m.def bindings in populate_python_codegen below.
+unsigned pyRegAllocSelectCount() {
+  return selectOrSplitCount.load(std::memory_order_relaxed);
+}
+void resetPyRegAllocSelectCount() {
+  selectOrSplitCount.store(0, std::memory_order_relaxed);
+}
+unsigned pyRegAllocSpillCount() {
+  return spillCount.load(std::memory_order_relaxed);
+}
+void resetPyRegAllocSpillCount() {
+  spillCount.store(0, std::memory_order_relaxed);
+}
 } // namespace eudsl
 
 void populate_python_codegen(nb::module_ &m) {
@@ -182,4 +532,17 @@ void populate_python_codegen(nb::module_ &m) {
       },
       "Names of the pre-RA MachineScheduler strategies registered in this "
       "extension, selectable via emit_object(scheduler=...).");
+
+  m.def("_regalloc_select_count", &eudsl::pyRegAllocSelectCount,
+        "Number of selectOrSplit calls the eudsl register allocator has "
+        "made; used by tests to verify the allocator actually runs when "
+        "selected via emit_object(regalloc=\"eudsl-python\").");
+  m.def("_reset_regalloc_select_count", &eudsl::resetPyRegAllocSelectCount,
+        "Reset the eudsl register allocator selectOrSplit counter to zero.");
+  m.def("_regalloc_spill_count", &eudsl::pyRegAllocSpillCount,
+        "Number of times the eudsl register allocator took its spill branch; "
+        "used by a test to verify the spill path runs under high register "
+        "pressure.");
+  m.def("_reset_regalloc_spill_count", &eudsl::resetPyRegAllocSpillCount,
+        "Reset the eudsl register allocator spill counter to zero.");
 }

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1,0 +1,436 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Drive the eudsl RegAllocBase allocator through codegen.
+
+emit_object(regalloc="eudsl-python") makes RegisterRegAlloc's default point at
+the extension's PyRegAlloc pass (a RegAllocBase-derived MachineFunctionPass that
+assigns the first non-interfering physreg per virtual register), so the back
+half of codegen runs it instead of the target's default greedy/fast allocator
+while emitting the object. Register allocation is semantics-preserving, so the
+emitted code alone cannot tell "the eudsl allocator ran" from a no-op; the
+pass exposes a diagnostic selectOrSplit counter, and the tests below assert it
+is non-zero exactly when regalloc="eudsl-python" is selected and zero otherwise
+(the fail-if-no-op witness that setDefault actually takes effect). A
+JIT-executed test additionally proves the allocated code stays correct.
+
+emit_object(select=<callable>) instead routes the allocator's selectOrSplit
+through a user Python callable: the callable receives the legal (non-interfering)
+candidate physregs for a virtual register as a list[int] of physreg ids and
+returns either an id from that set (assign it) or None (spill). This step assumes
+a well-behaved callback -- one that returns something uninterpretable falls back
+to the native first-free policy rather than raising. The callable appending to a
+list closed over by the test is the witness that Python (not the target default)
+actually drove selectOrSplit. select and regalloc name mutually exclusive ways of
+choosing the allocator; select is independent of the scheduler pick/scheduler.
+"""
+
+import ctypes
+import platform
+
+import pytest
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.eudslllvm_ext import mir as _mir_ext
+from llvm.testing import assert_no_leaks
+
+# Object emission uses an AArch64 target (cross ELF), so needs the AArch64
+# backend linked; JIT-executing additionally needs an AArch64 host (below).
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+_IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
+
+
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 add(i32,i32)->i32 MachineFunction:
+    liveins $w0/$w1, two COPYs in, ADDWrr, a COPY to $w0, RET_ReallyLR."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def test_eudsl_regalloc_runs_only_when_selected():
+    """The eudsl allocator's selectOrSplit counter proves it drives register
+    allocation when regalloc="eudsl-python", and is untouched otherwise --
+    allocation preserves semantics, so this counter is the only witness that the
+    extension's allocator (rather than the target default) actually ran, i.e.
+    that RegisterRegAlloc::setDefault took effect when the pipeline was built."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        mmi.emit_object(regalloc="eudsl-python")
+        assert _mir_ext._regalloc_select_count() > 0
+    assert_no_leaks()
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        # The target default allocator runs (the pipeline allocates registers),
+        # but it is not our pass, so the eudsl counter must stay at zero.
+        mmi.emit_object()
+        assert _mir_ext._regalloc_select_count() == 0
+    assert_no_leaks()
+
+
+def test_emit_object_with_eudsl_regalloc_produces_object():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(regalloc="eudsl-python")
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_unknown_regalloc_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="register allocator"):
+            mmi.emit_object(regalloc="does-not-exist")
+    assert_no_leaks()
+
+
+# More GPR32 vregs held live at once than AArch64 has allocatable (~29), so the
+# eudsl allocator must take its spill branch. 40 comfortably exceeds it.
+_HIGH_PRESSURE_N = 40
+
+
+def _build_high_pressure(mmi):
+    """Hand-build a selected AArch64 hot(i32 w0)->i32 that forces spilling.
+
+    Define N distinct vregs in the entry block (a chain v0 = base+base,
+    vi = v(i-1)+base, so vi = (i+2)*base -- distinct values, which MachineCSE
+    cannot collapse), then branch to a second block that sums them all. Every vi
+    is defined in the entry block and used in the successor, so all N are live
+    across the CFG edge; block-local scheduling cannot shorten that cross-block
+    liveness, so peak pressure is ~N simultaneously-live GPR32 vregs and the
+    allocator must spill. The result is sum_{i=0..N-1} (i+2)*w0."""
+    mf = mmi.machine_function("hot")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    tail = mf.create_block()
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    copy = mf.opcode("COPY")
+    addwrr = mf.opcode("ADDWrr")
+    b.set_block(entry)
+    base = mf.create_vreg(gpr32)
+    c = b.build_instr(copy)
+    c.add_reg(base, is_def=True)
+    c.add_reg(w0)
+    vs = []
+    prev = base
+    for _ in range(_HIGH_PRESSURE_N):
+        v = mf.create_vreg(gpr32)
+        a = b.build_instr(addwrr)
+        a.add_reg(v, is_def=True)
+        a.add_reg(prev)
+        a.add_reg(base)
+        vs.append(v)
+        prev = v
+    br = b.build_instr(mf.opcode("B"))
+    br.add_mbb(tail)
+    entry.add_successor(tail)
+    b.set_block(tail)
+    acc = vs[0]
+    for v in vs[1:]:
+        nv = mf.create_vreg(gpr32)
+        a = b.build_instr(addwrr)
+        a.add_reg(nv, is_def=True)
+        a.add_reg(acc)
+        a.add_reg(v)
+        acc = nv
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(acc)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def _high_pressure_expected(x):
+    """hot(x) = sum_{i=0..N-1} (i+2)*x."""
+    return x * sum(i + 2 for i in range(_HIGH_PRESSURE_N))
+
+
+def test_eudsl_regalloc_spills_under_high_pressure():
+    """A high-register-pressure function forces the eudsl allocator down its
+    spill branch (more GPR32 vregs live across a CFG edge than allocatable regs).
+    The spill counter proves the authored spill path -- not just the driver --
+    ran, and the allocation still produces a well-formed ELF object."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "hot")
+        _build_high_pressure(mmi)
+        _mir_ext._reset_regalloc_spill_count()
+        obj = mmi.emit_object(regalloc="eudsl-python")
+        assert _mir_ext._regalloc_spill_count() > 0  # the spill path ran
+        assert obj[:4] == b"\x7fELF"
+        assert b"hot\x00" in obj
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_spilled_high_pressure():
+    """Execute the spilled allocation to prove the spill/reload code the eudsl
+    allocator inserted is correct."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "hot")
+        _build_high_pressure(mmi)
+        _mir_ext._reset_regalloc_spill_count()
+        obj = mmi.emit_object(regalloc="eudsl-python")
+        assert _mir_ext._regalloc_spill_count() > 0
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        hot = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32)(j.lookup("hot"))
+        assert hot(3) == _high_pressure_expected(3)
+        assert hot(5) == _high_pressure_expected(5)
+        del j
+    assert_no_leaks()
+
+
+def test_regalloc_and_scheduler_are_independent():
+    """regalloc is orthogonal to scheduler/pick: a caller may drive the pre-RA
+    scheduler with a Python pick callback and the allocator with the eudsl
+    allocator in one emission. The scheduler pick callback runs (its recording
+    list is non-empty) and the allocator's select counter fires, proving a
+    scheduler-side and an allocator-side option drive one emit independently; the
+    object is a well-formed ELF."""
+    picks = []
+
+    def pick_cb(ready):
+        picks.append(len(ready))
+        return ready[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(pick=pick_cb, regalloc="eudsl-python")
+        assert picks  # the scheduler pick callback ran
+        assert _mir_ext._regalloc_select_count() > 0
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_python_select_callback_invoked_and_emits_object():
+    """emit_object(select=cb) routes selectOrSplit through the callable: it
+    receives the legal candidate physreg ids as a list[int] and returns the one
+    to assign. The callable records into `picks`, so a non-empty `picks`
+    witnesses that Python drove the allocator (semantics-preserving allocation
+    leaves no other trace); the emitted object is a well-formed ELF."""
+    picks = []
+
+    def cb(candidates):
+        picks.append(list(candidates))
+        return candidates[0]  # mimic the native first-free policy
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the callable really ran
+        assert all(cands for cands in picks)  # legal candidates were presented
+        assert all(isinstance(r, int) for cands in picks for r in cands)
+        assert _mir_ext._regalloc_select_count() > 0
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_select_callback_spills_via_none():
+    """A callable that returns None when no candidate is free signals a spill,
+    running the allocator's native spill path; when a candidate is free it
+    returns the first, mimicking the native first-free policy. Under high
+    register pressure this drives both the assign and the spill branch, and the
+    object is a well-formed ELF."""
+    selects = []
+
+    def cb(candidates):
+        selects.append(len(candidates))
+        return candidates[0] if candidates else None
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)  # cross: ELF, any host
+        mmi = mir.create_machine_function(mod, tm, "hot")
+        _build_high_pressure(mmi)
+        _mir_ext._reset_regalloc_spill_count()
+        obj = mmi.emit_object(select=cb)
+        assert selects  # the callable ran
+        assert 0 in selects  # at least once no candidate was free
+        assert _mir_ext._regalloc_spill_count() > 0  # the None spill path ran
+        assert obj[:4] == b"\x7fELF"
+        assert b"hot\x00" in obj
+    assert_no_leaks()
+
+
+def test_python_select_callback_bad_return_falls_back():
+    """A well-behaved-only contract for this step: a callable that returns
+    something uninterpretable (an id not among the presented candidates) does not
+    raise -- selectOrSplit falls back to the native first-free policy so the run
+    still produces a legal, well-formed object."""
+    picks = []
+
+    def cb(candidates):
+        picks.append(list(candidates))
+        return 999999  # not one of the presented candidate physreg ids
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the callable ran, its return was rejected
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+def test_select_and_pick_drive_one_emit():
+    """select (Python allocator) is independent of pick (Python scheduler): a
+    caller may drive both in one emission. Both callables run (each records into
+    its own list) and the allocator counter fires; the object is a well-formed
+    ELF."""
+    picks = []
+    selects = []
+
+    def pick_cb(ready):
+        picks.append(len(ready))
+        return ready[0]
+
+    def select_cb(candidates):
+        selects.append(list(candidates))
+        return candidates[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(pick=pick_cb, select=select_cb)
+        assert picks and selects  # both Python callbacks ran
+        assert _mir_ext._regalloc_select_count() > 0
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_regalloc_and_select_are_mutually_exclusive():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="regalloc"):
+            mmi.emit_object(regalloc="eudsl-python", select=lambda c: c[0])
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_python_selected_add():
+    picks = []
+
+    def cb(candidates):
+        picks.append(len(candidates))
+        return candidates[0]
+
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(select=cb)
+        assert picks  # the python callback drove selectOrSplit
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_eudsl_regalloc_add():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> object loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        _mir_ext._reset_regalloc_select_count()
+        obj = mmi.emit_object(regalloc="eudsl-python")
+        assert _mir_ext._regalloc_select_count() > 0  # our allocator drove RA
+
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()


### PR DESCRIPTION
Adds a Python-driven register allocator (native allocator + callback folded into one commit; lives in `src/MIR/PythonCodegen.cpp` alongside the scheduler). `class PyRegAlloc : MachineFunctionPass, RegAllocBase` (modeled on LLVM's `RABasic`, registered `regalloc="eudsl-python"`) makes its `selectOrSplit` decision either natively or via a user Python callable selected with `emit_object(select=<callable>)`.

- Native `selectOrSplit`: first `AllocationOrder` register with `Matrix->checkInterference == IK_Free`, else spill `VirtReg`; full `getAnalysisUsage`/`INITIALIZE_PASS` wiring copied from `RABasic`. The `select` callable receives the legal candidate physreg ids as a `list[int]` and returns an id to assign or `None` to spill (an out-of-set/wrong-type return falls back to the native policy here; raising is item 6, #634).
- Selection installs the allocator via `RegisterRegAlloc::setDefault` under a save/restore RAII. **Latent crash fixed:** naively restoring `getDefault()` SIGSEGVs on a fresh process — the process-global default is lazily set once via a `once_flag`, so installing our override first makes that init a no-op and a plain restore puts back `null`; we restore the `"default"` ctor when the saved value was null.
- `regalloc` (name) and `select` (callable) are mutually exclusive; a scheduler-side option (`scheduler`/`pick`) may be combined with an allocator-side one (`regalloc`/`select`) in a single `emit_object`.

Tests: a valid object is emitted and JIT-executes correctly; fail-if-no-op counters prove the allocator actually runs when selected (`select` count > 0) and its spill path runs under a high-register-pressure function (spill count > 0). 100% line+function C++ coverage.

`#600` items 4-5. Stacked on #629.