### PR TITLE
[eudsl-llvmpy] MIR: Python-subclassable MachineSchedStrategy driving the pre-RA MachineScheduler (#600)

### DIFF
--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -113,3 +113,27 @@ LLVM_PROFDATA="$(command -v llvm-profdata-18)" LLVM_COV="$(command -v llvm-cov-1
   COVERAGE_THRESHOLD=100 bash scripts/cpp_coverage.sh
 ```
 
+## Local incremental rebuilds: `cmake --build` does not update the imported module
+
+The editable install is configured with `editable.rebuild = false`, and the
+build writes the extension to its `LIBRARY_OUTPUT_DIRECTORY` (`src/llvm/`), while
+the editable finder imports `llvm` from the *installed* copy under
+`site-packages/llvm/` (`spec_from_file_location` resolves module paths against
+the finder's own dir, i.e. site-packages). So a bare
+`cmake --build build/<wheel-tag>` recompiles the `.so` into `src/llvm/` but
+`import llvm` keeps loading the stale site-packages copy — new bindings appear
+missing even though the build succeeded, and old ones linger.
+
+Two ways to pick up C++ changes:
+
+- Full reinstall (canonical): `LLVM_DIR=<distro>/lib/cmake/llvm python -m pip
+  install -e . --no-build-isolation` — reconfigures, rebuilds, and re-stages.
+- Fast loop: `cmake --build build/<wheel-tag>` then copy the rebuilt artifacts
+  into the import location, e.g.
+  `cp -R src/llvm/. "$(python -c 'import site;print(site.getsitepackages()[0])')/llvm/"`.
+
+Do not `rm` the site-packages `llvm/` directory to "clear the shadow": the finder
+serves the package from there, so removing it breaks `import llvm` until a
+reinstall or re-copy restores it.
+
+

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -125,6 +125,7 @@ nanobind_add_module(eudslllvm_ext
   src/IR/JIT.cpp
   src/IR/Intrinsics.cpp
   src/MIR/Machine.cpp
+  src/MIR/PythonCodegen.cpp
 )
 
 set(eudslllvm_ext_libs

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -30,8 +30,6 @@ if(EUDSLLLVM_STANDALONE_BUILD)
 
   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-  # Match the distro's ABI-affecting flags (NDEBUG/assertions, ...); nanobind's
-  # per-target -fexceptions/-frtti below re-enable what the bindings need.
   include(HandleLLVMOptions)
   include(AddLLVM)
 endif()

--- a/projects/eudsl-llvmpy/CMakeLists.txt
+++ b/projects/eudsl-llvmpy/CMakeLists.txt
@@ -30,6 +30,9 @@ if(EUDSLLLVM_STANDALONE_BUILD)
 
   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  # Match the distro's ABI-affecting flags (NDEBUG/assertions, ...); nanobind's
+  # per-target -fexceptions/-frtti below re-enable what the bindings need.
+  include(HandleLLVMOptions)
   include(AddLLVM)
 endif()
 

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -380,6 +380,35 @@ with ir.Context() as ctx:
     assert add(2, 3) == 5
 ```
 
+### Python-driven instruction scheduling
+
+`mir.MachineSchedStrategy` is the pre-RA MachineScheduler strategy interface,
+subclassable from Python. Override `initialize(dag)`, `get_policy()`,
+`release_top_node(su)` / `release_bottom_node(su)` (LLVM hands you ready
+`SUnit`s; you maintain your own ready set), `pick_node()` → `(SUnit,
+is_top_node)` or `None` when nothing is ready, and `sched_node(su, is_top)`.
+Register a subclass under a name and select it per emission:
+
+```python
+class MySched(mir.MachineSchedStrategy):
+    def initialize(self, dag): self.q = []
+    def get_policy(self):
+        p = mir.MachineSchedPolicy(); p.only_top_down = True
+        p.should_track_pressure = False; return p
+    def release_top_node(self, su): self.q.append(su)
+    def release_bottom_node(self, su): pass
+    def pick_node(self): return (self.q.pop(0), True) if self.q else None
+    def sched_node(self, su, is_top): pass
+
+mir.register_scheduler("mysched", MySched)
+obj = mmi.emit_object(scheduler="mysched")   # runs MySched as the pre-RA scheduler
+```
+
+For the common case, subclass `mir.ReadyQueueStrategy` and override only
+`pick(ready)`. A strategy that raises has its exception re-raised out of
+`emit_object` — stashed and re-raised after codegen winds down, never thrown
+across LLVM's `-fno-exceptions` frames.
+
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -405,14 +405,7 @@ obj = mmi.emit_object(scheduler="mysched")   # runs MySched as the pre-RA schedu
 ```
 
 For the common case, subclass `mir.ReadyQueueStrategy` and override only
-`pick(ready)`. A strategy that raises has its exception re-raised out of
-`emit_object` — stashed and re-raised after codegen winds down, never thrown
-across LLVM's `-fno-exceptions` frames.
-
-A subclass may also override the optional lifecycle hooks `register_roots(self)`
-(the initial ready set is complete), `enter_mbb(self, mbb)` / `leave_mbb(self)`
-(a block, possibly several scheduling regions, is starting/ending); omitting them
-keeps LLVM's defaults.
+`pick(ready)`.
 
 ## Limitations
 

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -409,6 +409,11 @@ For the common case, subclass `mir.ReadyQueueStrategy` and override only
 `emit_object` — stashed and re-raised after codegen winds down, never thrown
 across LLVM's `-fno-exceptions` frames.
 
+A subclass may also override the optional lifecycle hooks `register_roots(self)`
+(the initial ready set is complete), `enter_mbb(self, mbb)` / `leave_mbb(self)`
+(a block, possibly several scheduling regions, is starting/ending); omitting them
+keeps LLVM's defaults.
+
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not

--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -19,11 +19,6 @@
 
 namespace eudsl {
 
-// A Python exception raised in a scheduler override is stashed here rather than
-// thrown across llvm::legacy::PassManager::run: libLLVMCodeGen is
-// -fno-exceptions, so unwinding those frames std::terminates. Thread-local;
-// declared extern with a single definition in PythonCodegen.cpp so there is one
-// TLS object and no per-TU TLS-init wrapper.
 extern thread_local std::exception_ptr pendingCodegenError;
 
 // Run a codegen pass manager, then re-raise any exception a scheduler override

--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -22,8 +22,8 @@ namespace eudsl {
 // A Python exception raised in a scheduler override is stashed here rather than
 // thrown across llvm::legacy::PassManager::run: libLLVMCodeGen is
 // -fno-exceptions, so unwinding those frames std::terminates. Thread-local;
-// defined once in PythonCodegen.cpp (an inline thread_local would duplicate its
-// TLS init in every including TU).
+// declared extern with a single definition in PythonCodegen.cpp so there is one
+// TLS object and no per-TU TLS-init wrapper.
 extern thread_local std::exception_ptr pendingCodegenError;
 
 // Run a codegen pass manager, then re-raise any exception a scheduler override

--- a/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
+++ b/projects/eudsl-llvmpy/src/MIR/Diagnostics.h
@@ -10,11 +10,33 @@
 #include <llvm/IR/DiagnosticInfo.h>
 #include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 
+#include <exception>
 #include <string>
 
 namespace eudsl {
+
+// A Python exception raised in a scheduler override is stashed here rather than
+// thrown across llvm::legacy::PassManager::run: libLLVMCodeGen is
+// -fno-exceptions, so unwinding those frames std::terminates. Thread-local;
+// defined once in PythonCodegen.cpp (an inline thread_local would duplicate its
+// TLS init in every including TU).
+extern thread_local std::exception_ptr pendingCodegenError;
+
+// Run a codegen pass manager, then re-raise any exception a scheduler override
+// stashed during the run (before the caller inspects captured diagnostics).
+inline void runCodegenPipeline(llvm::legacy::PassManager &pm, llvm::Module &m) {
+  pendingCodegenError = nullptr;
+  pm.run(m);
+  if (pendingCodegenError) {
+    std::exception_ptr e = pendingCodegenError;
+    pendingCodegenError = nullptr;
+    std::rethrow_exception(e);
+  }
+}
 
 // MIR parsing and codegen report failures through LLVMContext::diagnose --
 // their return values are only a bare success/failure bit, so the rich reason

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -53,11 +53,13 @@
 #include <vector>
 
 namespace eudsl {
-// Defined in PythonCodegen.cpp: the Python class registered under a scheduler
-// name (empty object if none), and install/clear the per-thread active class
-// the shared registry ctor reads while the pipeline runs.
-nb::object schedulerClass(const std::string &name);
-void setActiveSchedClass(nb::object cls);
+// Defined in PythonCodegen.cpp: the class registered under a scheduler name (an
+// invalid object if the name was not registered via register_scheduler), the
+// shared MachineSchedRegistry ctor those names share, and install/clear the
+// per-thread active class the ctor reads while the pipeline runs.
+nb::type_object schedulerClass(const std::string &name);
+llvm::MachineSchedRegistry::ScheduleDAGCtor registeredSchedCtor();
+void setActiveSchedClass(nb::type_object cls);
 void clearActiveSchedClass();
 } // namespace eudsl
 
@@ -374,25 +376,18 @@ public:
     llvm::TargetMachine *tm = build->tm;
     llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
 
-    // Resolve the requested scheduler against the MachineSchedRegistry before
-    // touching codegen state so an unknown name fails cleanly.
-    // register_scheduler added a node per name sharing the
-    // createRegisteredPyStrategy ctor; below we point -misched at that ctor and
-    // install the run's active class.
+    // Resolve the requested scheduler against the strategies registered via
+    // register_scheduler (not the whole MachineSchedRegistry, which also holds
+    // LLVM's built-ins) so an unknown -- or built-in -- name fails cleanly
+    // before any codegen state is touched. All registered names share the
+    // createRegisteredPyStrategy ctor, which -misched is pointed at below.
     llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
-    nb::object schedClass;
+    nb::type_object schedClass;
     if (scheduler) {
-      for (llvm::MachineSchedRegistry *node =
-               llvm::MachineSchedRegistry::getList();
-           node; node = node->getNext()) {
-        if (node->getName() == *scheduler) {
-          schedCtor = node->getCtor();
-          break;
-        }
-      }
-      if (!schedCtor)
-        throw std::runtime_error("unknown scheduler: " + *scheduler);
       schedClass = eudsl::schedulerClass(*scheduler);
+      if (!schedClass.is_valid())
+        throw std::runtime_error("unknown scheduler: " + *scheduler);
+      schedCtor = eudsl::registeredSchedCtor();
     }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -63,6 +63,9 @@ void setActiveSchedClass(nb::type_object cls);
 void clearActiveSchedClass();
 } // namespace eudsl
 
+// Defined in PythonCodegen.cpp.
+void populate_python_codegen(nb::module_ &m);
+
 namespace {
 
 // A machine register paired with the MachineFunction that owns it. A virtual
@@ -376,11 +379,6 @@ public:
     llvm::TargetMachine *tm = build->tm;
     llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
 
-    // Resolve the requested scheduler against the strategies registered via
-    // register_scheduler (not the whole MachineSchedRegistry, which also holds
-    // LLVM's built-ins) so an unknown -- or built-in -- name fails cleanly
-    // before any codegen state is touched. All registered names share the
-    // createRegisteredPyStrategy ctor, which -misched is pointed at below.
     llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
     nb::type_object schedClass;
     if (scheduler) {
@@ -432,10 +430,6 @@ public:
     } restore{startAfter, saved};
     startAfter = "finalize-isel";
 
-    // Select the pre-RA MachineScheduler strategy, when one was requested:
-    // -misched is a process-global option whose value is the ScheduleDAGCtor
-    // the scheduler pass reads. Set+restore it under the same GIL-serialized
-    // assumption as -start-after; its value type is a constructor pointer.
     using SchedCtor = llvm::MachineSchedRegistry::ScheduleDAGCtor;
     using SchedOpt =
         llvm::cl::opt<SchedCtor, false,
@@ -542,9 +536,6 @@ private:
 };
 
 } // namespace
-
-// Defined in PythonCodegen.cpp.
-void populate_python_codegen(nb::module_ &m);
 
 // LowLevelType (LLT) is the generic-MIR type: a target-independent "bag of
 // bits" describing a scalar/pointer/vector operand, distinct from the uniqued

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -17,6 +17,7 @@
 #include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/CodeGen/MachineOperand.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
+#include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
@@ -40,7 +41,9 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
 #include <nanobind/stl/variant.h>
 
 #include <memory>
@@ -48,6 +51,15 @@
 #include <utility>
 #include <variant>
 #include <vector>
+
+namespace eudsl {
+// Defined in PythonCodegen.cpp: the Python class registered under a scheduler
+// name (empty object if none), and install/clear the per-thread active class
+// the shared registry ctor reads while the pipeline runs.
+nb::object schedulerClass(const std::string &name);
+void setActiveSchedClass(nb::object cls);
+void clearActiveSchedClass();
+} // namespace eudsl
 
 namespace {
 
@@ -351,7 +363,7 @@ public:
   // BuildOwned is consumed into an EmittedOwned, so "build-path only" and the
   // one-shot are enforced by the variant's active alternative rather than a
   // pair of runtime flags.
-  nb::bytes emitObject() {
+  nb::bytes emitObject(std::optional<std::string> scheduler) {
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
     BuildOwned *build = std::get_if<BuildOwned>(&state_);
@@ -361,6 +373,27 @@ public:
     }
     llvm::TargetMachine *tm = build->tm;
     llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
+
+    // Resolve the requested scheduler against the MachineSchedRegistry before
+    // touching codegen state so an unknown name fails cleanly.
+    // register_scheduler added a node per name sharing the
+    // createRegisteredPyStrategy ctor; below we point -misched at that ctor and
+    // install the run's active class.
+    llvm::MachineSchedRegistry::ScheduleDAGCtor schedCtor = nullptr;
+    nb::object schedClass;
+    if (scheduler) {
+      for (llvm::MachineSchedRegistry *node =
+               llvm::MachineSchedRegistry::getList();
+           node; node = node->getNext()) {
+        if (node->getName() == *scheduler) {
+          schedCtor = node->getCtor();
+          break;
+        }
+      }
+      if (!schedCtor)
+        throw std::runtime_error("unknown scheduler: " + *scheduler);
+      schedClass = eudsl::schedulerClass(*scheduler);
+    }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
     // unchecked primitives can produce it: bogus properties, undefined vregs,
@@ -404,6 +437,43 @@ public:
     } restore{startAfter, saved};
     startAfter = "finalize-isel";
 
+    // Select the pre-RA MachineScheduler strategy, when one was requested:
+    // -misched is a process-global option whose value is the ScheduleDAGCtor
+    // the scheduler pass reads. Set+restore it under the same GIL-serialized
+    // assumption as -start-after; its value type is a constructor pointer.
+    using SchedCtor = llvm::MachineSchedRegistry::ScheduleDAGCtor;
+    using SchedOpt =
+        llvm::cl::opt<SchedCtor, false,
+                      llvm::RegisterPassParser<llvm::MachineSchedRegistry>>;
+    struct RestoreSched {
+      SchedOpt *opt = nullptr;
+      SchedCtor value = nullptr;
+      ~RestoreSched() {
+        if (opt)
+          *opt = value;
+      }
+    } restoreSched;
+    struct RestoreActiveClass {
+      bool active = false;
+      ~RestoreActiveClass() {
+        if (active)
+          eudsl::clearActiveSchedClass();
+      }
+    } restoreActiveClass;
+    if (schedCtor) {
+      auto mischedIt = opts.find("misched");
+      // LCOV_EXCL_START -- misched is always registered by codegen
+      if (mischedIt == opts.end())
+        throw std::runtime_error("the -misched option is not registered");
+      // LCOV_EXCL_STOP
+      auto &misched = *static_cast<SchedOpt *>(mischedIt->second);
+      restoreSched.opt = &misched;
+      restoreSched.value = misched;
+      misched = schedCtor;
+      eudsl::setActiveSchedClass(schedClass);
+      restoreActiveClass.active = true;
+    }
+
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
     // no deferred flush surprises when `pm` outlives here).
     llvm::SmallVector<char, 0> buf;
@@ -432,11 +502,13 @@ public:
     }
     // A codegen pass reports failure through the context diagnostic handler
     // (DS_Error -> stderr + exit under the default handler), not pm->run()'s
-    // value; capture it so it surfaces as an exception.
+    // value; capture it so it surfaces as an exception. runCodegenPipeline
+    // re-raises any Python exception a scheduler override stashed during the
+    // run.
     std::string diag;
     {
       eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
-      pm->run(*module_);
+      eudsl::runCodegenPipeline(*pm, *module_);
     }
     // Consume the BuildOwned into an EmittedOwned: the released wrapper now
     // lives in `pm`, and a second emit_object sees EmittedOwned and refuses.
@@ -1206,10 +1278,14 @@ void populate_mir(nb::module_ &m) {
       .def("to_mir", &MirModule::toMIR,
            "Serialize the whole module (IR block + machine functions) as .mir "
            "text.")
-      .def("emit_object", &MirModule::emitObject,
-           "Emit a relocatable object file for the built (already-selected) "
-           "MIR by running the back half of codegen (regalloc, emission). "
-           "Verifies the MIR first, raising if it is malformed.");
+      .def(
+          "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
+          "Emit a relocatable object file for the built (already-selected) "
+          "MIR by running the back half of codegen (regalloc, emission). "
+          "Verifies the MIR first, raising if it is malformed. When "
+          "`scheduler` names a registered MachineSchedStrategy (see "
+          "register_scheduler), the pre-RA MachineScheduler runs it instead of "
+          "the target default; an unregistered name raises.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -467,6 +467,9 @@ private:
 
 } // namespace
 
+// Defined in PythonCodegen.cpp.
+void populate_python_codegen(nb::module_ &m);
+
 // LowLevelType (LLT) is the generic-MIR type: a target-independent "bag of
 // bits" describing a scalar/pointer/vector operand, distinct from the uniqued
 // llvm::Type hierarchy. It is a small value type (not context-owned and not
@@ -1712,4 +1715,6 @@ void populate_mir(nb::module_ &m) {
       },
       nb::rv_policy::reference,
       "The innermost MachineIRBuilder on the thread-local stack.");
+
+  populate_python_codegen(m);
 }

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -508,7 +508,16 @@ public:
     std::string diag;
     {
       eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
-      eudsl::runCodegenPipeline(*pm, *module_);
+      try {
+        eudsl::runCodegenPipeline(*pm, *module_);
+      } catch (...) {
+        // A scheduler override stashed a Python exception, now re-raised. The
+        // MMI wrapper already lives in `pm`, so consume into EmittedOwned (as
+        // the success path does) before propagating -- otherwise `state_` keeps
+        // a released (null) wrapper and `pm`/`info` would dangle.
+        state_ = EmittedOwned{std::move(pm), info};
+        throw;
+      }
     }
     // Consume the BuildOwned into an EmittedOwned: the released wrapper now
     // lives in `pm`, and a second emit_object sees EmittedOwned and refuses.

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -291,15 +291,12 @@ createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
 
 namespace eudsl {
 
-// Validate that cls subclasses MachineSchedStrategy and defines the required
-// methods, record it, and (if new) add a MachineSchedRegistry node so the
-// pipeline can select it by name. Re-registering a name swaps the class.
-void registerScheduler(const std::string &name, nb::type_object cls) {
-  if (PyObject_IsSubclass(cls.ptr(),
-                          nb::type<llvm::MachineSchedStrategy>().ptr()) != 1) {
-    throw nb::type_error(
-        "scheduler class must subclass mir.MachineSchedStrategy");
-  }
+// Validate that cls defines the required methods, record it, and (if new) add a
+// MachineSchedRegistry node so the pipeline can select it by name. The
+// type_object_t parameter makes nanobind reject a non-MachineSchedStrategy
+// class at the call boundary. Re-registering a name swaps the class.
+void registerScheduler(const std::string &name,
+                       nb::type_object_t<llvm::MachineSchedStrategy> cls) {
   static const char *required[] = {"initialize",       "get_policy",
                                    "pick_node",        "sched_node",
                                    "release_top_node", "release_bottom_node"};

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -2,13 +2,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Python-subclassable pre-RA MachineScheduler strategy.
-// mir.MachineSchedStrategy binds llvm::MachineSchedStrategy via a trampoline;
-// register_scheduler adds a MachineSchedRegistry node so
-// emit_object(scheduler="name") can select it. LLVM owns an OwningPyStrategy
-// adaptor that forwards into the Python instance, since nanobind won't move a
-// Python-created instance into a default-deleter unique_ptr.
-
 #include "IR/Common.h"
 #include "MIR/Diagnostics.h"
 
@@ -48,17 +41,6 @@ namespace {
 // GIL-serialized, matching the process-global -misched handling in Machine.cpp.
 thread_local nb::type_object activeSchedClass;
 
-// C++ side of mir.MachineSchedStrategy. Each override forwards into the Python
-// object (nb_trampoline.base()) by name with the GIL held outside the try; a
-// Python exception is stashed in pendingCodegenError and a legal value
-// returned, since LLVM's scheduler frames are -fno-exceptions.
-// runCodegenPipeline re-raises after the run.
-//
-// shadow mirrors the ready nodes LLVM releases, recorded before the fallible
-// Python call. It is the pick_node fallback after a stash: LLVM only releases
-// ready nodes, so a still-unscheduled one is always a legal choice. The raw
-// contract puts the real ready set in Python, out of reach once it has failed
-// -- this is the safety net.
 class PySchedStrategy : public llvm::MachineSchedStrategy {
 public:
   NB_TRAMPOLINE(llvm::MachineSchedStrategy, 9);
@@ -202,9 +184,11 @@ public:
   }
 
 private:
-  // Every ready node LLVM releases (top or bottom), recorded before the
-  // fallible Python call so the pick_node fallback above always has a legal
-  // choice.
+  // Mirrors the ready nodes LLVM releases, recorded before the fallible Python
+  // call. It is the pick_node fallback after a stash: LLVM only releases ready
+  // nodes, so a still-unscheduled one is always a legal choice. The raw
+  // contract puts the real ready set in Python, out of reach once it has failed
+  // -- this is the safety net.
   std::vector<llvm::SUnit *> shadow;
 };
 
@@ -391,12 +375,6 @@ void populate_python_codegen(nb::module_ &m) {
   // receives its nodes via release_top_node/release_bottom_node.
   nb::class_<llvm::ScheduleDAGMI>(m, "ScheduleDAGMI");
 
-  // The pre-RA MachineScheduler strategy interface, subclassable from Python.
-  // Override initialize(dag), get_policy() -> MachineSchedPolicy,
-  // release_top_node(su) / release_bottom_node(su) (maintain your own ready
-  // set), pick_node() -> (SUnit, is_top_node), and sched_node(su, is_top).
-  // Register with register_scheduler and select via
-  // emit_object(scheduler=name).
   nb::class_<llvm::MachineSchedStrategy, PySchedStrategy>(
       m, "MachineSchedStrategy")
       .def(nb::init<>());

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -1,0 +1,27 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Python-subclassable pre-RA MachineScheduler strategy.
+// mir.MachineSchedStrategy binds llvm::MachineSchedStrategy via a trampoline;
+// register_scheduler adds a MachineSchedRegistry node so
+// emit_object(scheduler="name") can select it. LLVM owns an OwningPyStrategy
+// adaptor that forwards into the Python instance, since nanobind won't move a
+// Python-created instance into a default-deleter unique_ptr.
+
+#include "IR/Common.h"
+#include "MIR/Diagnostics.h"
+
+#include <nanobind/nanobind.h>
+
+#include <exception>
+
+namespace nb = nanobind;
+
+namespace eudsl {
+// The single definition of the codegen-error stash declared extern in
+// Diagnostics.h; scheduler overrides in this TU stash into it.
+thread_local std::exception_ptr pendingCodegenError;
+} // namespace eudsl
+
+void populate_python_codegen(nb::module_ &m) { (void)m; }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -15,17 +15,297 @@
 #include <llvm/CodeGen/MachineInstr.h>
 #include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
+#include <llvm/CodeGen/ScheduleDAGMutation.h>
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/trampoline.h>
 
+#include <algorithm>
+#include <atomic>
+#include <deque>
 #include <exception>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace nb = nanobind;
+using namespace nb::literals;
 
 namespace eudsl {
 // The single definition of the codegen-error stash declared extern in
 // Diagnostics.h; scheduler overrides in this TU stash into it.
 thread_local std::exception_ptr pendingCodegenError;
+} // namespace eudsl
+
+namespace {
+
+// The Python strategy class emit_object selected for the current run. Set
+// (under the GIL) before the pipeline runs and cleared after, so the shared
+// registry ctor knows which class to instantiate per MachineFunction.
+// GIL-serialized, matching the process-global -misched handling in Machine.cpp.
+thread_local nb::object activeSchedClass;
+
+// Strategy instances constructed across all runs, so a test can assert one is
+// built per MachineFunction (scheduling is semantics-preserving, so the emitted
+// code alone cannot prove Python drove it).
+std::atomic<unsigned> schedInstanceCount{0};
+
+// C++ side of mir.MachineSchedStrategy. Each override forwards into the Python
+// object (nb_trampoline.base()) by name with the GIL held outside the try; a
+// Python exception is stashed in pendingCodegenError and a legal value
+// returned, since LLVM's scheduler frames are -fno-exceptions.
+// runCodegenPipeline re-raises after the run.
+//
+// shadowTop/shadowBottom mirror the ready nodes LLVM releases, recorded before
+// the fallible Python call. They are the pick_node fallback after a stash: LLVM
+// only releases ready nodes and we drop the picked one, so the shadow front is
+// always a legal choice. The raw contract puts the real ready set in Python,
+// out of reach once it has failed -- this is the safety net.
+class PySchedStrategy : public llvm::MachineSchedStrategy {
+public:
+  NB_TRAMPOLINE(llvm::MachineSchedStrategy, 6);
+
+  llvm::MachineSchedPolicy getPolicy() const override {
+    nb::gil_scoped_acquire gil;
+    if (eudsl::pendingCodegenError)
+      return {};
+    try {
+      return nb::cast<llvm::MachineSchedPolicy>(
+          nb_trampoline.base().attr("get_policy")());
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+      return {};
+    }
+  }
+
+  bool shouldTrackPressure() const override {
+    return getPolicy().ShouldTrackPressure;
+  }
+
+  void initialize(llvm::ScheduleDAGMI *dag) override {
+    shadowTop.clear();
+    shadowBottom.clear();
+    nb::gil_scoped_acquire gil;
+    if (eudsl::pendingCodegenError)
+      return;
+    try {
+      nb_trampoline.base().attr("initialize")(
+          nb::cast(dag, nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  void releaseTopNode(llvm::SUnit *su) override {
+    shadowTop.push_back(su);
+    nb::gil_scoped_acquire gil;
+    if (eudsl::pendingCodegenError)
+      return;
+    try {
+      nb_trampoline.base().attr("release_top_node")(
+          nb::cast(su, nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  void releaseBottomNode(llvm::SUnit *su) override {
+    shadowBottom.push_back(su);
+    nb::gil_scoped_acquire gil;
+    if (eudsl::pendingCodegenError)
+      return;
+    try {
+      nb_trampoline.base().attr("release_bottom_node")(
+          nb::cast(su, nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  llvm::SUnit *pickNode(bool &isTopNode) override {
+    nb::gil_scoped_acquire gil;
+    if (!eudsl::pendingCodegenError) {
+      try {
+        auto [su, isTop] = nb::cast<std::pair<llvm::SUnit *, bool>>(
+            nb_trampoline.base().attr("pick_node")());
+        isTopNode = isTop;
+        dropFromShadow(su);
+        return su;
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    // Stash path (or draining after a prior stash): return a still-ready node
+    // so the unskippable pipeline winds down to runCodegenPipeline's re-raise.
+    if (!shadowTop.empty()) {
+      isTopNode = true;
+      llvm::SUnit *su = shadowTop.front();
+      shadowTop.erase(shadowTop.begin());
+      return su;
+    }
+    if (!shadowBottom.empty()) {
+      isTopNode = false;
+      llvm::SUnit *su = shadowBottom.front();
+      shadowBottom.erase(shadowBottom.begin());
+      return su;
+    }
+    return nullptr;
+  }
+
+  void schedNode(llvm::SUnit *su, bool isTopNode) override {
+    nb::gil_scoped_acquire gil;
+    if (eudsl::pendingCodegenError)
+      return;
+    try {
+      nb_trampoline.base().attr("sched_node")(
+          nb::cast(su, nb::rv_policy::reference), isTopNode);
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+private:
+  void dropFromShadow(llvm::SUnit *su) {
+    auto t = std::find(shadowTop.begin(), shadowTop.end(), su);
+    if (t != shadowTop.end()) {
+      shadowTop.erase(t);
+      return;
+    }
+    auto b = std::find(shadowBottom.begin(), shadowBottom.end(), su);
+    if (b != shadowBottom.end())
+      shadowBottom.erase(b);
+  }
+
+  std::vector<llvm::SUnit *> shadowTop;
+  std::vector<llvm::SUnit *> shadowBottom;
+};
+
+// The strategy LLVM owns. nanobind refuses to move a Python-created instance
+// into a default-deleter unique_ptr<MachineSchedStrategy> (its C++ subobject is
+// inline in the PyObject, so a raw delete is UB) -- which is
+// ScheduleDAGMILive's sink. So LLVM owns this plain heap object, which keeps
+// the Python instance alive and forwards each virtual into its inline
+// PySchedStrategy (which does the work and never throws). The dtor drops the
+// Python reference under the GIL.
+class OwningPyStrategy : public llvm::MachineSchedStrategy {
+public:
+  explicit OwningPyStrategy(nb::object pyStrategy)
+      : pyStrategy(std::move(pyStrategy)),
+        inner(nb::inst_ptr<llvm::MachineSchedStrategy>(this->pyStrategy)) {}
+
+  ~OwningPyStrategy() override {
+    nb::gil_scoped_acquire gil;
+    pyStrategy.reset();
+  }
+
+  llvm::MachineSchedPolicy getPolicy() const override {
+    return inner->getPolicy();
+  }
+  bool shouldTrackPressure() const override {
+    return inner->shouldTrackPressure();
+  }
+  void initialize(llvm::ScheduleDAGMI *dag) override { inner->initialize(dag); }
+  void releaseTopNode(llvm::SUnit *su) override { inner->releaseTopNode(su); }
+  void releaseBottomNode(llvm::SUnit *su) override {
+    inner->releaseBottomNode(su);
+  }
+  llvm::SUnit *pickNode(bool &isTopNode) override {
+    return inner->pickNode(isTopNode);
+  }
+  void schedNode(llvm::SUnit *su, bool isTopNode) override {
+    inner->schedNode(su, isTopNode);
+  }
+
+private:
+  nb::object pyStrategy;
+  llvm::MachineSchedStrategy *inner;
+};
+
+// Registered name -> Python class. A leaked deque: deque never reallocates, so
+// the name c_str() handed to MachineSchedRegistry stays valid, and leaking
+// avoids dropping Python refs at interpreter shutdown.
+std::deque<std::pair<std::string, nb::object>> &schedClasses() {
+  static auto *classes = new std::deque<std::pair<std::string, nb::object>>();
+  return *classes;
+}
+
+// The live MachineSchedRegistry nodes, kept (leaked) so they stay registered
+// for process lifetime.
+std::vector<std::unique_ptr<llvm::MachineSchedRegistry>> &schedRegistryNodes() {
+  static auto *nodes =
+      new std::vector<std::unique_ptr<llvm::MachineSchedRegistry>>();
+  return *nodes;
+}
+
+// Shared registry ctor for every registered name (the ctor is a non-capturing
+// function pointer, so it cannot carry the class). emit_object set
+// activeSchedClass; construct a fresh instance per MachineFunction and hand
+// LLVM an OwningPyStrategy around it.
+llvm::ScheduleDAGInstrs *
+createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
+  nb::gil_scoped_acquire gil;
+  // LCOV_EXCL_START -- emit_object always sets the active class before running
+  if (!activeSchedClass.is_valid())
+    return llvm::createSchedLive(c);
+  // LCOV_EXCL_STOP
+  schedInstanceCount.fetch_add(1, std::memory_order_relaxed);
+  auto strategy = std::make_unique<OwningPyStrategy>(activeSchedClass());
+  auto *dag = new llvm::ScheduleDAGMILive(c, std::move(strategy));
+  dag->addMutation(llvm::createCopyConstrainDAGMutation(dag->TII, dag->TRI));
+  return dag;
+}
+
+} // namespace
+
+namespace eudsl {
+
+// Validate that cls defines the required methods, record it, and (if new) add a
+// MachineSchedRegistry node so -misched / the pipeline can select it by name.
+// Re-registering a name swaps the class.
+void registerScheduler(const std::string &name, nb::object cls) {
+  static const char *required[] = {"initialize",       "get_policy",
+                                   "pick_node",        "sched_node",
+                                   "release_top_node", "release_bottom_node"};
+  for (const char *method : required) {
+    if (!nb::hasattr(cls, method))
+      throw nb::type_error(
+          (std::string("scheduler class must define ") + method).c_str());
+  }
+  for (auto &entry : schedClasses()) {
+    if (entry.first == name) {
+      entry.second = std::move(cls);
+      return;
+    }
+  }
+  schedClasses().emplace_back(name, std::move(cls));
+  const char *cname = schedClasses().back().first.c_str();
+  schedRegistryNodes().push_back(std::make_unique<llvm::MachineSchedRegistry>(
+      cname, cname, createRegisteredPyStrategy));
+}
+
+// The class registered under `name`, or an empty object.
+nb::object schedulerClass(const std::string &name) {
+  for (auto &entry : schedClasses()) {
+    if (entry.first == name)
+      return entry.second;
+  }
+  return nb::object();
+}
+
+void setActiveSchedClass(nb::object cls) { activeSchedClass = std::move(cls); }
+void clearActiveSchedClass() { activeSchedClass = nb::object(); }
+
+unsigned schedInstanceCountValue() {
+  return schedInstanceCount.load(std::memory_order_relaxed);
+}
+void resetSchedInstanceCount() {
+  schedInstanceCount.store(0, std::memory_order_relaxed);
+}
+
 } // namespace eudsl
 
 void populate_python_codegen(nb::module_ &m) {
@@ -57,4 +337,40 @@ void populate_python_codegen(nb::module_ &m) {
           "instr", [](llvm::SUnit &su) { return su.getInstr(); },
           nb::rv_policy::reference_internal,
           "The representative MachineInstr this unit wraps.");
+
+  // The pre-RA MachineScheduler strategy interface, subclassable from Python.
+  // Override initialize(dag), get_policy() -> MachineSchedPolicy,
+  // release_top_node(su) / release_bottom_node(su) (maintain your own ready
+  // set), pick_node() -> (SUnit, is_top_node), and sched_node(su, is_top).
+  // Register with register_scheduler and select via
+  // emit_object(scheduler=name).
+  nb::class_<llvm::MachineSchedStrategy, PySchedStrategy>(
+      m, "MachineSchedStrategy")
+      .def(nb::init<>());
+
+  m.def("register_scheduler", &eudsl::registerScheduler, "name"_a, "cls"_a,
+        "Register a MachineSchedStrategy subclass under `name` so "
+        "emit_object(scheduler=name) can select it. The class must define "
+        "initialize, get_policy, pick_node, sched_node, release_top_node, and "
+        "release_bottom_node; re-registering a name replaces it.");
+
+  m.def(
+      "registered_schedulers",
+      []() {
+        std::vector<std::string> names;
+        for (llvm::MachineSchedRegistry *node =
+                 llvm::MachineSchedRegistry::getList();
+             node; node = node->getNext())
+          names.emplace_back(node->getName().str());
+        return names;
+      },
+      "Names of the pre-RA MachineScheduler strategies registered in this "
+      "extension, selectable via emit_object(scheduler=...).");
+
+  m.def("_sched_instance_count", &eudsl::schedInstanceCountValue,
+        "Number of Python strategy instances the scheduler registry ctor has "
+        "constructed; used by tests to verify per-MachineFunction "
+        "instantiation.");
+  m.def("_reset_sched_instance_count", &eudsl::resetSchedInstanceCount,
+        "Reset the scheduler instance counter to zero.");
 }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -45,7 +45,7 @@ namespace {
 // (under the GIL) before the pipeline runs and cleared after, so the shared
 // registry ctor knows which class to instantiate per MachineFunction.
 // GIL-serialized, matching the process-global -misched handling in Machine.cpp.
-thread_local nb::object activeSchedClass;
+thread_local nb::type_object activeSchedClass;
 
 // C++ side of mir.MachineSchedStrategy. Each override forwards into the Python
 // object (nb_trampoline.base()) by name with the GIL held outside the try; a
@@ -244,27 +244,42 @@ createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
   if (!activeSchedClass.is_valid())
     return llvm::createSchedLive(c);
   // LCOV_EXCL_STOP
-  auto strategy = std::make_unique<OwningPyStrategy>(activeSchedClass());
-  auto *dag = new llvm::ScheduleDAGMILive(c, std::move(strategy));
-  dag->addMutation(llvm::createCopyConstrainDAGMutation(dag->TII, dag->TRI));
-  return dag;
+  try {
+    auto strategy = std::make_unique<OwningPyStrategy>(activeSchedClass());
+    auto *dag = new llvm::ScheduleDAGMILive(c, std::move(strategy));
+    dag->addMutation(llvm::createCopyConstrainDAGMutation(dag->TII, dag->TRI));
+    return dag;
+  } catch (...) {
+    // Constructing the strategy runs the subclass __init__, which can raise.
+    // This ctor is called from inside pm.run (libLLVMCodeGen, -fno-exceptions),
+    // so stash the error and wind down with the default DAG; runCodegenPipeline
+    // re-raises after the run.
+    eudsl::pendingCodegenError = std::current_exception();
+    return llvm::createSchedLive(c);
+  }
 }
 
 } // namespace
 
 namespace eudsl {
 
-// Validate that cls defines the required methods, record it, and (if new) add a
-// MachineSchedRegistry node so -misched / the pipeline can select it by name.
-// Re-registering a name swaps the class.
-void registerScheduler(const std::string &name, nb::object cls) {
+// Validate that cls subclasses MachineSchedStrategy and defines the required
+// methods, record it, and (if new) add a MachineSchedRegistry node so the
+// pipeline can select it by name. Re-registering a name swaps the class.
+void registerScheduler(const std::string &name, nb::type_object cls) {
+  if (PyObject_IsSubclass(cls.ptr(),
+                          nb::type<llvm::MachineSchedStrategy>().ptr()) != 1) {
+    throw nb::type_error(
+        "scheduler class must subclass mir.MachineSchedStrategy");
+  }
   static const char *required[] = {"initialize",       "get_policy",
                                    "pick_node",        "sched_node",
                                    "release_top_node", "release_bottom_node"};
   for (const char *method : required) {
-    if (!nb::hasattr(cls, method))
+    if (!nb::hasattr(cls, method)) {
       throw nb::type_error(
           (std::string("scheduler class must define ") + method).c_str());
+    }
   }
   nb::dict classes = schedulerClasses();
   if (!classes.contains(name.c_str())) {
@@ -273,22 +288,28 @@ void registerScheduler(const std::string &name, nb::object cls) {
     schedRegistryNodes().push_back(std::make_unique<llvm::MachineSchedRegistry>(
         cname, cname, createRegisteredPyStrategy));
   }
-  classes[name.c_str()] = std::move(cls);
+  classes[name.c_str()] = cls;
 }
 
-// The class registered under `name`, or an empty object.
-nb::object schedulerClass(const std::string &name) {
+// The class registered under `name`, or an invalid object if `name` was not
+// registered via register_scheduler.
+nb::type_object schedulerClass(const std::string &name) {
   nb::dict classes = schedulerClasses();
   if (classes.contains(name.c_str()))
-    return classes[name.c_str()];
-  // LCOV_EXCL_START -- emit_object only calls this after resolving the name in
-  // the MachineSchedRegistry, and register_scheduler adds both together.
-  return nb::object();
-  // LCOV_EXCL_STOP
+    return nb::borrow<nb::type_object>(classes[name.c_str()]);
+  return nb::type_object();
 }
 
-void setActiveSchedClass(nb::object cls) { activeSchedClass = std::move(cls); }
-void clearActiveSchedClass() { activeSchedClass = nb::object(); }
+// The ctor every register_scheduler name shares, so emit_object can point
+// -misched at it without walking the registry.
+llvm::MachineSchedRegistry::ScheduleDAGCtor registeredSchedCtor() {
+  return createRegisteredPyStrategy;
+}
+
+void setActiveSchedClass(nb::type_object cls) {
+  activeSchedClass = std::move(cls);
+}
+void clearActiveSchedClass() { activeSchedClass = nb::type_object(); }
 
 } // namespace eudsl
 
@@ -345,13 +366,9 @@ void populate_python_codegen(nb::module_ &m) {
   m.def(
       "registered_schedulers",
       []() {
-        std::vector<std::string> names;
-        for (llvm::MachineSchedRegistry *node =
-                 llvm::MachineSchedRegistry::getList();
-             node; node = node->getNext())
-          names.emplace_back(node->getName().str());
-        return names;
+        return std::vector<std::string>(schedNames().begin(),
+                                        schedNames().end());
       },
-      "Names of the pre-RA MachineScheduler strategies registered in this "
-      "extension, selectable via emit_object(scheduler=...).");
+      "Names registered via register_scheduler, selectable with "
+      "emit_object(scheduler=...).");
 }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -12,6 +12,10 @@
 #include "IR/Common.h"
 #include "MIR/Diagnostics.h"
 
+#include <llvm/CodeGen/MachineInstr.h>
+#include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/ScheduleDAG.h>
+
 #include <nanobind/nanobind.h>
 
 #include <exception>
@@ -24,4 +28,33 @@ namespace eudsl {
 thread_local std::exception_ptr pendingCodegenError;
 } // namespace eudsl
 
-void populate_python_codegen(nb::module_ &m) { (void)m; }
+void populate_python_codegen(nb::module_ &m) {
+  // Per-region scheduling policy a strategy returns from get_policy(). Field
+  // names mirror MachineSchedPolicy's members.
+  nb::class_<llvm::MachineSchedPolicy>(m, "MachineSchedPolicy")
+      .def(nb::init<>())
+      .def_rw("should_track_pressure",
+              &llvm::MachineSchedPolicy::ShouldTrackPressure)
+      .def_rw("should_track_lane_masks",
+              &llvm::MachineSchedPolicy::ShouldTrackLaneMasks)
+      .def_rw("only_top_down", &llvm::MachineSchedPolicy::OnlyTopDown)
+      .def_rw("only_bottom_up", &llvm::MachineSchedPolicy::OnlyBottomUp);
+
+  // One scheduling unit (a MachineInstr plus its dependency edges). A strategy
+  // receives these via release_top_node/release_bottom_node and returns one
+  // from pick_node.
+  nb::class_<llvm::SUnit>(m, "SUnit")
+      .def_prop_ro(
+          "node_num", [](llvm::SUnit &su) { return su.NodeNum; },
+          "Entry number of this node in the DAG's node vector.")
+      .def_prop_ro(
+          "is_top_ready", [](llvm::SUnit &su) { return su.isTopReady(); },
+          "All predecessors scheduled (ready top-down).")
+      .def_prop_ro(
+          "is_bottom_ready", [](llvm::SUnit &su) { return su.isBottomReady(); },
+          "All successors scheduled (ready bottom-up).")
+      .def_prop_ro(
+          "instr", [](llvm::SUnit &su) { return su.getInstr(); },
+          nb::rv_policy::reference_internal,
+          "The representative MachineInstr this unit wraps.");
+}

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -24,7 +24,6 @@
 #include <nanobind/trampoline.h>
 
 #include <algorithm>
-#include <atomic>
 #include <deque>
 #include <exception>
 #include <memory>
@@ -48,11 +47,6 @@ namespace {
 // registry ctor knows which class to instantiate per MachineFunction.
 // GIL-serialized, matching the process-global -misched handling in Machine.cpp.
 thread_local nb::object activeSchedClass;
-
-// Strategy instances constructed across all runs, so a test can assert one is
-// built per MachineFunction (scheduling is semantics-preserving, so the emitted
-// code alone cannot prove Python drove it).
-std::atomic<unsigned> schedInstanceCount{0};
 
 // C++ side of mir.MachineSchedStrategy. Each override forwards into the Python
 // object (nb_trampoline.base()) by name with the GIL held outside the try; a
@@ -136,24 +130,21 @@ public:
           return nullptr;
         auto [su, isTop] = nb::cast<std::pair<llvm::SUnit *, bool>>(choice);
         isTopNode = isTop;
-        dropFromShadow(su);
         return su;
       } catch (...) {
         eudsl::pendingCodegenError = std::current_exception();
       }
     }
-    // Stash path (or draining after a prior stash): return a still-ready node
-    // so the unskippable pipeline winds down to runCodegenPipeline's re-raise.
-    if (!shadowTop.empty()) {
+    // Stash path (or draining after a prior stash): return a still-ready,
+    // not-yet-scheduled node so the unskippable pipeline winds down to
+    // runCodegenPipeline's re-raise. A node released both top- and bottom-ready
+    // sits in both shadows, so skip any LLVM has already scheduled.
+    if (llvm::SUnit *su = popUnscheduled(shadowTop)) {
       isTopNode = true;
-      llvm::SUnit *su = shadowTop.front();
-      shadowTop.erase(shadowTop.begin());
       return su;
     }
-    if (!shadowBottom.empty()) {
+    if (llvm::SUnit *su = popUnscheduled(shadowBottom)) {
       isTopNode = false;
-      llvm::SUnit *su = shadowBottom.front();
-      shadowBottom.erase(shadowBottom.begin());
       return su;
     }
     return nullptr;
@@ -172,15 +163,16 @@ public:
   }
 
 private:
-  void dropFromShadow(llvm::SUnit *su) {
-    auto t = std::find(shadowTop.begin(), shadowTop.end(), su);
-    if (t != shadowTop.end()) {
-      shadowTop.erase(t);
-      return;
+  // Pop shadow entries until an unscheduled node is found (LLVM marks a node
+  // scheduled once picked), or the shadow drains.
+  static llvm::SUnit *popUnscheduled(std::vector<llvm::SUnit *> &shadow) {
+    while (!shadow.empty()) {
+      llvm::SUnit *su = shadow.front();
+      shadow.erase(shadow.begin());
+      if (!su->isScheduled)
+        return su;
     }
-    auto b = std::find(shadowBottom.begin(), shadowBottom.end(), su);
-    if (b != shadowBottom.end())
-      shadowBottom.erase(b);
+    return nullptr;
   }
 
   std::vector<llvm::SUnit *> shadowTop;
@@ -255,7 +247,6 @@ createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
   if (!activeSchedClass.is_valid())
     return llvm::createSchedLive(c);
   // LCOV_EXCL_STOP
-  schedInstanceCount.fetch_add(1, std::memory_order_relaxed);
   auto strategy = std::make_unique<OwningPyStrategy>(activeSchedClass());
   auto *dag = new llvm::ScheduleDAGMILive(c, std::move(strategy));
   dag->addMutation(llvm::createCopyConstrainDAGMutation(dag->TII, dag->TRI));
@@ -301,13 +292,6 @@ nb::object schedulerClass(const std::string &name) {
 
 void setActiveSchedClass(nb::object cls) { activeSchedClass = std::move(cls); }
 void clearActiveSchedClass() { activeSchedClass = nb::object(); }
-
-unsigned schedInstanceCountValue() {
-  return schedInstanceCount.load(std::memory_order_relaxed);
-}
-void resetSchedInstanceCount() {
-  schedInstanceCount.store(0, std::memory_order_relaxed);
-}
 
 } // namespace eudsl
 
@@ -373,11 +357,4 @@ void populate_python_codegen(nb::module_ &m) {
       },
       "Names of the pre-RA MachineScheduler strategies registered in this "
       "extension, selectable via emit_object(scheduler=...).");
-
-  m.def("_sched_instance_count", &eudsl::schedInstanceCountValue,
-        "Number of Python strategy instances the scheduler registry ctor has "
-        "constructed; used by tests to verify per-MachineFunction "
-        "instantiation.");
-  m.def("_reset_sched_instance_count", &eudsl::resetSchedInstanceCount,
-        "Reset the scheduler instance counter to zero.");
 }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -23,7 +23,6 @@
 #include <nanobind/stl/vector.h>
 #include <nanobind/trampoline.h>
 
-#include <algorithm>
 #include <deque>
 #include <exception>
 #include <memory>
@@ -54,11 +53,11 @@ thread_local nb::object activeSchedClass;
 // returned, since LLVM's scheduler frames are -fno-exceptions.
 // runCodegenPipeline re-raises after the run.
 //
-// shadowTop/shadowBottom mirror the ready nodes LLVM releases, recorded before
-// the fallible Python call. They are the pick_node fallback after a stash: LLVM
-// only releases ready nodes and we drop the picked one, so the shadow front is
-// always a legal choice. The raw contract puts the real ready set in Python,
-// out of reach once it has failed -- this is the safety net.
+// shadow mirrors the ready nodes LLVM releases, recorded before the fallible
+// Python call. It is the pick_node fallback after a stash: LLVM only releases
+// ready nodes, so a still-unscheduled one is always a legal choice. The raw
+// contract puts the real ready set in Python, out of reach once it has failed
+// -- this is the safety net.
 class PySchedStrategy : public llvm::MachineSchedStrategy {
 public:
   NB_TRAMPOLINE(llvm::MachineSchedStrategy, 6);
@@ -81,8 +80,7 @@ public:
   }
 
   void initialize(llvm::ScheduleDAGMI *dag) override {
-    shadowTop.clear();
-    shadowBottom.clear();
+    shadow.clear();
     nb::gil_scoped_acquire gil;
     if (eudsl::pendingCodegenError)
       return;
@@ -95,7 +93,7 @@ public:
   }
 
   void releaseTopNode(llvm::SUnit *su) override {
-    shadowTop.push_back(su);
+    shadow.push_back(su);
     nb::gil_scoped_acquire gil;
     if (eudsl::pendingCodegenError)
       return;
@@ -108,7 +106,7 @@ public:
   }
 
   void releaseBottomNode(llvm::SUnit *su) override {
-    shadowBottom.push_back(su);
+    shadow.push_back(su);
     nb::gil_scoped_acquire gil;
     if (eudsl::pendingCodegenError)
       return;
@@ -137,15 +135,15 @@ public:
     }
     // Stash path (or draining after a prior stash): return a still-ready,
     // not-yet-scheduled node so the unskippable pipeline winds down to
-    // runCodegenPipeline's re-raise. A node released both top- and bottom-ready
-    // sits in both shadows, so skip any LLVM has already scheduled.
-    if (llvm::SUnit *su = popUnscheduled(shadowTop)) {
-      isTopNode = true;
-      return su;
-    }
-    if (llvm::SUnit *su = popUnscheduled(shadowBottom)) {
-      isTopNode = false;
-      return su;
+    // runCodegenPipeline's re-raise. LLVM only releases ready nodes; skip any
+    // it has since scheduled, and report the node's readiness direction.
+    while (!shadow.empty()) {
+      llvm::SUnit *su = shadow.front();
+      shadow.erase(shadow.begin());
+      if (!su->isScheduled) {
+        isTopNode = su->isTopReady();
+        return su;
+      }
     }
     return nullptr;
   }
@@ -163,20 +161,10 @@ public:
   }
 
 private:
-  // Pop shadow entries until an unscheduled node is found (LLVM marks a node
-  // scheduled once picked), or the shadow drains.
-  static llvm::SUnit *popUnscheduled(std::vector<llvm::SUnit *> &shadow) {
-    while (!shadow.empty()) {
-      llvm::SUnit *su = shadow.front();
-      shadow.erase(shadow.begin());
-      if (!su->isScheduled)
-        return su;
-    }
-    return nullptr;
-  }
-
-  std::vector<llvm::SUnit *> shadowTop;
-  std::vector<llvm::SUnit *> shadowBottom;
+  // Every ready node LLVM releases (top or bottom), recorded before the
+  // fallible Python call so the pick_node fallback above always has a legal
+  // choice.
+  std::vector<llvm::SUnit *> shadow;
 };
 
 // The strategy LLVM owns. nanobind refuses to move a Python-created instance
@@ -220,12 +208,21 @@ private:
   llvm::MachineSchedStrategy *inner;
 };
 
-// Registered name -> Python class. A leaked deque: deque never reallocates, so
-// the name c_str() handed to MachineSchedRegistry stays valid, and leaking
-// avoids dropping Python refs at interpreter shutdown.
-std::deque<std::pair<std::string, nb::object>> &schedClasses() {
-  static auto *classes = new std::deque<std::pair<std::string, nb::object>>();
-  return *classes;
+// Stable storage for registered names: a leaked deque (pure C++, no Python
+// refs) whose element c_str() the MachineSchedRegistry node borrows for process
+// lifetime.
+std::deque<std::string> &schedNames() {
+  static auto *names = new std::deque<std::string>();
+  return *names;
+}
+
+// name -> Python class, held in llvm.mir_strategies._scheduler_classes. Python
+// owns it, so the classes are released at interpreter teardown (a C++-held
+// nb::object static would pin the subclass types past nanobind's teardown and
+// trip its leak checker).
+nb::dict schedulerClasses() {
+  return nb::cast<nb::dict>(
+      nb::module_::import_("llvm.mir_strategies").attr("_scheduler_classes"));
 }
 
 // The live MachineSchedRegistry nodes, kept (leaked) so they stay registered
@@ -269,25 +266,25 @@ void registerScheduler(const std::string &name, nb::object cls) {
       throw nb::type_error(
           (std::string("scheduler class must define ") + method).c_str());
   }
-  for (auto &entry : schedClasses()) {
-    if (entry.first == name) {
-      entry.second = std::move(cls);
-      return;
-    }
+  nb::dict classes = schedulerClasses();
+  if (!classes.contains(name.c_str())) {
+    schedNames().push_back(name);
+    const char *cname = schedNames().back().c_str();
+    schedRegistryNodes().push_back(std::make_unique<llvm::MachineSchedRegistry>(
+        cname, cname, createRegisteredPyStrategy));
   }
-  schedClasses().emplace_back(name, std::move(cls));
-  const char *cname = schedClasses().back().first.c_str();
-  schedRegistryNodes().push_back(std::make_unique<llvm::MachineSchedRegistry>(
-      cname, cname, createRegisteredPyStrategy));
+  classes[name.c_str()] = std::move(cls);
 }
 
 // The class registered under `name`, or an empty object.
 nb::object schedulerClass(const std::string &name) {
-  for (auto &entry : schedClasses()) {
-    if (entry.first == name)
-      return entry.second;
-  }
+  nb::dict classes = schedulerClasses();
+  if (classes.contains(name.c_str()))
+    return classes[name.c_str()];
+  // LCOV_EXCL_START -- emit_object only calls this after resolving the name in
+  // the MachineSchedRegistry, and register_scheduler adds both together.
   return nb::object();
+  // LCOV_EXCL_STOP
 }
 
 void setActiveSchedClass(nb::object cls) { activeSchedClass = std::move(cls); }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -130,8 +130,11 @@ public:
     nb::gil_scoped_acquire gil;
     if (!eudsl::pendingCodegenError) {
       try {
-        auto [su, isTop] = nb::cast<std::pair<llvm::SUnit *, bool>>(
-            nb_trampoline.base().attr("pick_node")());
+        nb::object choice = nb_trampoline.base().attr("pick_node")();
+        // None signals "nothing ready" -- end scheduling (LLVM's nullptr).
+        if (choice.is_none())
+          return nullptr;
+        auto [su, isTop] = nb::cast<std::pair<llvm::SUnit *, bool>>(choice);
         isTopNode = isTop;
         dropFromShadow(su);
         return su;
@@ -337,6 +340,10 @@ void populate_python_codegen(nb::module_ &m) {
           "instr", [](llvm::SUnit &su) { return su.getInstr(); },
           nb::rv_policy::reference_internal,
           "The representative MachineInstr this unit wraps.");
+
+  // The scheduling DAG passed to initialize(dag). Opaque for now -- a strategy
+  // receives its nodes via release_top_node/release_bottom_node.
+  nb::class_<llvm::ScheduleDAGMI>(m, "ScheduleDAGMI");
 
   // The pre-RA MachineScheduler strategy interface, subclassable from Python.
   // Override initialize(dag), get_policy() -> MachineSchedPolicy,

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -12,6 +12,7 @@
 #include "IR/Common.h"
 #include "MIR/Diagnostics.h"
 
+#include <llvm/CodeGen/MachineBasicBlock.h>
 #include <llvm/CodeGen/MachineInstr.h>
 #include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
@@ -60,7 +61,7 @@ thread_local nb::type_object activeSchedClass;
 // -- this is the safety net.
 class PySchedStrategy : public llvm::MachineSchedStrategy {
 public:
-  NB_TRAMPOLINE(llvm::MachineSchedStrategy, 6);
+  NB_TRAMPOLINE(llvm::MachineSchedStrategy, 9);
 
   llvm::MachineSchedPolicy getPolicy() const override {
     nb::gil_scoped_acquire gil;
@@ -160,6 +161,46 @@ public:
     }
   }
 
+  // Optional lifecycle hooks: forwarded only if the Python subclass defines
+  // them, otherwise LLVM's no-op default stands. registerRoots fires once the
+  // full initial ready set has been released; enterMBB/leaveMBB bracket each
+  // block (which may hold several scheduling regions).
+  void registerRoots() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError || !nb::hasattr(self, "register_roots"))
+      return;
+    try {
+      self.attr("register_roots")();
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  void enterMBB(llvm::MachineBasicBlock *mbb) override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError || !nb::hasattr(self, "enter_mbb"))
+      return;
+    try {
+      self.attr("enter_mbb")(nb::cast(mbb, nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  void leaveMBB() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError || !nb::hasattr(self, "leave_mbb"))
+      return;
+    try {
+      self.attr("leave_mbb")();
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
 private:
   // Every ready node LLVM releases (top or bottom), recorded before the
   // fallible Python call so the pick_node fallback above always has a legal
@@ -202,6 +243,9 @@ public:
   void schedNode(llvm::SUnit *su, bool isTopNode) override {
     inner->schedNode(su, isTopNode);
   }
+  void registerRoots() override { inner->registerRoots(); }
+  void enterMBB(llvm::MachineBasicBlock *mbb) override { inner->enterMBB(mbb); }
+  void leaveMBB() override { inner->leaveMBB(); }
 
 private:
   nb::object pyStrategy;

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -21,3 +21,6 @@ from . import (
 from .dsl.values import install_value_casters as _install_value_casters
 
 _install_value_casters()
+
+# Attaches mir.ReadyQueueStrategy onto the mir submodule.
+from . import mir_strategies as _mir_strategies  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
@@ -10,10 +10,10 @@ Importing this module attaches them to the `mir` submodule, so they read as
 from . import mir
 
 # name -> registered MachineSchedStrategy subclass; populated by
-# mir.register_scheduler (C++). Python owns this so classes are released at
-# interpreter teardown rather than pinned in a C++ static.
+# mir.register_scheduler (C++) and read back by it via
+# llvm.mir_strategies._scheduler_classes. Python owns this so classes are
+# released at interpreter teardown rather than pinned in a C++ static.
 _scheduler_classes = {}
-mir._scheduler_classes = _scheduler_classes
 
 
 class ReadyQueueStrategy(mir.MachineSchedStrategy):

--- a/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
@@ -9,6 +9,12 @@ Importing this module attaches them to the `mir` submodule, so they read as
 
 from . import mir
 
+# name -> registered MachineSchedStrategy subclass; populated by
+# mir.register_scheduler (C++). Python owns this so classes are released at
+# interpreter teardown rather than pinned in a C++ static.
+_scheduler_classes = {}
+mir._scheduler_classes = _scheduler_classes
+
 
 class ReadyQueueStrategy(mir.MachineSchedStrategy):
     """Top-down strategy that maintains the ready queue for you.

--- a/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
@@ -1,0 +1,51 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Convenience MachineSchedStrategy subclasses (pure Python).
+
+Importing this module attaches them to the `mir` submodule, so they read as
+`mir.ReadyQueueStrategy`.
+"""
+
+from . import mir
+
+
+class ReadyQueueStrategy(mir.MachineSchedStrategy):
+    """Top-down strategy that maintains the ready queue for you.
+
+    Subclass and override ``pick(ready)`` to choose one node from the currently
+    ready list; the default picks the first (native first-ready). Power users
+    that need the full lifecycle (custom priority, deferral, bottom-up) subclass
+    mir.MachineSchedStrategy directly.
+    """
+
+    def initialize(self, dag):
+        self._q = []
+
+    def get_policy(self):
+        p = mir.MachineSchedPolicy()
+        p.only_top_down = True
+        p.should_track_pressure = False
+        return p
+
+    def release_top_node(self, su):
+        self._q.append(su)
+
+    def release_bottom_node(self, su):
+        pass
+
+    def sched_node(self, su, is_top):
+        pass
+
+    def pick_node(self):
+        if not self._q:
+            return None
+        chosen = self.pick(self._q)
+        self._q.remove(chosen)
+        return chosen, True
+
+    def pick(self, ready):
+        return ready[0]
+
+
+mir.ReadyQueueStrategy = ReadyQueueStrategy

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -150,3 +150,162 @@ def test_registered_strategy_emits_object():
         assert obj[:4] == b"\x7fELF"
         assert b"add\x00" in obj
     assert_no_leaks()
+
+
+def test_python_strategy_actually_drives_scheduling():
+    """A strategy recording into a list witnesses that Python drove
+    initialize/pick (semantics-preserving scheduling leaves no other trace)."""
+    trace = []
+
+    class Recording(_TopDownFirstReady):
+        def initialize(self, dag):
+            super().initialize(dag)
+            trace.append("init")
+
+        def pick_node(self):
+            trace.append("pick")
+            return super().pick_node()
+
+    mir.register_scheduler("t6-recording", Recording)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t6-recording")
+        assert "init" in trace and "pick" in trace
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_two_strategies_coexist():
+    ran = {"a": 0, "b": 0}
+
+    class A(_TopDownFirstReady):
+        def pick_node(self):
+            ran["a"] += 1
+            return super().pick_node()
+
+    class B(_TopDownFirstReady):
+        def pick_node(self):
+            ran["b"] += 1
+            return super().pick_node()
+
+    mir.register_scheduler("t6-a", A)
+    mir.register_scheduler("t6-b", B)
+    assert "t6-a" in mir.registered_schedulers()
+    assert "t6-b" in mir.registered_schedulers()
+    for name, key in (("t6-a", "a"), ("t6-b", "b")):
+        other = "b" if key == "a" else "a"
+        before_other = ran[other]
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_selected_add(mmi)
+            mmi.emit_object(scheduler=name)
+        assert ran[key] > 0  # this run's strategy ran
+        assert ran[other] == before_other  # the other did not
+    assert_no_leaks()
+
+
+def test_fresh_instance_per_function():
+    """The registry ctor constructs a fresh strategy instance per
+    MachineFunction (counted via the subclass __init__)."""
+    instances = []
+
+    class Counting(_TopDownFirstReady):
+        def __init__(self):
+            super().__init__()
+            instances.append(1)
+
+    mir.register_scheduler("t6-perfunc", Counting)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        mmi.emit_object(scheduler="t6-perfunc")
+    assert len(instances) == 1  # one MachineFunction -> one instance
+    assert_no_leaks()
+
+
+def test_pick_node_raise_propagates():
+    """A pick_node that raises surfaces as a Python exception out of emit_object
+    (stashed and re-raised after codegen winds down, never thrown across LLVM's
+    -fno-exceptions frames); the interpreter survives and nothing leaks."""
+
+    class Boom(_TopDownFirstReady):
+        def pick_node(self):
+            raise ValueError("boom")
+
+    mir.register_scheduler("t6-boom", Boom)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="boom"):
+            mmi.emit_object(scheduler="t6-boom")
+    assert_no_leaks()
+
+
+def test_pick_node_bad_return_propagates():
+    """pick_node returning a non-(SUnit, bool) surfaces as a Python error, not a
+    crash: the trampoline's cast fails, is stashed, and re-raised."""
+
+    class BadReturn(_TopDownFirstReady):
+        def pick_node(self):
+            return 123  # not (SUnit, bool) and not None
+
+    mir.register_scheduler("t6-badret", BadReturn)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(Exception):
+            mmi.emit_object(scheduler="t6-badret")
+    assert_no_leaks()
+
+
+def test_initialize_raise_propagates():
+    """Every override is a stash site: a raise from initialize (not just
+    pick_node) is stashed and re-raised out of emit_object."""
+
+    class InitBoom(_TopDownFirstReady):
+        def initialize(self, dag):
+            raise ValueError("init-boom")
+
+    mir.register_scheduler("t6-initboom", InitBoom)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="init-boom"):
+            mmi.emit_object(scheduler="t6-initboom")
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_python_scheduled_add():
+    mir.register_scheduler("t6-jit", _TopDownFirstReady)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple -> loadable in-process
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t6-jit")
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -395,3 +395,102 @@ def test_jit_executes_bottom_up_scheduled_add():
         assert add(7, 8) == 15  # bottom-up schedule still correct
         del j
     assert_no_leaks()
+
+
+def test_sunit_accessors_readable():
+    """The SUnit read accessors return sensible values for ready nodes."""
+    seen = []
+
+    class ReadsFields(_TopDownFirstReady):
+        def pick_node(self):
+            if not self.q:
+                return None
+            su = self.q[0]
+            seen.append(
+                (su.node_num, su.is_top_ready, su.is_bottom_ready, su.instr)
+            )
+            return self.q.pop(0), True
+
+    mir.register_scheduler("t9-fields", ReadsFields)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        mmi.emit_object(scheduler="t9-fields")
+    assert seen
+    node_num, is_top, is_bottom, instr = seen[0]
+    assert node_num >= 0
+    assert is_top  # a top-ready node has no unscheduled predecessors
+    assert isinstance(is_bottom, bool)
+    assert instr is not None  # every ready SUnit wraps a MachineInstr
+    assert_no_leaks()
+
+
+@pytest.mark.parametrize(
+    "method", ["get_policy", "release_top_node", "release_bottom_node", "sched_node"]
+)
+def test_override_raise_propagates(method):
+    """A raise from any forwarded override is stashed and re-raised out of
+    emit_object (every override is a -fno-exceptions stash site)."""
+
+    def boom(self, *args):
+        raise ValueError("boom-" + method)
+
+    Strat = type("Strat", (_TopDownFirstReady,), {method: boom})
+    mir.register_scheduler("t9-" + method, Strat)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="boom-" + method):
+            mmi.emit_object(scheduler="t9-" + method)
+    assert_no_leaks()
+
+
+def test_bottom_up_pick_raise_drains_bottom_shadow():
+    """A bottom-up strategy whose pick_node raises: the fallback drains the top
+    shadow, then the bottom shadow (the is_top=False fallback path)."""
+
+    class BottomBoom(_BottomUpStrategy):
+        def pick_node(self):
+            raise ValueError("bottom-boom")
+
+    mir.register_scheduler("t9-bottomboom", BottomBoom)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="bottom-boom"):
+            mmi.emit_object(scheduler="t9-bottomboom")
+    assert_no_leaks()
+
+
+def test_reregister_replaces_scheduler():
+    """Registering an existing name replaces its class (the registry node for
+    that name is reused)."""
+    picks = []
+
+    class First(_TopDownFirstReady):
+        def pick_node(self):
+            picks.append("first")
+            return super().pick_node()
+
+    class Second(_TopDownFirstReady):
+        def pick_node(self):
+            picks.append("second")
+            return super().pick_node()
+
+    mir.register_scheduler("t9-dup", First)
+    mir.register_scheduler("t9-dup", Second)  # replaces First
+    assert mir.registered_schedulers().count("t9-dup") == 1
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        mmi.emit_object(scheduler="t9-dup")
+    assert "second" in picks and "first" not in picks
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -1,0 +1,25 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Python-subclassable MachineScheduler strategy.
+
+mir.MachineSchedStrategy binds llvm::MachineSchedStrategy so Python can subclass
+it and override the scheduling virtuals. register_scheduler adds it to the
+MachineScheduler registry under a name; emit_object(scheduler="name") runs it as
+the pre-RA scheduler. Scheduling is semantics-preserving, so a strategy
+recording into a test-visible object is the witness that Python drove it; a
+JIT-executed test proves the result stays correct.
+"""
+
+from llvm import mir
+
+
+def test_machine_sched_policy_fields_roundtrip():
+    p = mir.MachineSchedPolicy()
+    assert p.only_top_down is False
+    assert p.should_track_pressure is False
+    p.only_top_down = True
+    p.only_bottom_up = True
+    p.should_track_pressure = False
+    p.should_track_lane_masks = False
+    assert p.only_top_down and p.only_bottom_up

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -331,3 +331,67 @@ def test_ready_queue_strategy_helper_pick():
         assert picks  # the helper's pick() hook ran
         assert obj[:4] == b"\x7fELF"
     assert_no_leaks()
+
+
+class _BottomUpStrategy(mir.MachineSchedStrategy):
+    """Bottom-up scheduling: consume nodes released bottom-ready and pick them
+    with is_top=False. Impossible with the top-down ReadyQueueStrategy helper --
+    exercises get_policy(only_bottom_up), release_bottom_node, and the
+    is_top=False pick path."""
+
+    def initialize(self, dag):
+        self.q = []
+
+    def get_policy(self):
+        p = mir.MachineSchedPolicy()
+        p.only_bottom_up = True
+        p.should_track_pressure = False
+        return p
+
+    def release_top_node(self, su):
+        pass
+
+    def release_bottom_node(self, su):
+        self.q.append(su)
+
+    def pick_node(self):
+        if not self.q:
+            return None
+        return self.q.pop(0), False  # is_top_node = False
+
+    def sched_node(self, su, is_top):
+        pass
+
+
+def test_bottom_up_strategy_emits_valid_object():
+    mir.register_scheduler("t8-bottomup", _BottomUpStrategy)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t8-bottomup")
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(
+    not _IS_AARCH64,
+    reason="hand-built MIR is AArch64; executing it needs an AArch64 host",
+)
+def test_jit_executes_bottom_up_scheduled_add():
+    mir.register_scheduler("t8-bottomup-jit", _BottomUpStrategy)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t8-bottomup-jit")
+        j = jit.LLJIT()
+        j.add_object(obj)
+        add = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_int32, ctypes.c_int32)(
+            j.lookup("add")
+        )
+        assert add(7, 8) == 15  # bottom-up schedule still correct
+        del j
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -309,3 +309,25 @@ def test_jit_executes_python_scheduled_add():
         assert add(40, 2) == 42
         del j
     assert_no_leaks()
+
+
+def test_ready_queue_strategy_helper_pick():
+    """mir.ReadyQueueStrategy maintains the ready queue; the subclass only
+    overrides pick(ready)."""
+    picks = []
+
+    class LastReady(mir.ReadyQueueStrategy):
+        def pick(self, ready):
+            picks.append(len(ready))
+            return ready[-1]
+
+    mir.register_scheduler("t7-lastready", LastReady)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t7-lastready")
+        assert picks  # the helper's pick() hook ran
+        assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -13,7 +13,52 @@ JIT-executed test proves the result stays correct.
 
 from llvm import mir
 
+import ctypes
+import platform
+
 import pytest
+
+import llvm
+from llvm import ir, jit
+from llvm.testing import assert_no_leaks
+
+# Object emission uses an AArch64 target (cross ELF), so needs the AArch64
+# backend linked; JIT-executing additionally needs an AArch64 host.
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+_IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
+
+
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 add(i32,i32)->i32 MachineFunction."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
 
 
 def test_machine_sched_policy_fields_roundtrip():
@@ -46,6 +91,8 @@ class _TopDownFirstReady(mir.MachineSchedStrategy):
         pass
 
     def pick_node(self):
+        if not self.q:
+            return None
         return self.q.pop(0), True
 
     def sched_node(self, su, is_top):
@@ -79,3 +126,27 @@ def test_register_scheduler_missing_method_raises():
     with pytest.raises(TypeError, match="pick_node"):
         mir.register_scheduler("t4-incomplete", Incomplete)
 
+
+
+def test_unknown_scheduler_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="scheduler"):
+            mmi.emit_object(scheduler="does-not-exist")
+    assert_no_leaks()
+
+
+def test_registered_strategy_emits_object():
+    mir.register_scheduler("t5-firstready", _TopDownFirstReady)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t5-firstready")
+        assert obj[:4] == b"\x7fELF"
+        assert b"add\x00" in obj
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -527,7 +527,8 @@ def test_reregister_replaces_scheduler():
 
 def test_register_non_subclass_raises():
     """A class with the right methods but not subclassing MachineSchedStrategy is
-    rejected (it would otherwise reach nb::inst_ptr on a non-bound object)."""
+    rejected by the typed `cls` parameter at the call boundary (it would
+    otherwise reach nb::inst_ptr on a non-bound object)."""
 
     class NotAStrategy:  # duck-typed, but not a mir.MachineSchedStrategy
         def initialize(self, dag): ...
@@ -537,7 +538,7 @@ def test_register_non_subclass_raises():
         def release_top_node(self, su): ...
         def release_bottom_node(self, su): ...
 
-    with pytest.raises(TypeError, match="subclass"):
+    with pytest.raises(TypeError, match="incompatible function arguments"):
         mir.register_scheduler("t10-notsub", NotAStrategy)
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -133,7 +133,7 @@ def test_unknown_scheduler_name_raises():
         tm = jit.TargetMachine(triple=_AARCH64_LINUX)
         mmi = mir.create_machine_function(mod, tm, "add")
         _build_selected_add(mmi)
-        with pytest.raises(RuntimeError, match="scheduler"):
+        with pytest.raises(RuntimeError, match="unknown scheduler"):
             mmi.emit_object(scheduler="does-not-exist")
     assert_no_leaks()
 
@@ -210,22 +210,25 @@ def test_two_strategies_coexist():
 
 def test_fresh_instance_per_function():
     """The registry ctor constructs a fresh strategy instance per
-    MachineFunction (counted via the subclass __init__)."""
+    MachineFunction, not a reused singleton. Two emissions (each with one
+    MachineFunction) must construct two *distinct* instances."""
     instances = []
 
     class Counting(_TopDownFirstReady):
         def __init__(self):
             super().__init__()
-            instances.append(1)
+            instances.append(self)
 
     mir.register_scheduler("t6-perfunc", Counting)
-    with ir.Context() as ctx:
-        mod = ir.Module("m", ctx)
-        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
-        mmi = mir.create_machine_function(mod, tm, "add")
-        _build_selected_add(mmi)
-        mmi.emit_object(scheduler="t6-perfunc")
-    assert len(instances) == 1  # one MachineFunction -> one instance
+    for _ in range(2):
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_selected_add(mmi)
+            mmi.emit_object(scheduler="t6-perfunc")
+    assert len(instances) == 2  # one instance per MachineFunction emitted
+    assert instances[0] is not instances[1]  # fresh, not a cached singleton
     assert_no_leaks()
 
 
@@ -263,7 +266,7 @@ def test_pick_node_bad_return_propagates():
         tm = jit.TargetMachine(triple=_AARCH64_LINUX)
         mmi = mir.create_machine_function(mod, tm, "add")
         _build_selected_add(mmi)
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="bad_cast"):
             mmi.emit_object(scheduler="t6-badret")
     assert_no_leaks()
 
@@ -362,14 +365,33 @@ class _BottomUpStrategy(mir.MachineSchedStrategy):
         pass
 
 
-def test_bottom_up_strategy_emits_valid_object():
-    mir.register_scheduler("t8-bottomup", _BottomUpStrategy)
+def test_bottom_up_strategy_drives_scheduling():
+    """Witness that Python drove a *bottom-up* schedule: the recording subclass
+    sees nodes via release_bottom_node and returns them with is_top=False (a path
+    the top-down ReadyQueueStrategy helper cannot reach)."""
+    released_bottom = []
+    picks = []
+
+    class Recording(_BottomUpStrategy):
+        def release_bottom_node(self, su):
+            released_bottom.append(su.node_num)
+            super().release_bottom_node(su)
+
+        def pick_node(self):
+            choice = super().pick_node()
+            if choice is not None:
+                picks.append(choice[1])  # is_top_node
+            return choice
+
+    mir.register_scheduler("t8-bottomup", Recording)
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_AARCH64_LINUX)
         mmi = mir.create_machine_function(mod, tm, "add")
         _build_selected_add(mmi)
         obj = mmi.emit_object(scheduler="t8-bottomup")
+        assert released_bottom  # nodes arrived via the bottom-ready path
+        assert picks and all(is_top is False for is_top in picks)  # is_top=False
         assert obj[:4] == b"\x7fELF"
     assert_no_leaks()
 
@@ -446,9 +468,10 @@ def test_override_raise_propagates(method):
     assert_no_leaks()
 
 
-def test_bottom_up_pick_raise_drains_bottom_shadow():
-    """A bottom-up strategy whose pick_node raises: the fallback drains the top
-    shadow, then the bottom shadow (the is_top=False fallback path)."""
+def test_bottom_up_pick_raise_propagates():
+    """A bottom-up strategy whose pick_node raises: the exception is stashed and
+    re-raised, and the single shadow ready-set drains (returning still-ready
+    nodes with is_top from isTopReady()) so the pipeline winds down cleanly."""
 
     class BottomBoom(_BottomUpStrategy):
         def pick_node(self):
@@ -490,4 +513,82 @@ def test_reregister_replaces_scheduler():
         _build_selected_add(mmi)
         mmi.emit_object(scheduler="t9-dup")
     assert "second" in picks and "first" not in picks
+    assert_no_leaks()
+
+
+def test_register_non_subclass_raises():
+    """A class with the right methods but not subclassing MachineSchedStrategy is
+    rejected (it would otherwise reach nb::inst_ptr on a non-bound object)."""
+
+    class NotAStrategy:  # duck-typed, but not a mir.MachineSchedStrategy
+        def initialize(self, dag): ...
+        def get_policy(self): ...
+        def pick_node(self): ...
+        def sched_node(self, su, is_top): ...
+        def release_top_node(self, su): ...
+        def release_bottom_node(self, su): ...
+
+    with pytest.raises(TypeError, match="subclass"):
+        mir.register_scheduler("t10-notsub", NotAStrategy)
+
+
+def test_raising_init_propagates():
+    """A subclass whose __init__ raises surfaces as a Python exception out of
+    emit_object rather than crashing across LLVM's -fno-exceptions frames (the
+    strategy-construction path is a stash site too)."""
+
+    class InitBoom(_TopDownFirstReady):
+        def __init__(self):
+            raise ValueError("ctor-boom")
+
+    mir.register_scheduler("t10-ctorboom", InitBoom)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(ValueError, match="ctor-boom"):
+            mmi.emit_object(scheduler="t10-ctorboom")
+    assert_no_leaks()
+
+
+def test_get_policy_wrong_type_propagates():
+    """get_policy returning a non-MachineSchedPolicy fails the trampoline cast;
+    the error is stashed and re-raised out of emit_object."""
+
+    class BadPolicy(_TopDownFirstReady):
+        def get_policy(self):
+            return 123  # not a MachineSchedPolicy
+
+    mir.register_scheduler("t10-badpolicy", BadPolicy)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="bad_cast"):
+            mmi.emit_object(scheduler="t10-badpolicy")
+    assert_no_leaks()
+
+
+def test_pressure_tracking_emits_object():
+    """A strategy with should_track_pressure=True exercises the
+    shouldTrackPressure() true-branch through codegen (register-pressure
+    tracking) and still emits a well-formed object."""
+
+    class Pressure(_TopDownFirstReady):
+        def get_policy(self):
+            p = mir.MachineSchedPolicy()
+            p.only_top_down = True
+            p.should_track_pressure = True
+            return p
+
+    mir.register_scheduler("t10-pressure", Pressure)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(scheduler="t10-pressure")
+        assert obj[:4] == b"\x7fELF"
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -447,7 +447,16 @@ def test_sunit_accessors_readable():
 
 
 @pytest.mark.parametrize(
-    "method", ["get_policy", "release_top_node", "release_bottom_node", "sched_node"]
+    "method",
+    [
+        "get_policy",
+        "release_top_node",
+        "release_bottom_node",
+        "sched_node",
+        "register_roots",
+        "enter_mbb",
+        "leave_mbb",
+    ],
 )
 def test_override_raise_propagates(method):
     """A raise from any forwarded override is stashed and re-raised out of
@@ -591,4 +600,35 @@ def test_pressure_tracking_emits_object():
         _build_selected_add(mmi)
         obj = mmi.emit_object(scheduler="t10-pressure")
         assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_optional_lifecycle_hooks_invoked():
+    """The optional hooks (register_roots, enter_mbb, leave_mbb) are forwarded to
+    a subclass that defines them: register_roots fires once the initial ready set
+    is released, enter_mbb/leave_mbb bracket the block, and enter_mbb receives the
+    MachineBasicBlock."""
+    events = []
+
+    class Hooked(_TopDownFirstReady):
+        def enter_mbb(self, mbb):
+            events.append(("enter", mbb.name))
+
+        def register_roots(self):
+            events.append(("roots", None))
+
+        def leave_mbb(self):
+            events.append(("leave", None))
+
+    mir.register_scheduler("t11-hooks", Hooked)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        mmi.emit_object(scheduler="t11-hooks")
+    kinds = [k for k, _ in events]
+    assert "enter" in kinds and "roots" in kinds and "leave" in kinds
+    assert kinds.index("enter") < kinds.index("roots") < kinds.index("leave")
+    assert isinstance(dict(events).get("enter"), str)  # enter_mbb got an MBB name
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -13,6 +13,8 @@ JIT-executed test proves the result stays correct.
 
 from llvm import mir
 
+import pytest
+
 
 def test_machine_sched_policy_fields_roundtrip():
     p = mir.MachineSchedPolicy()
@@ -23,3 +25,57 @@ def test_machine_sched_policy_fields_roundtrip():
     p.should_track_pressure = False
     p.should_track_lane_masks = False
     assert p.only_top_down and p.only_bottom_up
+
+
+class _TopDownFirstReady(mir.MachineSchedStrategy):
+    """Minimal top-down strategy: schedule ready nodes in first-ready order."""
+
+    def initialize(self, dag):
+        self.q = []
+
+    def get_policy(self):
+        p = mir.MachineSchedPolicy()
+        p.only_top_down = True
+        p.should_track_pressure = False
+        return p
+
+    def release_top_node(self, su):
+        self.q.append(su)
+
+    def release_bottom_node(self, su):
+        pass
+
+    def pick_node(self):
+        return self.q.pop(0), True
+
+    def sched_node(self, su, is_top):
+        pass
+
+
+def test_register_scheduler_appears_in_registry():
+    mir.register_scheduler("t4-appears", _TopDownFirstReady)
+    assert "t4-appears" in mir.registered_schedulers()
+
+
+def test_register_scheduler_missing_method_raises():
+    class Incomplete(mir.MachineSchedStrategy):
+        def initialize(self, dag):
+            pass
+
+        def get_policy(self):
+            return mir.MachineSchedPolicy()
+
+        def sched_node(self, su, is_top):
+            pass
+
+        def release_top_node(self, su):
+            pass
+
+        def release_bottom_node(self, su):
+            pass
+
+        # pick_node intentionally missing
+
+    with pytest.raises(TypeError, match="pick_node"):
+        mir.register_scheduler("t4-incomplete", Incomplete)
+

--- a/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_scheduler.py
@@ -127,7 +127,6 @@ def test_register_scheduler_missing_method_raises():
         mir.register_scheduler("t4-incomplete", Incomplete)
 
 
-
 def test_unknown_scheduler_name_raises():
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
@@ -406,9 +405,7 @@ def test_sunit_accessors_readable():
             if not self.q:
                 return None
             su = self.q[0]
-            seen.append(
-                (su.node_num, su.is_top_ready, su.is_bottom_ready, su.instr)
-            )
+            seen.append((su.node_num, su.is_top_ready, su.is_bottom_ready, su.instr))
             return self.q.pop(0), True
 
     mir.register_scheduler("t9-fields", ReadsFields)


### PR DESCRIPTION
Replaces the `emit_object(pick=callable)` scheduler-callback approach with a
Python-**subclassable** `llvm::MachineSchedStrategy` (#600 items 1–3).

## What
- `mir.MachineSchedStrategy` binds the real `llvm::MachineSchedStrategy` (nanobind
  trampoline); Python overrides `initialize`, `get_policy`,
  `release_top_node`/`release_bottom_node`, `pick_node() -> (SUnit, is_top) | None`,
  `sched_node`.
- `mir.register_scheduler(name, cls)` adds a runtime `MachineSchedRegistry` node;
  `emit_object(scheduler="name")` runs it as the pre-RA MachineScheduler. Multiple
  named strategies coexist and appear in `registered_schedulers()`.
- `mir.MachineSchedPolicy` / `mir.SUnit` bindings; `mir.ReadyQueueStrategy`
  pure-Python convenience base (override only `pick(ready)`).
- **Ownership:** LLVM owns a C++ `OwningPyStrategy` adaptor — nanobind refuses to
  move a Python-created instance into a default-deleter `unique_ptr` — which
  forwards into the Python instance and drops it under the GIL. Registered classes
  live in a Python-owned dict so no subclass types are pinned at teardown.
- **Exceptions:** every override is a `-fno-exceptions` boundary; Python errors are
  stashed in `pendingCodegenError` and re-raised after the pipeline winds down
  (never thrown across LLVM frames), with an `isScheduled`-safe shadow ready-set
  giving `pick_node` a legal fallback.
- **Build:** matches the distro's ABI flags via `HandleLLVMOptions`.