### PR TITLE
[eudsl-llvmpy] MIR: Python-subclassable RegAllocBase + SplitEditor region splitting (#600)

### DIFF
--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -47,6 +47,14 @@ holds. Reach for `nb::object`/`nb::handle` only when the value is genuinely an
 arbitrary Python object with no more specific type — e.g. the ignored
 `exc_type`/`exc_value`/`traceback` parameters of `__exit__`.
 
+## Comments explain why, not what
+
+Do not write comments that restate what the code plainly does. Add a comment
+only when it documents *why* something non-obvious was done -- a workaround, a
+constraint imposed by an external API, a subtle ordering requirement, a reason a
+simpler-looking alternative fails. If the code is self-explanatory, leave it
+uncommented.
+
 ## No forward-reference comments
 
 Do not write comments that reference future work, later PRs, or task numbers

--- a/projects/eudsl-llvmpy/CLAUDE.md
+++ b/projects/eudsl-llvmpy/CLAUDE.md
@@ -82,6 +82,23 @@ Every import goes at module top. No function-local imports. When a test exists
 to show that two extensions coexist, import both at module scope and assert on
 them in the body.
 
+## Tests: running the suite needs FileCheck
+
+Many `tests/` (the DSL/IR filecheck tests via `llvm.testing.filecheck_with_comments`)
+shell out to the LLVM `FileCheck` binary, located via `$FILECHECK`, then
+`$LLVM_BINDIR/FileCheck`, then `FileCheck` on `PATH`. If none resolves, those
+tests raise and their half-run leaves a Module alive, so the autouse leak
+fixture then reports `Module object(s) leaked past the test` — a confusing
+cascade whose real cause is the missing binary, not a leak or the code under
+test. Point the run at the wheel's tools when FileCheck is not on `PATH`:
+
+```
+LLVM_BINDIR="$PWD/../../mlir_wheel/bin" python -m pytest tests/ -p no:cacheprovider --no-cov
+```
+
+`scripts/cpp_coverage.sh` already exports `LLVM_BINDIR`, so the coverage gate
+runs the suite correctly; a bare `pytest tests/` does not.
+
 ## Tests: leak checking
 
 `llvm.testing.assert_no_leaks()` already runs `gc.collect()` before it checks

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -407,6 +407,70 @@ obj = mmi.emit_object(scheduler="mysched")   # runs MySched as the pre-RA schedu
 For the common case, subclass `mir.ReadyQueueStrategy` and override only
 `pick(ready)`.
 
+### Python-driven register allocation
+
+`mir.RegAllocBase` is `llvm::RegAllocBase` — the register-allocation driver and
+interface — subclassable from Python. The one required override is
+`select_or_split(li)`: for each unassigned live interval, return a physical
+register id, or return `None` after handling it yourself (spill or split, which
+append new virtual registers that get re-enqueued). The allocator queries and
+mutates state through `self`: `allocation_order(li)` (physregs to try, in target
+order), `self.matrix` (`is_free`/`check_interference`/`assign`/`unassign`),
+`self.lis` (LiveIntervals: `instruction_index`, `mbb_start_index`,
+`mbb_end_index`, `has_interval`, `interval`), `self.vrm`, and
+`self.machine_function`. Optional overrides: `enqueue(li)`/`dequeue()` (drive the
+assignment order; the default is a spill-weight priority queue),
+`post_optimization()`, and `about_to_remove_interval(li)`.
+
+Register a subclass under a name and select it per emission. For the trivial
+first-free-or-spill allocator, use the built-in `mir.BasicRegAlloc`:
+
+```python
+class FirstFree(mir.RegAllocBase):
+    def select_or_split(self, li):
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)        # append spill-code vregs; they get re-enqueued
+        return None
+
+mir.register_regalloc("first-free", FirstFree)
+obj = mmi.emit_object(regalloc="first-free")   # drives FirstFree instead of greedy
+```
+
+For RAGreedy-style live-range splitting, `self.split_analysis` (a
+`SplitAnalysis`: `analyze(li)`, `use_blocks()`, `num_through_blocks()`,
+`through_blocks()`, `last_split_point(mbb)`) plans the split and
+`self.split_editor` (a `SplitEditor`: `reset`, `open_intv`, `enter_intv_*`,
+`use_intv`/`use_intv_mbb`, `leave_intv_*`, `overlap_intv`, `finish`) applies it,
+writing into `self.new_live_range_edit(li)`:
+
+```python
+class RegionSplit(mir.RegAllocBase):
+    def select_or_split(self, li):
+        sa = self.split_analysis
+        sa.analyze(li)
+        if sa.num_through_blocks() > 0:                 # live across a block: split it out
+            se = self.split_editor
+            se.reset(self.new_live_range_edit(li))
+            se.open_intv()
+            bi = [b for b in sa.use_blocks() if not b.live_out][-1]
+            start = se.enter_intv_before(bi.first_instr)
+            se.use_intv(start, se.leave_intv_after(bi.last_instr))
+            se.finish()                                 # new vregs re-enqueued
+            return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+```
+
+A fresh allocator instance is constructed per `MachineFunction`. Because this
+build has assertions enabled, an invalid split aborts with a diagnostic rather
+than emitting bad code, and an exception raised in any override propagates out
+of `emit_object`.
+
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -418,9 +418,11 @@ mutates state through `self`: `allocation_order(li)` (physregs to try, in target
 order), `self.matrix` (`is_free`/`check_interference`/`assign`/`unassign`),
 `self.lis` (LiveIntervals: `instruction_index`, `mbb_start_index`,
 `mbb_end_index`, `has_interval`, `interval`), `self.vrm`, and
-`self.machine_function`. Optional overrides: `enqueue(li)`/`dequeue()` (drive the
-assignment order; the default is a spill-weight priority queue),
-`post_optimization()`, and `about_to_remove_interval(li)`.
+`self.machine_function`. Optional overrides: `enqueue(reg)`/`dequeue()` (drive
+the assignment order; both traffic in register ids -- stable across splitting,
+unlike interval objects -- and `dequeue` returns a reg id or `None`; the default
+is a spill-weight priority queue), `post_optimization()`, and
+`about_to_remove_interval(li)`.
 
 Register a subclass under a name and select it per emission. For the trivial
 first-free-or-spill allocator, use the built-in `mir.BasicRegAlloc`:

--- a/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
+++ b/projects/eudsl-llvmpy/scripts/cpp_coverage.sh
@@ -72,4 +72,5 @@ echo ">> checking src/IR + src/MIR coverage (threshold=${THRESHOLD}%)"
   --profdata "${COV_DIR}/eudslllvm.profdata" \
   --objects "$SO" \
   --sources "${PROJ_DIR}/src/IR" "${PROJ_DIR}/src/MIR" \
+  --ignore-filename-regex 'src/MIR/(RegAllocBase|AllocationOrder|SplitKit)\.h$' \
   --threshold="${THRESHOLD}"

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -18,6 +18,7 @@
 #include <llvm/CodeGen/MachineOperand.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/RegAllocRegistry.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
 #include <llvm/CodeGen/TargetPassConfig.h>
@@ -61,6 +62,14 @@ nb::type_object schedulerClass(const std::string &name);
 llvm::MachineSchedRegistry::ScheduleDAGCtor registeredSchedCtor();
 void setActiveSchedClass(nb::type_object cls);
 void clearActiveSchedClass();
+
+// The regalloc analogues: the RegAllocBase subclass registered under a name,
+// the shared harness-pass ctor emit_object points the -regalloc option at, and
+// install/clear the per-thread active class the harness reads while it runs.
+nb::type_object regallocClass(const std::string &name);
+llvm::RegisterRegAlloc::FunctionPassCtor registeredRegAllocCtor();
+void setActiveRegAllocClass(nb::type_object cls);
+void clearActiveRegAllocClass();
 } // namespace eudsl
 
 // Defined in PythonCodegen.cpp.
@@ -368,7 +377,8 @@ public:
   // BuildOwned is consumed into an EmittedOwned, so "build-path only" and the
   // one-shot are enforced by the variant's active alternative rather than a
   // pair of runtime flags.
-  nb::bytes emitObject(std::optional<std::string> scheduler) {
+  nb::bytes emitObject(std::optional<std::string> scheduler,
+                       std::optional<std::string> regalloc) {
     if (std::holds_alternative<EmittedOwned>(state_))
       throw std::runtime_error("object already emitted");
     BuildOwned *build = std::get_if<BuildOwned>(&state_);
@@ -386,6 +396,15 @@ public:
       if (!schedClass.is_valid())
         throw std::runtime_error("unknown scheduler: " + *scheduler);
       schedCtor = eudsl::registeredSchedCtor();
+    }
+
+    llvm::RegisterRegAlloc::FunctionPassCtor regAllocCtor = nullptr;
+    nb::type_object regAllocClass;
+    if (regalloc) {
+      regAllocClass = eudsl::regallocClass(*regalloc);
+      if (!regAllocClass.is_valid())
+        throw std::runtime_error("unknown regalloc: " + *regalloc);
+      regAllocCtor = eudsl::registeredRegAllocCtor();
     }
 
     // Verify the hand-built MIR up front so malformed input (the prior PRs'
@@ -461,6 +480,39 @@ public:
       misched = schedCtor;
       eudsl::setActiveSchedClass(schedClass);
       restoreActiveClass.active = true;
+    }
+
+    using RACtor = llvm::RegisterRegAlloc::FunctionPassCtor;
+    using RAOpt =
+        llvm::cl::opt<RACtor, false,
+                      llvm::RegisterPassParser<llvm::RegisterRegAlloc>>;
+    struct RestoreRegAlloc {
+      RAOpt *opt = nullptr;
+      RACtor value = nullptr;
+      ~RestoreRegAlloc() {
+        if (opt)
+          *opt = value;
+      }
+    } restoreRegAlloc;
+    struct RestoreActiveRegAllocClass {
+      bool active = false;
+      ~RestoreActiveRegAllocClass() {
+        if (active)
+          eudsl::clearActiveRegAllocClass();
+      }
+    } restoreActiveRegAllocClass;
+    if (regAllocCtor) {
+      auto regallocIt = opts.find("regalloc");
+      // LCOV_EXCL_START -- regalloc is always registered by codegen
+      if (regallocIt == opts.end())
+        throw std::runtime_error("the -regalloc option is not registered");
+      // LCOV_EXCL_STOP
+      auto &regallocOpt = *static_cast<RAOpt *>(regallocIt->second);
+      restoreRegAlloc.opt = &regallocOpt;
+      restoreRegAlloc.value = regallocOpt;
+      regallocOpt = regAllocCtor;
+      eudsl::setActiveRegAllocClass(regAllocClass);
+      restoreActiveRegAllocClass.active = true;
     }
 
     // Write straight into a SmallVector (raw_svector_ostream writes through, so
@@ -1275,12 +1327,17 @@ void populate_mir(nb::module_ &m) {
            "text.")
       .def(
           "emit_object", &MirModule::emitObject, "scheduler"_a = nb::none(),
+          "regalloc"_a = nb::none(),
           "Emit a relocatable object file for the built (already-selected) "
           "MIR by running the back half of codegen (regalloc, emission). "
           "Verifies the MIR first, raising if it is malformed. When "
           "`scheduler` names a registered MachineSchedStrategy (see "
           "register_scheduler), the pre-RA MachineScheduler runs it instead of "
-          "the target default; an unregistered name raises.");
+          "the target default; an unregistered name raises. When `regalloc` "
+          "names a registered RegAllocBase subclass (see register_regalloc), "
+          "it "
+          "drives register allocation instead of the target default; an "
+          "unregistered name raises.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -486,12 +486,19 @@ public:
     using RAOpt =
         llvm::cl::opt<RACtor, false,
                       llvm::RegisterPassParser<llvm::RegisterRegAlloc>>;
+    // createRegAllocPass reads RegisterRegAlloc::getDefault(), which the
+    // codegen pipeline caches process-globally via call_once the first time it
+    // runs -- the -regalloc cl::opt is only that cache's seed. So override
+    // getDefault() directly (the cl::opt is ignored once cached) and restore
+    // it, falling back to the cl::opt's value (the useDefaultRegisterAllocator
+    // sentinel) when nothing has seeded it yet, so a later default run never
+    // dereferences a null ctor.
     struct RestoreRegAlloc {
-      RAOpt *opt = nullptr;
+      bool active = false;
       RACtor value = nullptr;
       ~RestoreRegAlloc() {
-        if (opt)
-          *opt = value;
+        if (active)
+          llvm::RegisterRegAlloc::setDefault(value);
       }
     } restoreRegAlloc;
     struct RestoreActiveRegAllocClass {
@@ -502,15 +509,19 @@ public:
       }
     } restoreActiveRegAllocClass;
     if (regAllocCtor) {
-      auto regallocIt = opts.find("regalloc");
-      // LCOV_EXCL_START -- regalloc is always registered by codegen
-      if (regallocIt == opts.end())
-        throw std::runtime_error("the -regalloc option is not registered");
+      RACtor prev = llvm::RegisterRegAlloc::getDefault();
+      // LCOV_EXCL_START -- getDefault() is null only when no codegen pipeline
+      // has run yet in the process; the suite always emits before this point.
+      if (!prev) {
+        auto regallocIt = opts.find("regalloc");
+        if (regallocIt == opts.end())
+          throw std::runtime_error("the -regalloc option is not registered");
+        prev = *static_cast<RAOpt *>(regallocIt->second);
+      }
       // LCOV_EXCL_STOP
-      auto &regallocOpt = *static_cast<RAOpt *>(regallocIt->second);
-      restoreRegAlloc.opt = &regallocOpt;
-      restoreRegAlloc.value = regallocOpt;
-      regallocOpt = regAllocCtor;
+      restoreRegAlloc.value = prev;
+      restoreRegAlloc.active = true;
+      llvm::RegisterRegAlloc::setDefault(regAllocCtor);
       eudsl::setActiveRegAllocClass(regAllocClass);
       restoreActiveRegAllocClass.active = true;
     }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -8,7 +8,10 @@
 #include "MIR/RegAllocBase.h"
 #include "MIR/SplitKit.h"
 
+#include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/ProfileSummaryInfo.h>
 #include <llvm/CodeGen/CalcSpillWeights.h>
+#include <llvm/CodeGen/LiveDebugVariables.h>
 #include <llvm/CodeGen/LiveInterval.h>
 #include <llvm/CodeGen/LiveIntervals.h>
 #include <llvm/CodeGen/LiveRangeEdit.h>
@@ -28,6 +31,7 @@
 #include <llvm/CodeGen/SlotIndexes.h>
 #include <llvm/CodeGen/Spiller.h>
 #include <llvm/CodeGen/VirtRegMap.h>
+#include <llvm/PassRegistry.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>
@@ -311,52 +315,26 @@ createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
   }
 }
 
-// Trampoline letting Python subclass llvm::RegAllocBase. RegAllocBase is a
-// driver mixed into a MachineFunctionPass: its state (VRM/LIS/Matrix/...) and
-// the init()/allocatePhysRegs() driver are protected, so the harness pass
-// reaches them through the public py* wrappers below rather than owning an
-// adaptor (there is no unique_ptr sink to satisfy, unlike the scheduler).
-class PyRegAllocBase : public llvm::RegAllocBase {
+// A complete pure-C++ RegAllocBase: first-free-or-spill over the target
+// allocation order, driven by a spill-weight priority queue. It is both the
+// base for the Python trampoline (supplying the fallback each virtual defers
+// to) and the standalone allocator the harness runs when a Python __init__
+// raises, so the emitted MIR stays valid and the stashed exception can
+// re-raise.
+class NativeRegAlloc : public llvm::RegAllocBase {
 public:
-  NB_TRAMPOLINE(llvm::RegAllocBase, 6);
-
   // spiller() is pure and dereferenced by allocatePhysRegs; the harness injects
   // the concrete Spiller before driving, so this is never called with null.
   llvm::Spiller &spiller() override { return *injectedSpiller; }
 
-  // Always mirror the register into the native priority queue so the fallback
-  // set stays complete even when Python drives dequeue itself; then forward to
-  // an optional Python enqueue.
   void enqueueImpl(const llvm::LiveInterval *li) override {
     nativeQueue.push({li->weight(), li->reg()});
-    nb::gil_scoped_acquire gil;
-    nb::handle self = nb_trampoline.base();
-    if (eudsl::pendingCodegenError || !nb::hasattr(self, "enqueue"))
-      return;
-    try {
-      self.attr("enqueue")(nb::cast(const_cast<llvm::LiveInterval *>(li),
-                                    nb::rv_policy::reference));
-    } catch (...) {
-      eudsl::pendingCodegenError = std::current_exception();
-    }
   }
 
   const llvm::LiveInterval *dequeue() override {
-    nb::gil_scoped_acquire gil;
-    nb::handle self = nb_trampoline.base();
-    if (!eudsl::pendingCodegenError && nb::hasattr(self, "dequeue")) {
-      try {
-        nb::object choice = self.attr("dequeue")();
-        if (choice.is_none())
-          return nullptr;
-        return nb::cast<llvm::LiveInterval *>(choice);
-      } catch (...) {
-        eudsl::pendingCodegenError = std::current_exception();
-      }
-    }
-    // Native drain (default queue, or winding down after a stash): the queue
-    // holds (weight, reg) rather than pointers because splitting recreates
-    // intervals, so re-fetch and skip registers already assigned or gone.
+    // The queue holds (weight, reg) rather than pointers because splitting
+    // recreates intervals, so re-fetch and skip registers already assigned or
+    // gone (the spiller coalesces snippets).
     while (!nativeQueue.empty()) {
       QueueEntry e = nativeQueue.top();
       nativeQueue.pop();
@@ -370,57 +348,16 @@ public:
   llvm::MCRegister
   selectOrSplit(const llvm::LiveInterval &vreg,
                 llvm::SmallVectorImpl<llvm::Register> &splitLVRs) override {
-    currentSplit = &splitLVRs;
-    nb::gil_scoped_acquire gil;
-    if (!eudsl::pendingCodegenError) {
-      try {
-        nb::object r = nb_trampoline.base().attr("select_or_split")(nb::cast(
-            const_cast<llvm::LiveInterval *>(&vreg), nb::rv_policy::reference));
-        currentSplit = nullptr;
-        // None means Python handled it (spill/split appended new vregs); an int
-        // is the chosen physreg for the driver to assign.
-        if (r.is_none())
-          return llvm::MCRegister();
-        return llvm::MCRegister(nb::cast<unsigned>(r));
-      } catch (...) {
-        eudsl::pendingCodegenError = std::current_exception();
-      }
+    auto order =
+        llvm::AllocationOrder::create(vreg.reg(), *VRM, RegClassInfo, Matrix);
+    for (llvm::MCRegister phys : order) {
+      if (Matrix->checkInterference(vreg, phys) == llvm::LiveRegMatrix::IK_Free)
+        return phys;
     }
-    llvm::MCRegister phys = nativeSelectOrSplit(vreg, splitLVRs);
-    currentSplit = nullptr;
-    return phys;
-  }
-
-  void postOptimization() override {
-    nb::gil_scoped_acquire gil;
-    nb::handle self = nb_trampoline.base();
-    if (!eudsl::pendingCodegenError && nb::hasattr(self, "post_optimization")) {
-      try {
-        self.attr("post_optimization")();
-        return;
-      } catch (...) {
-        eudsl::pendingCodegenError = std::current_exception();
-      }
-    }
-    // No override, or winding down after a stash: run the base cleanup (spiller
-    // post-optimize + dead-remat removal) so the emitted MIR stays valid.
-    llvm::RegAllocBase::postOptimization();
-  }
-
-  // Called by allocatePhysRegs before it drops an interval the spiller left
-  // unused; forwarded to an optional Python about_to_remove_interval.
-  void aboutToRemoveInterval(const llvm::LiveInterval &li) override {
-    nb::gil_scoped_acquire gil;
-    nb::handle self = nb_trampoline.base();
-    if (eudsl::pendingCodegenError ||
-        !nb::hasattr(self, "about_to_remove_interval"))
-      return;
-    try {
-      self.attr("about_to_remove_interval")(nb::cast(
-          const_cast<llvm::LiveInterval *>(&li), nb::rv_policy::reference));
-    } catch (...) {
-      eudsl::pendingCodegenError = std::current_exception();
-    }
+    llvm::LiveRangeEdit lre(&vreg, splitLVRs, *mf, *LIS, VRM,
+                            /*delegate=*/nullptr, &DeadRemats);
+    injectedSpiller->spill(lre);
+    return llvm::MCRegister();
   }
 
   // Public wrappers the harness pass uses to reach the protected driver.
@@ -464,24 +401,7 @@ public:
 
   llvm::Spiller *injectedSpiller = nullptr;
 
-private:
-  // First-free-or-spill over the target allocation order; the only fallback
-  // once Python has raised, so it must always make forward progress.
-  llvm::MCRegister
-  nativeSelectOrSplit(const llvm::LiveInterval &vreg,
-                      llvm::SmallVectorImpl<llvm::Register> &splitLVRs) {
-    auto order =
-        llvm::AllocationOrder::create(vreg.reg(), *VRM, RegClassInfo, Matrix);
-    for (llvm::MCRegister phys : order) {
-      if (Matrix->checkInterference(vreg, phys) == llvm::LiveRegMatrix::IK_Free)
-        return phys;
-    }
-    llvm::LiveRangeEdit lre(&vreg, splitLVRs, *mf, *LIS, VRM,
-                            /*delegate=*/nullptr, &DeadRemats);
-    injectedSpiller->spill(lre);
-    return llvm::MCRegister();
-  }
-
+protected:
   struct QueueEntry {
     float weight;
     llvm::Register reg;
@@ -502,6 +422,104 @@ private:
   llvm::MachineFunction *mf = nullptr;
   llvm::SplitAnalysis *splitAnalysis = nullptr;
   llvm::SplitEditor *splitEditor = nullptr;
+};
+
+// Trampoline letting Python subclass the allocator. Each virtual calls the
+// Python override under the GIL and stashes on raise; when no override exists
+// or the run is already winding down after a stash, it defers to the
+// NativeRegAlloc base (which always makes forward progress), so the pipeline
+// reaches runCodegenPipeline's re-raise with valid MIR.
+class PyRegAllocBase : public NativeRegAlloc {
+public:
+  NB_TRAMPOLINE(NativeRegAlloc, 6);
+
+  // Keep the native fallback queue complete, then forward to an optional
+  // Python enqueue.
+  void enqueueImpl(const llvm::LiveInterval *li) override {
+    NativeRegAlloc::enqueueImpl(li);
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError || !nb::hasattr(self, "enqueue"))
+      return;
+    try {
+      self.attr("enqueue")(nb::cast(const_cast<llvm::LiveInterval *>(li),
+                                    nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  const llvm::LiveInterval *dequeue() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (!eudsl::pendingCodegenError && nb::hasattr(self, "dequeue")) {
+      try {
+        nb::object choice = self.attr("dequeue")();
+        if (choice.is_none())
+          return nullptr;
+        return nb::cast<llvm::LiveInterval *>(choice);
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    return NativeRegAlloc::dequeue();
+  }
+
+  llvm::MCRegister
+  selectOrSplit(const llvm::LiveInterval &vreg,
+                llvm::SmallVectorImpl<llvm::Register> &splitLVRs) override {
+    currentSplit = &splitLVRs;
+    nb::gil_scoped_acquire gil;
+    if (!eudsl::pendingCodegenError) {
+      try {
+        nb::object r = nb_trampoline.base().attr("select_or_split")(nb::cast(
+            const_cast<llvm::LiveInterval *>(&vreg), nb::rv_policy::reference));
+        currentSplit = nullptr;
+        // None means Python handled it (spill/split appended new vregs); an int
+        // is the chosen physreg for the driver to assign.
+        if (r.is_none())
+          return llvm::MCRegister();
+        return llvm::MCRegister(nb::cast<unsigned>(r));
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    llvm::MCRegister phys = NativeRegAlloc::selectOrSplit(vreg, splitLVRs);
+    currentSplit = nullptr;
+    return phys;
+  }
+
+  void postOptimization() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (!eudsl::pendingCodegenError && nb::hasattr(self, "post_optimization")) {
+      try {
+        self.attr("post_optimization")();
+        return;
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    // No override, or winding down after a stash: run the base cleanup (spiller
+    // post-optimize + dead-remat removal) so the emitted MIR stays valid.
+    llvm::RegAllocBase::postOptimization();
+  }
+
+  // Called by allocatePhysRegs before it drops an interval the spiller left
+  // unused; forwarded to an optional Python about_to_remove_interval.
+  void aboutToRemoveInterval(const llvm::LiveInterval &li) override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError ||
+        !nb::hasattr(self, "about_to_remove_interval"))
+      return;
+    try {
+      self.attr("about_to_remove_interval")(nb::cast(
+          const_cast<llvm::LiveInterval *>(&li), nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
 };
 
 // name -> Python RegAllocBase subclass, held in
@@ -536,7 +554,155 @@ void registerRegAlloc(const std::string &name,
   classes[name.c_str()] = cls;
 }
 
+// The fixed C++ MachineFunctionPass that hosts the Python allocator. It
+// occupies the register-allocator slot in the codegen pipeline (selected via
+// the -regalloc option), fetches the analyses a RegAllocBase driver needs,
+// builds the spiller + SplitAnalysis/SplitEditor, constructs a fresh Python
+// allocator per MachineFunction, and drives it through the public
+// pyInit/pyAllocate wrappers. Analysis wiring mirrors RABasic (the minimal
+// RegAllocBase user); the SplitAnalysis/SplitEditor it injects give Python the
+// greedy-style splitting primitives without RAGreedy's extra pass dependencies.
+class PyRegAllocDriver : public llvm::MachineFunctionPass {
+public:
+  static char ID;
+  PyRegAllocDriver() : llvm::MachineFunctionPass(ID) {}
+
+  ~PyRegAllocDriver() override {
+    if (heldInstance.is_valid()) {
+      nb::gil_scoped_acquire gil;
+      heldInstance.reset();
+    }
+  }
+
+  llvm::StringRef getPassName() const override {
+    return "eudsl Python register allocator";
+  }
+
+  void getAnalysisUsage(llvm::AnalysisUsage &au) const override {
+    au.setPreservesCFG();
+    au.addRequired<llvm::AAResultsWrapperPass>();
+    au.addPreserved<llvm::AAResultsWrapperPass>();
+    au.addRequired<llvm::LiveIntervalsWrapperPass>();
+    au.addPreserved<llvm::LiveIntervalsWrapperPass>();
+    au.addPreserved<llvm::SlotIndexesWrapperPass>();
+    au.addRequired<llvm::LiveDebugVariablesWrapperLegacy>();
+    au.addPreserved<llvm::LiveDebugVariablesWrapperLegacy>();
+    au.addRequired<llvm::LiveStacksWrapperLegacy>();
+    au.addPreserved<llvm::LiveStacksWrapperLegacy>();
+    au.addRequired<llvm::ProfileSummaryInfoWrapperPass>();
+    au.addRequired<llvm::MachineBlockFrequencyInfoWrapperPass>();
+    au.addRequired<llvm::MachineDominatorTreeWrapperPass>();
+    au.addRequiredID(llvm::MachineDominatorsID);
+    au.addRequired<llvm::MachineLoopInfoWrapperPass>();
+    au.addRequired<llvm::VirtRegMapWrapperLegacy>();
+    au.addPreserved<llvm::VirtRegMapWrapperLegacy>();
+    au.addRequired<llvm::LiveRegMatrixWrapperLegacy>();
+    au.addPreserved<llvm::LiveRegMatrixWrapperLegacy>();
+    llvm::MachineFunctionPass::getAnalysisUsage(au);
+  }
+
+  llvm::MachineFunctionProperties getRequiredProperties() const override {
+    return llvm::MachineFunctionProperties().set(
+        llvm::MachineFunctionProperties::Property::NoPHIs);
+  }
+
+  bool runOnMachineFunction(llvm::MachineFunction &mfn) override {
+    llvm::VirtRegMap &vrm =
+        getAnalysis<llvm::VirtRegMapWrapperLegacy>().getVRM();
+    llvm::LiveIntervals &lis =
+        getAnalysis<llvm::LiveIntervalsWrapperPass>().getLIS();
+    llvm::LiveRegMatrix &mat =
+        getAnalysis<llvm::LiveRegMatrixWrapperLegacy>().getLRM();
+    llvm::MachineBlockFrequencyInfo &mbfi =
+        getAnalysis<llvm::MachineBlockFrequencyInfoWrapperPass>().getMBFI();
+    llvm::LiveStacks &livestks =
+        getAnalysis<llvm::LiveStacksWrapperLegacy>().getLS();
+    llvm::MachineDominatorTree &mdt =
+        getAnalysis<llvm::MachineDominatorTreeWrapperPass>().getDomTree();
+    llvm::MachineLoopInfo &loops =
+        getAnalysis<llvm::MachineLoopInfoWrapperPass>().getLI();
+    llvm::ProfileSummaryInfo &psi =
+        getAnalysis<llvm::ProfileSummaryInfoWrapperPass>().getPSI();
+
+    nb::gil_scoped_acquire gil;
+    // LCOV_EXCL_START -- emit_object always sets the active class before
+    // running
+    if (!activeRegAllocClass.is_valid())
+      return false;
+    // LCOV_EXCL_STOP
+
+    // Analyses shared by whichever allocator drives this function.
+    llvm::VirtRegAuxInfo vrai(mfn, lis, vrm, loops, mbfi, &psi);
+    vrai.calculateSpillWeightsAndHints();
+    std::unique_ptr<llvm::Spiller> spiller(
+        llvm::createInlineSpiller({lis, livestks, mdt, mbfi}, mfn, vrm, vrai));
+    llvm::SplitAnalysis sa(vrm, lis, loops);
+    llvm::SplitEditor se(sa, lis, vrm, mdt, mbfi, vrai);
+
+    nb::object obj;
+    try {
+      obj = activeRegAllocClass();
+    } catch (...) {
+      // The subclass __init__ raised. Stash it and allocate natively so the MIR
+      // is valid and the pipeline reaches runCodegenPipeline's re-raise instead
+      // of aborting the rewriter on unallocated vregs.
+      eudsl::pendingCodegenError = std::current_exception();
+      NativeRegAlloc fallback;
+      fallback.pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se);
+      fallback.pyAllocate();
+      return true;
+    }
+    auto *base =
+        static_cast<PyRegAllocBase *>(nb::inst_ptr<PyRegAllocBase>(obj));
+    base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se);
+    base->pyAllocate();
+    // Hold the instance until the pass is destroyed so its C++ subobject (and
+    // any Python-recorded witness state) outlives this call; dropped under the
+    // GIL in the dtor.
+    heldInstance = std::move(obj);
+    return true;
+  }
+
+private:
+  nb::object heldInstance;
+};
+
+// The ctor every registered name shares; emit_object points the -regalloc
+// option at it (as it does -misched for the scheduler) and sets
+// activeRegAllocClass so this knows which subclass to instantiate.
+llvm::FunctionPass *createRegisteredPyRegAlloc() {
+  return new PyRegAllocDriver();
+}
+
 } // namespace
+
+// Declared here (rather than InitializePasses.h) since this pass lives in-tree;
+// the INITIALIZE_PASS block below defines it.
+namespace llvm {
+void initializePyRegAllocDriverPass(PassRegistry &);
+} // namespace llvm
+
+char PyRegAllocDriver::ID = 0;
+
+// INITIALIZE_PASS expands to unqualified PassRegistry/PassInfo/callDefaultCtor
+// (LLVM's macros assume an in-scope llvm namespace).
+using namespace llvm;
+
+INITIALIZE_PASS_BEGIN(PyRegAllocDriver, "eudsl-python-regalloc",
+                      "eudsl Python register allocator", false, false)
+INITIALIZE_PASS_DEPENDENCY(LiveDebugVariablesWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(SlotIndexesWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(LiveIntervalsWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(LiveStacksWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(AAResultsWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfoWrapperPass)
+INITIALIZE_PASS_END(PyRegAllocDriver, "eudsl-python-regalloc",
+                    "eudsl Python register allocator", false, false)
 
 namespace eudsl {
 
@@ -599,6 +765,12 @@ void setActiveRegAllocClass(nb::type_object cls) {
 }
 void clearActiveRegAllocClass() { activeRegAllocClass = nb::type_object(); }
 
+// The ctor emit_object points the -regalloc option at, mirroring
+// registeredSchedCtor for -misched.
+llvm::RegisterRegAlloc::FunctionPassCtor registeredRegAllocCtor() {
+  return createRegisteredPyRegAlloc;
+}
+
 } // namespace eudsl
 
 void populate_python_codegen(nb::module_ &m) {
@@ -653,6 +825,10 @@ void populate_python_codegen(nb::module_ &m) {
       },
       "Names registered via register_scheduler, selectable with "
       "emit_object(scheduler=...).");
+
+  // Register the harness pass (and its analysis dependencies) so the legacy
+  // PassManager can resolve them when the pipeline runs the allocator slot.
+  llvm::initializePyRegAllocDriverPass(*llvm::PassRegistry::getPassRegistry());
 
   nb::class_<PyRegAllocBase>(m, "RegAllocBase")
       .def(nb::init<>())

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -323,15 +323,185 @@ public:
   // spiller() is pure and dereferenced by allocatePhysRegs; the harness injects
   // the concrete Spiller before driving, so this is never called with null.
   llvm::Spiller &spiller() override { return *injectedSpiller; }
-  void enqueueImpl(const llvm::LiveInterval *) override {}
-  const llvm::LiveInterval *dequeue() override { return nullptr; }
+
+  // Always mirror the register into the native priority queue so the fallback
+  // set stays complete even when Python drives dequeue itself; then forward to
+  // an optional Python enqueue.
+  void enqueueImpl(const llvm::LiveInterval *li) override {
+    nativeQueue.push({li->weight(), li->reg()});
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError || !nb::hasattr(self, "enqueue"))
+      return;
+    try {
+      self.attr("enqueue")(nb::cast(const_cast<llvm::LiveInterval *>(li),
+                                    nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  const llvm::LiveInterval *dequeue() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (!eudsl::pendingCodegenError && nb::hasattr(self, "dequeue")) {
+      try {
+        nb::object choice = self.attr("dequeue")();
+        if (choice.is_none())
+          return nullptr;
+        return nb::cast<llvm::LiveInterval *>(choice);
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    // Native drain (default queue, or winding down after a stash): the queue
+    // holds (weight, reg) rather than pointers because splitting recreates
+    // intervals, so re-fetch and skip registers already assigned or gone.
+    while (!nativeQueue.empty()) {
+      QueueEntry e = nativeQueue.top();
+      nativeQueue.pop();
+      if (VRM->hasPhys(e.reg) || !LIS->hasInterval(e.reg))
+        continue;
+      return &LIS->getInterval(e.reg);
+    }
+    return nullptr;
+  }
+
   llvm::MCRegister
-  selectOrSplit(const llvm::LiveInterval &,
-                llvm::SmallVectorImpl<llvm::Register> &) override {
-    return llvm::MCRegister();
+  selectOrSplit(const llvm::LiveInterval &vreg,
+                llvm::SmallVectorImpl<llvm::Register> &splitLVRs) override {
+    currentSplit = &splitLVRs;
+    nb::gil_scoped_acquire gil;
+    if (!eudsl::pendingCodegenError) {
+      try {
+        nb::object r = nb_trampoline.base().attr("select_or_split")(nb::cast(
+            const_cast<llvm::LiveInterval *>(&vreg), nb::rv_policy::reference));
+        currentSplit = nullptr;
+        // None means Python handled it (spill/split appended new vregs); an int
+        // is the chosen physreg for the driver to assign.
+        if (r.is_none())
+          return llvm::MCRegister();
+        return llvm::MCRegister(nb::cast<unsigned>(r));
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    llvm::MCRegister phys = nativeSelectOrSplit(vreg, splitLVRs);
+    currentSplit = nullptr;
+    return phys;
+  }
+
+  void postOptimization() override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (!eudsl::pendingCodegenError && nb::hasattr(self, "post_optimization")) {
+      try {
+        self.attr("post_optimization")();
+        return;
+      } catch (...) {
+        eudsl::pendingCodegenError = std::current_exception();
+      }
+    }
+    // No override, or winding down after a stash: run the base cleanup (spiller
+    // post-optimize + dead-remat removal) so the emitted MIR stays valid.
+    llvm::RegAllocBase::postOptimization();
+  }
+
+  // Called by allocatePhysRegs before it drops an interval the spiller left
+  // unused; forwarded to an optional Python about_to_remove_interval.
+  void aboutToRemoveInterval(const llvm::LiveInterval &li) override {
+    nb::gil_scoped_acquire gil;
+    nb::handle self = nb_trampoline.base();
+    if (eudsl::pendingCodegenError ||
+        !nb::hasattr(self, "about_to_remove_interval"))
+      return;
+    try {
+      self.attr("about_to_remove_interval")(nb::cast(
+          const_cast<llvm::LiveInterval *>(&li), nb::rv_policy::reference));
+    } catch (...) {
+      eudsl::pendingCodegenError = std::current_exception();
+    }
+  }
+
+  // Public wrappers the harness pass uses to reach the protected driver.
+  void pyInit(llvm::VirtRegMap &vrm, llvm::LiveIntervals &lis,
+              llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
+              llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
+              llvm::SplitEditor *se) {
+    injectedSpiller = &sp;
+    mf = &mfn;
+    splitAnalysis = sa;
+    splitEditor = se;
+    init(vrm, lis, mat);
+  }
+  void pyAllocate() {
+    allocatePhysRegs();
+    postOptimization();
+  }
+
+  // Protected RegAllocBase state, surfaced to the Python helpers.
+  llvm::LiveRegMatrix *matrix() { return Matrix; }
+  llvm::LiveIntervals *intervals() { return LIS; }
+  llvm::VirtRegMap *virtRegMap() { return VRM; }
+  llvm::MachineFunction *machineFunction() { return mf; }
+
+  // Physregs, in target allocation order, that Python may try for `li`.
+  std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
+    auto order =
+        llvm::AllocationOrder::create(li.reg(), *VRM, RegClassInfo, Matrix);
+    std::vector<unsigned> ids;
+    for (llvm::MCRegister r : order)
+      ids.push_back(r.id());
+    return ids;
+  }
+
+  // Spill `li` into the current select_or_split's split-vreg vector.
+  void spill(const llvm::LiveInterval &li) {
+    llvm::LiveRangeEdit lre(&li, *currentSplit, *mf, *LIS, VRM,
+                            /*delegate=*/nullptr, &DeadRemats);
+    injectedSpiller->spill(lre);
   }
 
   llvm::Spiller *injectedSpiller = nullptr;
+
+private:
+  // First-free-or-spill over the target allocation order; the only fallback
+  // once Python has raised, so it must always make forward progress.
+  llvm::MCRegister
+  nativeSelectOrSplit(const llvm::LiveInterval &vreg,
+                      llvm::SmallVectorImpl<llvm::Register> &splitLVRs) {
+    auto order =
+        llvm::AllocationOrder::create(vreg.reg(), *VRM, RegClassInfo, Matrix);
+    for (llvm::MCRegister phys : order) {
+      if (Matrix->checkInterference(vreg, phys) == llvm::LiveRegMatrix::IK_Free)
+        return phys;
+    }
+    llvm::LiveRangeEdit lre(&vreg, splitLVRs, *mf, *LIS, VRM,
+                            /*delegate=*/nullptr, &DeadRemats);
+    injectedSpiller->spill(lre);
+    return llvm::MCRegister();
+  }
+
+  struct QueueEntry {
+    float weight;
+    llvm::Register reg;
+  };
+  // Highest spill weight first; break ties on the lower register id so the
+  // default order is deterministic.
+  struct QueueLess {
+    bool operator()(const QueueEntry &a, const QueueEntry &b) const {
+      if (a.weight != b.weight)
+        return a.weight < b.weight;
+      return a.reg.id() > b.reg.id();
+    }
+  };
+
+  std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueLess>
+      nativeQueue;
+  llvm::SmallVectorImpl<llvm::Register> *currentSplit = nullptr;
+  llvm::MachineFunction *mf = nullptr;
+  llvm::SplitAnalysis *splitAnalysis = nullptr;
+  llvm::SplitEditor *splitEditor = nullptr;
 };
 
 // name -> Python RegAllocBase subclass, held in
@@ -484,7 +654,29 @@ void populate_python_codegen(nb::module_ &m) {
       "Names registered via register_scheduler, selectable with "
       "emit_object(scheduler=...).");
 
-  nb::class_<PyRegAllocBase>(m, "RegAllocBase").def(nb::init<>());
+  nb::class_<PyRegAllocBase>(m, "RegAllocBase")
+      .def(nb::init<>())
+      .def("allocation_order", &PyRegAllocBase::allocationOrder, "li"_a,
+           "Physregs (as ids) to try for `li`, in target allocation order.")
+      .def("spill", &PyRegAllocBase::spill, "li"_a,
+           "Spill `li`; new split vregs are appended for re-enqueue.")
+      .def_prop_ro(
+          "matrix", [](PyRegAllocBase &self) { return self.matrix(); },
+          nb::rv_policy::reference_internal,
+          "The LiveRegMatrix for interference queries and assignment.")
+      .def_prop_ro(
+          "lis", [](PyRegAllocBase &self) { return self.intervals(); },
+          nb::rv_policy::reference_internal,
+          "The LiveIntervals analysis for this function.")
+      .def_prop_ro(
+          "vrm", [](PyRegAllocBase &self) { return self.virtRegMap(); },
+          nb::rv_policy::reference_internal,
+          "The VirtRegMap being populated with assignments.")
+      .def_prop_ro(
+          "machine_function",
+          [](PyRegAllocBase &self) { return self.machineFunction(); },
+          nb::rv_policy::reference_internal,
+          "The MachineFunction being allocated.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -382,6 +382,16 @@ public:
   llvm::VirtRegMap *virtRegMap() { return VRM; }
   llvm::MachineFunction *machineFunction() { return mf; }
   llvm::SplitAnalysis *splitAnalysisPtr() { return splitAnalysis; }
+  llvm::SplitEditor *splitEditorPtr() { return splitEditor; }
+
+  // Build a LiveRangeEdit over the current split-vreg vector for the split
+  // editor to write into. Held so it outlives the SplitEditor reset/open/use/
+  // finish calls that reference it (all within one select_or_split).
+  llvm::LiveRangeEdit *newLiveRangeEdit(const llvm::LiveInterval &li) {
+    heldEdit = std::make_unique<llvm::LiveRangeEdit>(
+        &li, *currentSplit, *mf, *LIS, VRM, /*delegate=*/nullptr, &DeadRemats);
+    return heldEdit.get();
+  }
 
   // Physregs, in target allocation order, that Python may try for `li`.
   std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
@@ -423,6 +433,7 @@ protected:
   llvm::MachineFunction *mf = nullptr;
   llvm::SplitAnalysis *splitAnalysis = nullptr;
   llvm::SplitEditor *splitEditor = nullptr;
+  std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
 
 // Trampoline letting Python subclass the allocator. Each virtual calls the
@@ -858,7 +869,20 @@ void populate_python_codegen(nb::module_ &m) {
           "split_analysis",
           [](PyRegAllocBase &self) { return self.splitAnalysisPtr(); },
           nb::rv_policy::reference_internal,
-          "The SplitAnalysis for planning live-range splits.");
+          "The SplitAnalysis for planning live-range splits.")
+      .def_prop_ro(
+          "split_editor",
+          [](PyRegAllocBase &self) { return self.splitEditorPtr(); },
+          nb::rv_policy::reference_internal,
+          "The SplitEditor for applying live-range splits.")
+      .def(
+          "new_live_range_edit",
+          [](PyRegAllocBase &self, const llvm::LiveInterval &li) {
+            return self.newLiveRangeEdit(li);
+          },
+          nb::rv_policy::reference_internal, "li"_a,
+          "A LiveRangeEdit over the current split-vreg vector, for "
+          "split_editor.reset.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
@@ -965,6 +989,59 @@ void populate_python_codegen(nb::module_ &m) {
           v.push_back(b);
         return v;
       });
+
+  // The edit buffer the split editor writes new vregs into.
+  nb::class_<llvm::LiveRangeEdit>(m, "LiveRangeEdit")
+      .def("new_vregs", [](llvm::LiveRangeEdit &e) {
+        std::vector<unsigned> v;
+        for (llvm::Register r : e.regs())
+          v.push_back(r.id());
+        return v;
+      });
+
+  nb::enum_<llvm::SplitEditor::ComplementSpillMode>(m, "ComplementSpillMode")
+      .value("SM_Partition", llvm::SplitEditor::SM_Partition)
+      .value("SM_Size", llvm::SplitEditor::SM_Size)
+      .value("SM_Speed", llvm::SplitEditor::SM_Speed);
+
+  // Raw live-range splitting primitives (RAGreedy uses these internally); a
+  // Python allocator drives them to open/enter/use/leave an interval and
+  // finish, producing new vregs for re-enqueue.
+  nb::class_<llvm::SplitEditor>(m, "SplitEditor")
+      .def("reset", &llvm::SplitEditor::reset, "live_range_edit"_a,
+           "mode"_a = llvm::SplitEditor::SM_Partition)
+      .def("open_intv", &llvm::SplitEditor::openIntv)
+      .def("select_intv", &llvm::SplitEditor::selectIntv, "idx"_a)
+      .def("enter_intv_before", &llvm::SplitEditor::enterIntvBefore, "idx"_a)
+      .def("enter_intv_after", &llvm::SplitEditor::enterIntvAfter, "idx"_a)
+      .def(
+          "enter_intv_at_end",
+          [](llvm::SplitEditor &s, llvm::MachineBasicBlock *mbb) {
+            return s.enterIntvAtEnd(*mbb);
+          },
+          "mbb"_a)
+      .def(
+          "use_intv",
+          [](llvm::SplitEditor &s, llvm::SlotIndex a, llvm::SlotIndex b) {
+            s.useIntv(a, b);
+          },
+          "start"_a, "end"_a)
+      .def(
+          "use_intv_mbb",
+          [](llvm::SplitEditor &s, llvm::MachineBasicBlock *mbb) {
+            s.useIntv(*mbb);
+          },
+          "mbb"_a)
+      .def("leave_intv_after", &llvm::SplitEditor::leaveIntvAfter, "idx"_a)
+      .def("leave_intv_before", &llvm::SplitEditor::leaveIntvBefore, "idx"_a)
+      .def(
+          "leave_intv_at_top",
+          [](llvm::SplitEditor &s, llvm::MachineBasicBlock *mbb) {
+            return s.leaveIntvAtTop(*mbb);
+          },
+          "mbb"_a)
+      .def("overlap_intv", &llvm::SplitEditor::overlapIntv, "start"_a, "end"_a)
+      .def("finish", [](llvm::SplitEditor &s) { s.finish(nullptr); });
 
   nb::enum_<llvm::LiveRegMatrix::InterferenceKind>(m, "InterferenceKind")
       .value("IK_Free", llvm::LiveRegMatrix::IK_Free)

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -867,7 +867,67 @@ void populate_python_codegen(nb::module_ &m) {
 
   nb::class_<llvm::VirtRegMap>(m, "VirtRegMap");
   nb::class_<llvm::Spiller>(m, "Spiller");
-  nb::class_<llvm::LiveIntervals>(m, "LiveIntervals");
+
+  // A program point. Live ranges and the split editor are expressed in terms of
+  // these; they order the instructions of a function.
+  nb::class_<llvm::SlotIndex>(m, "SlotIndex")
+      .def("is_valid", &llvm::SlotIndex::isValid)
+      .def(
+          "__lt__",
+          [](const llvm::SlotIndex &a, const llvm::SlotIndex &b) {
+            return a < b;
+          },
+          "other"_a)
+      .def(
+          "__eq__",
+          [](const llvm::SlotIndex &a, const llvm::SlotIndex &b) {
+            return a == b;
+          },
+          "other"_a)
+      .def("get_reg_slot",
+           [](const llvm::SlotIndex &i) { return i.getRegSlot(); })
+      .def("get_base_index",
+           [](const llvm::SlotIndex &i) { return i.getBaseIndex(); })
+      .def("get_boundary_index",
+           [](const llvm::SlotIndex &i) { return i.getBoundaryIndex(); })
+      .def("get_next_index",
+           [](const llvm::SlotIndex &i) { return i.getNextIndex(); })
+      .def("__repr__", [](const llvm::SlotIndex &i) {
+        return i.isValid() ? std::string("SlotIndex(valid)")
+                           : std::string("SlotIndex(invalid)");
+      });
+
+  nb::class_<llvm::LiveIntervals>(m, "LiveIntervals")
+      .def(
+          "instruction_index",
+          [](llvm::LiveIntervals &l, llvm::MachineInstr *mi) {
+            return l.getInstructionIndex(*mi);
+          },
+          "mi"_a)
+      .def(
+          "mbb_start_index",
+          [](llvm::LiveIntervals &l, llvm::MachineBasicBlock *mbb) {
+            return l.getMBBStartIdx(mbb);
+          },
+          "mbb"_a)
+      .def(
+          "mbb_end_index",
+          [](llvm::LiveIntervals &l, llvm::MachineBasicBlock *mbb) {
+            return l.getMBBEndIdx(mbb);
+          },
+          "mbb"_a)
+      .def(
+          "has_interval",
+          [](llvm::LiveIntervals &l, unsigned reg) {
+            return l.hasInterval(llvm::Register(reg));
+          },
+          "reg"_a)
+      .def(
+          "interval",
+          [](llvm::LiveIntervals &l, unsigned reg) -> llvm::LiveInterval & {
+            return l.getInterval(llvm::Register(reg));
+          },
+          nb::rv_policy::reference_internal, "reg"_a);
 
   nb::enum_<llvm::LiveRegMatrix::InterferenceKind>(m, "InterferenceKind")
       .value("IK_Free", llvm::LiveRegMatrix::IK_Free)

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -381,6 +381,7 @@ public:
   llvm::LiveIntervals *intervals() { return LIS; }
   llvm::VirtRegMap *virtRegMap() { return VRM; }
   llvm::MachineFunction *machineFunction() { return mf; }
+  llvm::SplitAnalysis *splitAnalysisPtr() { return splitAnalysis; }
 
   // Physregs, in target allocation order, that Python may try for `li`.
   std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
@@ -852,7 +853,12 @@ void populate_python_codegen(nb::module_ &m) {
           "machine_function",
           [](PyRegAllocBase &self) { return self.machineFunction(); },
           nb::rv_policy::reference_internal,
-          "The MachineFunction being allocated.");
+          "The MachineFunction being allocated.")
+      .def_prop_ro(
+          "split_analysis",
+          [](PyRegAllocBase &self) { return self.splitAnalysisPtr(); },
+          nb::rv_policy::reference_internal,
+          "The SplitAnalysis for planning live-range splits.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
@@ -928,6 +934,37 @@ void populate_python_codegen(nb::module_ &m) {
             return l.getInterval(llvm::Register(reg));
           },
           nb::rv_policy::reference_internal, "reg"_a);
+
+  // Splitting analysis: after analyze(li), it describes how `li` is used per
+  // block, guiding where the split editor should open/close intervals.
+  nb::class_<llvm::SplitAnalysis> sa(m, "SplitAnalysis");
+  nb::class_<llvm::SplitAnalysis::BlockInfo>(sa, "BlockInfo")
+      .def_prop_ro(
+          "mbb", [](const llvm::SplitAnalysis::BlockInfo &b) { return b.MBB; },
+          nb::rv_policy::reference)
+      .def_ro("first_instr", &llvm::SplitAnalysis::BlockInfo::FirstInstr)
+      .def_ro("last_instr", &llvm::SplitAnalysis::BlockInfo::LastInstr)
+      .def_ro("first_def", &llvm::SplitAnalysis::BlockInfo::FirstDef)
+      .def_ro("live_in", &llvm::SplitAnalysis::BlockInfo::LiveIn)
+      .def_ro("live_out", &llvm::SplitAnalysis::BlockInfo::LiveOut);
+  sa.def(
+        "analyze",
+        [](llvm::SplitAnalysis &s, const llvm::LiveInterval &li) {
+          s.analyze(&li);
+        },
+        "li"_a)
+      .def("use_blocks",
+           [](llvm::SplitAnalysis &s) {
+             return std::vector<llvm::SplitAnalysis::BlockInfo>(
+                 s.getUseBlocks().begin(), s.getUseBlocks().end());
+           })
+      .def("num_through_blocks", &llvm::SplitAnalysis::getNumThroughBlocks)
+      .def("through_blocks", [](llvm::SplitAnalysis &s) {
+        std::vector<unsigned> v;
+        for (unsigned b : s.getThroughBlocks().set_bits())
+          v.push_back(b);
+        return v;
+      });
 
   nb::enum_<llvm::LiveRegMatrix::InterferenceKind>(m, "InterferenceKind")
       .value("IK_Free", llvm::LiveRegMatrix::IK_Free)

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -600,10 +600,9 @@ nb::dict regallocClasses() {
       nb::module_::import_("llvm.mir_strategies").attr("_regalloc_classes"));
 }
 
-// Registered allocator names, in registration order.
 std::deque<std::string> &regallocNames() {
-  static auto *names = new std::deque<std::string>();
-  return *names;
+  static std::deque<std::string> names;
+  return names;
 }
 
 // select_or_split is the one required override: the trampoline calls it

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -486,6 +486,55 @@ void populate_python_codegen(nb::module_ &m) {
 
   nb::class_<PyRegAllocBase>(m, "RegAllocBase").def(nb::init<>());
 
+  // A virtual register's live interval: the allocator receives one per
+  // select_or_split call and queries/assigns it against the matrix.
+  nb::class_<llvm::LiveInterval>(m, "LiveInterval")
+      .def_prop_ro("reg",
+                   [](const llvm::LiveInterval &li) { return li.reg().id(); })
+      .def_prop_ro("weight",
+                   [](const llvm::LiveInterval &li) { return li.weight(); })
+      .def_prop_ro("is_spillable", [](const llvm::LiveInterval &li) {
+        return li.isSpillable();
+      });
+
+  nb::class_<llvm::VirtRegMap>(m, "VirtRegMap");
+  nb::class_<llvm::Spiller>(m, "Spiller");
+  nb::class_<llvm::LiveIntervals>(m, "LiveIntervals");
+
+  nb::enum_<llvm::LiveRegMatrix::InterferenceKind>(m, "InterferenceKind")
+      .value("IK_Free", llvm::LiveRegMatrix::IK_Free)
+      .value("IK_VirtReg", llvm::LiveRegMatrix::IK_VirtReg)
+      .value("IK_RegUnit", llvm::LiveRegMatrix::IK_RegUnit)
+      .value("IK_RegMask", llvm::LiveRegMatrix::IK_RegMask);
+
+  nb::class_<llvm::LiveRegMatrix>(m, "LiveRegMatrix")
+      .def(
+          "check_interference",
+          [](llvm::LiveRegMatrix &mat, const llvm::LiveInterval &li,
+             unsigned preg) {
+            return mat.checkInterference(li, llvm::MCRegister(preg));
+          },
+          "li"_a, "physreg"_a)
+      .def(
+          "is_free",
+          [](llvm::LiveRegMatrix &mat, const llvm::LiveInterval &li,
+             unsigned preg) {
+            return mat.checkInterference(li, llvm::MCRegister(preg)) ==
+                   llvm::LiveRegMatrix::IK_Free;
+          },
+          "li"_a, "physreg"_a)
+      .def(
+          "assign",
+          [](llvm::LiveRegMatrix &mat, const llvm::LiveInterval &li,
+             unsigned preg) { mat.assign(li, llvm::MCRegister(preg)); },
+          "li"_a, "physreg"_a)
+      .def(
+          "unassign",
+          [](llvm::LiveRegMatrix &mat, const llvm::LiveInterval &li) {
+            mat.unassign(li);
+          },
+          "li"_a);
+
   m.def("register_regalloc", &registerRegAlloc, "name"_a, "cls"_a,
         "Register a RegAllocBase subclass under `name` so "
         "emit_object(regalloc=name) can select it. The class must define "

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -3,13 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "IR/Common.h"
+#include "MIR/AllocationOrder.h"
 #include "MIR/Diagnostics.h"
+#include "MIR/RegAllocBase.h"
+#include "MIR/SplitKit.h"
 
+#include <llvm/CodeGen/CalcSpillWeights.h>
+#include <llvm/CodeGen/LiveInterval.h>
+#include <llvm/CodeGen/LiveIntervals.h>
+#include <llvm/CodeGen/LiveRangeEdit.h>
+#include <llvm/CodeGen/LiveRegMatrix.h>
+#include <llvm/CodeGen/LiveStacks.h>
 #include <llvm/CodeGen/MachineBasicBlock.h>
+#include <llvm/CodeGen/MachineBlockFrequencyInfo.h>
+#include <llvm/CodeGen/MachineDominators.h>
+#include <llvm/CodeGen/MachineFunctionPass.h>
 #include <llvm/CodeGen/MachineInstr.h>
+#include <llvm/CodeGen/MachineLoopInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/Passes.h>
+#include <llvm/CodeGen/RegAllocRegistry.h>
 #include <llvm/CodeGen/ScheduleDAG.h>
 #include <llvm/CodeGen/ScheduleDAGMutation.h>
+#include <llvm/CodeGen/SlotIndexes.h>
+#include <llvm/CodeGen/Spiller.h>
+#include <llvm/CodeGen/VirtRegMap.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>
@@ -20,6 +38,7 @@
 #include <deque>
 #include <exception>
 #include <memory>
+#include <queue>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,6 +59,11 @@ namespace {
 // registry ctor knows which class to instantiate per MachineFunction.
 // GIL-serialized, matching the process-global -misched handling in Machine.cpp.
 thread_local nb::type_object activeSchedClass;
+
+// The Python RegAllocBase subclass emit_object selected for the current run,
+// set/cleared under the GIL. Mirrors activeSchedClass: the harness pass ctor is
+// a non-capturing function pointer, so it reads the class from here.
+thread_local nb::type_object activeRegAllocClass;
 
 class PySchedStrategy : public llvm::MachineSchedStrategy {
 public:
@@ -287,6 +311,61 @@ createRegisteredPyStrategy(llvm::MachineSchedContext *c) {
   }
 }
 
+// Trampoline letting Python subclass llvm::RegAllocBase. RegAllocBase is a
+// driver mixed into a MachineFunctionPass: its state (VRM/LIS/Matrix/...) and
+// the init()/allocatePhysRegs() driver are protected, so the harness pass
+// reaches them through the public py* wrappers below rather than owning an
+// adaptor (there is no unique_ptr sink to satisfy, unlike the scheduler).
+class PyRegAllocBase : public llvm::RegAllocBase {
+public:
+  NB_TRAMPOLINE(llvm::RegAllocBase, 6);
+
+  // spiller() is pure and dereferenced by allocatePhysRegs; the harness injects
+  // the concrete Spiller before driving, so this is never called with null.
+  llvm::Spiller &spiller() override { return *injectedSpiller; }
+  void enqueueImpl(const llvm::LiveInterval *) override {}
+  const llvm::LiveInterval *dequeue() override { return nullptr; }
+  llvm::MCRegister
+  selectOrSplit(const llvm::LiveInterval &,
+                llvm::SmallVectorImpl<llvm::Register> &) override {
+    return llvm::MCRegister();
+  }
+
+  llvm::Spiller *injectedSpiller = nullptr;
+};
+
+// name -> Python RegAllocBase subclass, held in
+// llvm.mir_strategies._regalloc_classes (Python owns it so the subclass types
+// are released at interpreter teardown, matching schedulerClasses()).
+nb::dict regallocClasses() {
+  return nb::cast<nb::dict>(
+      nb::module_::import_("llvm.mir_strategies").attr("_regalloc_classes"));
+}
+
+// Registered allocator names, in registration order.
+std::deque<std::string> &regallocNames() {
+  static auto *names = new std::deque<std::string>();
+  return *names;
+}
+
+// select_or_split is the one required override (RegAllocBase's only pure
+// heuristic hook without a default); enqueue/dequeue/post_optimization are
+// optional and fall back to the native queue / base default. type_object_t
+// rejects a non-RegAllocBase class at the call boundary. Keyed on the
+// trampoline (the bound value type) rather than llvm::RegAllocBase because that
+// class has a protected destructor, which nanobind cannot bind as a value type.
+void registerRegAlloc(const std::string &name,
+                      nb::type_object_t<PyRegAllocBase> cls) {
+  if (!nb::hasattr(cls, "select_or_split")) {
+    throw nb::type_error(
+        "register allocator class must define select_or_split");
+  }
+  nb::dict classes = regallocClasses();
+  if (!classes.contains(name.c_str()))
+    regallocNames().push_back(name);
+  classes[name.c_str()] = cls;
+}
+
 } // namespace
 
 namespace eudsl {
@@ -335,6 +414,20 @@ void setActiveSchedClass(nb::type_object cls) {
   activeSchedClass = std::move(cls);
 }
 void clearActiveSchedClass() { activeSchedClass = nb::type_object(); }
+
+// The class registered under `name`, or an invalid object if `name` was not
+// registered via register_regalloc.
+nb::type_object regallocClass(const std::string &name) {
+  nb::dict classes = regallocClasses();
+  if (classes.contains(name.c_str()))
+    return nb::borrow<nb::type_object>(classes[name.c_str()]);
+  return nb::type_object();
+}
+
+void setActiveRegAllocClass(nb::type_object cls) {
+  activeRegAllocClass = std::move(cls);
+}
+void clearActiveRegAllocClass() { activeRegAllocClass = nb::type_object(); }
 
 } // namespace eudsl
 
@@ -390,4 +483,21 @@ void populate_python_codegen(nb::module_ &m) {
       },
       "Names registered via register_scheduler, selectable with "
       "emit_object(scheduler=...).");
+
+  nb::class_<PyRegAllocBase>(m, "RegAllocBase").def(nb::init<>());
+
+  m.def("register_regalloc", &registerRegAlloc, "name"_a, "cls"_a,
+        "Register a RegAllocBase subclass under `name` so "
+        "emit_object(regalloc=name) can select it. The class must define "
+        "select_or_split; enqueue, dequeue, and post_optimization are "
+        "optional. Re-registering a name replaces it.");
+
+  m.def(
+      "registered_regallocs",
+      []() {
+        return std::vector<std::string>(regallocNames().begin(),
+                                        regallocNames().end());
+      },
+      "Names registered via register_regalloc, selectable with "
+      "emit_object(regalloc=...).");
 }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -374,6 +374,10 @@ public:
   void pyAllocate() {
     allocatePhysRegs();
     postOptimization();
+    // Free any LiveRangeEdit handed to Python while MRI is still alive: its
+    // dtor calls MRI.resetDelegate, and MRI is torn down with the function once
+    // the harness returns.
+    heldEdit.reset();
   }
 
   // Protected RegAllocBase state, surfaced to the Python helpers.
@@ -983,6 +987,12 @@ void populate_python_codegen(nb::module_ &m) {
                  s.getUseBlocks().begin(), s.getUseBlocks().end());
            })
       .def("num_through_blocks", &llvm::SplitAnalysis::getNumThroughBlocks)
+      .def(
+          "last_split_point",
+          [](llvm::SplitAnalysis &s, llvm::MachineBasicBlock *mbb) {
+            return s.getLastSplitPoint(mbb);
+          },
+          "mbb"_a)
       .def("through_blocks", [](llvm::SplitAnalysis &s) {
         std::vector<unsigned> v;
         for (unsigned b : s.getThroughBlocks().set_bits())

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -363,58 +363,15 @@ public:
   // Public wrappers the harness pass uses to reach the protected driver.
   void pyInit(llvm::VirtRegMap &vrm, llvm::LiveIntervals &lis,
               llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
-              llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
-              llvm::SplitEditor *se) {
+              llvm::MachineFunction &mfn) {
     injectedSpiller = &sp;
     mf = &mfn;
-    splitAnalysis = sa;
-    splitEditor = se;
     init(vrm, lis, mat);
   }
   void pyAllocate() {
     allocatePhysRegs();
     postOptimization();
-    // Free any LiveRangeEdit handed to Python while MRI is still alive: its
-    // dtor calls MRI.resetDelegate, and MRI is torn down with the function once
-    // the harness returns.
-    heldEdit.reset();
   }
-
-  // Protected RegAllocBase state, surfaced to the Python helpers.
-  llvm::LiveRegMatrix *matrix() { return Matrix; }
-  llvm::LiveIntervals *intervals() { return LIS; }
-  llvm::VirtRegMap *virtRegMap() { return VRM; }
-  llvm::MachineFunction *machineFunction() { return mf; }
-  llvm::SplitAnalysis *splitAnalysisPtr() { return splitAnalysis; }
-  llvm::SplitEditor *splitEditorPtr() { return splitEditor; }
-
-  // Build a LiveRangeEdit over the current split-vreg vector for the split
-  // editor to write into. Held so it outlives the SplitEditor reset/open/use/
-  // finish calls that reference it (all within one select_or_split).
-  llvm::LiveRangeEdit *newLiveRangeEdit(const llvm::LiveInterval &li) {
-    heldEdit = std::make_unique<llvm::LiveRangeEdit>(
-        &li, *currentSplit, *mf, *LIS, VRM, /*delegate=*/nullptr, &DeadRemats);
-    return heldEdit.get();
-  }
-
-  // Physregs, in target allocation order, that Python may try for `li`.
-  std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
-    auto order =
-        llvm::AllocationOrder::create(li.reg(), *VRM, RegClassInfo, Matrix);
-    std::vector<unsigned> ids;
-    for (llvm::MCRegister r : order)
-      ids.push_back(r.id());
-    return ids;
-  }
-
-  // Spill `li` into the current select_or_split's split-vreg vector.
-  void spill(const llvm::LiveInterval &li) {
-    llvm::LiveRangeEdit lre(&li, *currentSplit, *mf, *LIS, VRM,
-                            /*delegate=*/nullptr, &DeadRemats);
-    injectedSpiller->spill(lre);
-  }
-
-  llvm::Spiller *injectedSpiller = nullptr;
 
 protected:
   struct QueueEntry {
@@ -433,24 +390,25 @@ protected:
 
   std::priority_queue<QueueEntry, std::vector<QueueEntry>, QueueLess>
       nativeQueue;
-  llvm::SmallVectorImpl<llvm::Register> *currentSplit = nullptr;
   llvm::MachineFunction *mf = nullptr;
-  llvm::SplitAnalysis *splitAnalysis = nullptr;
-  llvm::SplitEditor *splitEditor = nullptr;
-  std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
+  llvm::Spiller *injectedSpiller = nullptr;
 };
 
 // Trampoline letting Python subclass the allocator. Each virtual calls the
 // Python override under the GIL and stashes on raise; when no override exists
 // or the run is already winding down after a stash, it defers to the
 // NativeRegAlloc base (which always makes forward progress), so the pipeline
-// reaches runCodegenPipeline's re-raise with valid MIR.
+// reaches runCodegenPipeline's re-raise with valid MIR. It also carries the
+// Python-only splitting surface (split analysis/editor, the current split-vreg
+// vector, and the edit buffer) that the standalone NativeRegAlloc fallback has
+// no use for.
 class PyRegAllocBase : public NativeRegAlloc {
 public:
   NB_TRAMPOLINE(NativeRegAlloc, 6);
 
-  // Keep the native fallback queue complete, then forward to an optional
-  // Python enqueue.
+  // Keep the native fallback queue complete, then forward the register id (not
+  // the interval, which splitting can invalidate) to an optional Python
+  // enqueue.
   void enqueueImpl(const llvm::LiveInterval *li) override {
     NativeRegAlloc::enqueueImpl(li);
     nb::gil_scoped_acquire gil;
@@ -458,8 +416,7 @@ public:
     if (eudsl::pendingCodegenError || !nb::hasattr(self, "enqueue"))
       return;
     try {
-      self.attr("enqueue")(nb::cast(const_cast<llvm::LiveInterval *>(li),
-                                    nb::rv_policy::reference));
+      self.attr("enqueue")(li->reg().id());
     } catch (...) {
       eudsl::pendingCodegenError = std::current_exception();
     }
@@ -470,10 +427,17 @@ public:
     nb::handle self = nb_trampoline.base();
     if (!eudsl::pendingCodegenError && nb::hasattr(self, "dequeue")) {
       try {
-        nb::object choice = self.attr("dequeue")();
-        if (choice.is_none())
-          return nullptr;
-        return nb::cast<llvm::LiveInterval *>(choice);
+        // Python returns register ids (stable across splitting); re-fetch and
+        // skip any already assigned or removed, mirroring the native drain.
+        while (true) {
+          nb::object choice = self.attr("dequeue")();
+          if (choice.is_none())
+            return nullptr;
+          llvm::Register r(nb::cast<unsigned>(choice));
+          if (VRM->hasPhys(r) || !LIS->hasInterval(r))
+            continue;
+          return &LIS->getInterval(r);
+        }
       } catch (...) {
         eudsl::pendingCodegenError = std::current_exception();
       }
@@ -490,18 +454,20 @@ public:
       try {
         nb::object r = nb_trampoline.base().attr("select_or_split")(nb::cast(
             const_cast<llvm::LiveInterval *>(&vreg), nb::rv_policy::reference));
-        currentSplit = nullptr;
-        // None means Python handled it (spill/split appended new vregs); an int
-        // is the chosen physreg for the driver to assign.
-        if (r.is_none())
-          return llvm::MCRegister();
-        return llvm::MCRegister(nb::cast<unsigned>(r));
+        // None means Python handled it via spill/split (new vregs appended); an
+        // int is a physreg to assign, validated as a free candidate rather than
+        // letting Matrix::assign abort on a bad choice.
+        llvm::MCRegister phys;
+        if (!r.is_none())
+          phys = validatedPhysReg(vreg, nb::cast<unsigned>(r));
+        clearSplitContext();
+        return phys;
       } catch (...) {
         eudsl::pendingCodegenError = std::current_exception();
       }
     }
     llvm::MCRegister phys = NativeRegAlloc::selectOrSplit(vreg, splitLVRs);
-    currentSplit = nullptr;
+    clearSplitContext();
     return phys;
   }
 
@@ -536,6 +502,94 @@ public:
       eudsl::pendingCodegenError = std::current_exception();
     }
   }
+
+  void pyInit(llvm::VirtRegMap &vrm, llvm::LiveIntervals &lis,
+              llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
+              llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
+              llvm::SplitEditor *se) {
+    splitAnalysis = sa;
+    splitEditor = se;
+    NativeRegAlloc::pyInit(vrm, lis, mat, sp, mfn);
+  }
+
+  // Protected driver state, surfaced to the Python helpers. These borrow
+  // objects owned by the harness pass frame; the bindings hand them out with
+  // rv_policy::reference (not reference_internal) since the allocator does not
+  // own them, and they are valid only for the duration of an allocator
+  // callback.
+  llvm::LiveRegMatrix *matrix() { return Matrix; }
+  llvm::LiveIntervals *intervals() { return LIS; }
+  llvm::VirtRegMap *virtRegMap() { return VRM; }
+  llvm::MachineFunction *machineFunction() { return mf; }
+  llvm::SplitAnalysis *splitAnalysisPtr() { return splitAnalysis; }
+  llvm::SplitEditor *splitEditorPtr() { return splitEditor; }
+
+  // Physregs, in target allocation order, that Python may try for `li`.
+  std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
+    auto order =
+        llvm::AllocationOrder::create(li.reg(), *VRM, RegClassInfo, Matrix);
+    std::vector<unsigned> ids;
+    for (llvm::MCRegister r : order)
+      ids.push_back(r.id());
+    return ids;
+  }
+
+  // Spill `li` into the current select_or_split's split-vreg vector.
+  void spill(const llvm::LiveInterval &li) {
+    if (!currentSplit)
+      throw nb::value_error("spill() is only valid inside select_or_split");
+    llvm::LiveRangeEdit lre(&li, *currentSplit, *mf, *LIS, VRM,
+                            /*delegate=*/nullptr, &DeadRemats);
+    injectedSpiller->spill(lre);
+  }
+
+  // A LiveRangeEdit over the current split-vreg vector for the split editor to
+  // write into. Held so it outlives the SplitEditor reset/open/use/finish calls
+  // that reference it; cleared at the end of the select_or_split so it never
+  // outlives the loop-local vector it references nor lingers as an MRI delegate
+  // into later iterations.
+  llvm::LiveRangeEdit *newLiveRangeEdit(const llvm::LiveInterval &li) {
+    if (!currentSplit)
+      throw nb::value_error(
+          "new_live_range_edit() is only valid inside select_or_split");
+    heldEdit = std::make_unique<llvm::LiveRangeEdit>(
+        &li, *currentSplit, *mf, *LIS, VRM, /*delegate=*/nullptr, &DeadRemats);
+    return heldEdit.get();
+  }
+
+private:
+  // A returned physreg must be a free candidate in `vreg`'s allocation order;
+  // otherwise the driver's Matrix::assign would abort. Checking membership
+  // first keeps the checkInterference call on a valid physreg.
+  llvm::MCRegister validatedPhysReg(const llvm::LiveInterval &vreg,
+                                    unsigned id) {
+    llvm::MCRegister phys(id);
+    auto order =
+        llvm::AllocationOrder::create(vreg.reg(), *VRM, RegClassInfo, Matrix);
+    for (llvm::MCRegister cand : order) {
+      if (cand == phys) {
+        if (Matrix->checkInterference(vreg, phys) ==
+            llvm::LiveRegMatrix::IK_Free)
+          return phys;
+        break;
+      }
+    }
+    throw nb::value_error("select_or_split returned a physreg that is not a "
+                          "free candidate in the allocation order");
+  }
+
+  // End-of-select_or_split cleanup: the split-vreg vector and edit buffer both
+  // reference allocatePhysRegs's per-iteration loop-local storage, so neither
+  // may outlive this call.
+  void clearSplitContext() {
+    currentSplit = nullptr;
+    heldEdit.reset();
+  }
+
+  llvm::SmallVectorImpl<llvm::Register> *currentSplit = nullptr;
+  llvm::SplitAnalysis *splitAnalysis = nullptr;
+  llvm::SplitEditor *splitEditor = nullptr;
+  std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
 
 // name -> Python RegAllocBase subclass, held in
@@ -552,12 +606,13 @@ std::deque<std::string> &regallocNames() {
   return *names;
 }
 
-// select_or_split is the one required override (RegAllocBase's only pure
-// heuristic hook without a default); enqueue/dequeue/post_optimization are
-// optional and fall back to the native queue / base default. type_object_t
-// rejects a non-RegAllocBase class at the call boundary. Keyed on the
-// trampoline (the bound value type) rather than llvm::RegAllocBase because that
-// class has a protected destructor, which nanobind cannot bind as a value type.
+// select_or_split is the one required override: the trampoline calls it
+// unconditionally, whereas enqueue/dequeue/post_optimization/
+// about_to_remove_interval are hasattr-guarded and fall back to the native
+// queue / base default. type_object_t rejects a non-RegAllocBase class at the
+// call boundary. Keyed on the trampoline (the bound value type) rather than
+// llvm::RegAllocBase because that class has a protected destructor, which
+// nanobind cannot bind as a value type.
 void registerRegAlloc(const std::string &name,
                       nb::type_object_t<PyRegAllocBase> cls) {
   if (!nb::hasattr(cls, "select_or_split")) {
@@ -655,17 +710,34 @@ public:
     llvm::SplitAnalysis sa(vrm, lis, loops);
     llvm::SplitEditor se(sa, lis, vrm, mdt, mbfi, vrai);
 
+    auto runNative = [&] {
+      NativeRegAlloc fallback;
+      fallback.pyInit(vrm, lis, mat, *spiller, mfn);
+      fallback.pyAllocate();
+    };
+
+    // LCOV_EXCL_START -- a module from create_machine_function holds exactly
+    // one MachineFunction, so this runs once per emit_object and a stash from
+    // an earlier function is never already pending. Defensive for a
+    // hypothetical multi-function module: don't re-enter Python (which would
+    // clobber the pending error); allocate natively so this function's MIR
+    // stays valid and the original error still re-raises.
+    if (eudsl::pendingCodegenError) {
+      runNative();
+      return true;
+    }
+    // LCOV_EXCL_STOP
+
     nb::object obj;
     try {
       obj = activeRegAllocClass();
     } catch (...) {
-      // The subclass __init__ raised. Stash it and allocate natively so the MIR
-      // is valid and the pipeline reaches runCodegenPipeline's re-raise instead
-      // of aborting the rewriter on unallocated vregs.
-      eudsl::pendingCodegenError = std::current_exception();
-      NativeRegAlloc fallback;
-      fallback.pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se);
-      fallback.pyAllocate();
+      // The subclass __init__ raised; keep the first pending error if any, then
+      // allocate natively so the MIR is valid and the pipeline reaches
+      // runCodegenPipeline's re-raise instead of aborting on unallocated vregs.
+      if (!eudsl::pendingCodegenError)
+        eudsl::pendingCodegenError = std::current_exception();
+      runNative();
       return true;
     }
     auto *base =
@@ -851,42 +923,51 @@ void populate_python_codegen(nb::module_ &m) {
       .def("allocation_order", &PyRegAllocBase::allocationOrder, "li"_a,
            "Physregs (as ids) to try for `li`, in target allocation order.")
       .def("spill", &PyRegAllocBase::spill, "li"_a,
-           "Spill `li`; new split vregs are appended for re-enqueue.")
+           "Spill `li`; new split vregs are appended for re-enqueue. Only "
+           "valid inside select_or_split.")
       .def_prop_ro(
           "matrix", [](PyRegAllocBase &self) { return self.matrix(); },
-          nb::rv_policy::reference_internal,
-          "The LiveRegMatrix for interference queries and assignment.")
+          nb::rv_policy::reference,
+          "The LiveRegMatrix for interference queries and assignment. Borrowed "
+          "and valid only within an allocator callback; do not retain.")
       .def_prop_ro(
           "lis", [](PyRegAllocBase &self) { return self.intervals(); },
-          nb::rv_policy::reference_internal,
-          "The LiveIntervals analysis for this function.")
+          nb::rv_policy::reference,
+          "The LiveIntervals analysis for this function. Borrowed and valid "
+          "only within an allocator callback; do not retain.")
       .def_prop_ro(
           "vrm", [](PyRegAllocBase &self) { return self.virtRegMap(); },
-          nb::rv_policy::reference_internal,
-          "The VirtRegMap being populated with assignments.")
+          nb::rv_policy::reference,
+          "The VirtRegMap being populated with assignments. Borrowed and valid "
+          "only within an allocator callback; do not retain.")
       .def_prop_ro(
           "machine_function",
           [](PyRegAllocBase &self) { return self.machineFunction(); },
-          nb::rv_policy::reference_internal,
-          "The MachineFunction being allocated.")
+          nb::rv_policy::reference,
+          "The MachineFunction being allocated. Borrowed and valid only within "
+          "an allocator callback; do not retain.")
       .def_prop_ro(
           "split_analysis",
           [](PyRegAllocBase &self) { return self.splitAnalysisPtr(); },
-          nb::rv_policy::reference_internal,
-          "The SplitAnalysis for planning live-range splits.")
+          nb::rv_policy::reference,
+          "The SplitAnalysis for planning live-range splits. Borrowed and "
+          "valid only within an allocator callback; do not retain.")
       .def_prop_ro(
           "split_editor",
           [](PyRegAllocBase &self) { return self.splitEditorPtr(); },
-          nb::rv_policy::reference_internal,
-          "The SplitEditor for applying live-range splits.")
+          nb::rv_policy::reference,
+          "The SplitEditor for applying live-range splits (call reset(...) "
+          "before open_intv/use_intv). Borrowed and valid only within an "
+          "allocator callback; do not retain.")
       .def(
           "new_live_range_edit",
           [](PyRegAllocBase &self, const llvm::LiveInterval &li) {
             return self.newLiveRangeEdit(li);
           },
-          nb::rv_policy::reference_internal, "li"_a,
+          nb::rv_policy::reference, "li"_a,
           "A LiveRangeEdit over the current split-vreg vector, for "
-          "split_editor.reset.");
+          "split_editor.reset. Only valid inside select_or_split; do not "
+          "retain past the call.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.

--- a/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
@@ -15,6 +15,10 @@ from . import mir
 # released at interpreter teardown rather than pinned in a C++ static.
 _scheduler_classes = {}
 
+# name -> registered RegAllocBase subclass; the regalloc analogue of
+# _scheduler_classes, owned by Python for the same teardown reason.
+_regalloc_classes = {}
+
 
 class ReadyQueueStrategy(mir.MachineSchedStrategy):
     """Top-down strategy that maintains the ready queue for you.

--- a/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_strategies.py
@@ -59,3 +59,23 @@ class ReadyQueueStrategy(mir.MachineSchedStrategy):
 
 
 mir.ReadyQueueStrategy = ReadyQueueStrategy
+
+
+class BasicRegAlloc(mir.RegAllocBase):
+    """First-free-or-spill allocator.
+
+    Relies on the C++ default spill-weight queue (no enqueue/dequeue override):
+    for each unassigned live interval, take the first interference-free physreg
+    in the target allocation order, else spill it and let the resulting split
+    vregs be re-enqueued.
+    """
+
+    def select_or_split(self, li):
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+mir.BasicRegAlloc = BasicRegAlloc

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1,7 +1,17 @@
 #  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 #  See https://llvm.org/LICENSE.txt for license information.
 #  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import ctypes, math, platform
+"""Python-subclassable RegAllocBase register allocator.
+
+mir.RegAllocBase binds llvm::RegAllocBase (via a trampoline) so Python can
+subclass it and implement an arbitrary allocator. register_regalloc adds it
+under a name; emit_object(regalloc="name") drives the codegen allocator slot
+with it. Allocation is semantics-preserving, so an allocator recording into a
+test-visible object witnesses that Python drove it; JIT-executed tests prove the
+result stays correct.
+"""
+
+import ctypes, platform
 import pytest
 import llvm
 from llvm import ir, jit, mir
@@ -15,9 +25,405 @@ _AARCH64_LINUX = "aarch64-unknown-linux-gnu"
 _IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
 
 
+def _build_selected_add(mmi):
+    """Hand-build a fully-selected AArch64 add(i32,i32)->i32 MachineFunction."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    ret_copy = b.build_instr(copy)
+    ret_copy.add_reg(w0, is_def=True)
+    ret_copy.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+# result(x) = sum of N copies of x = N*x, over N vregs kept live simultaneously
+# (all defined before the reduction consumes them) so allocation is forced past
+# the GPR32 register file and must spill.
+_HP_N = 48
+
+
+def _hp_closed_form(x):
+    return _HP_N * x
+
+
+def _build_high_pressure(mmi):
+    """Hand-build a single-block hp(i32)->i32 with high register pressure."""
+    mf = mmi.machine_function("hp")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    copy = mf.opcode("COPY")
+    addrr = mf.opcode("ADDWrr")
+
+    # N independent copies of the input, all live until the reduction consumes
+    # them (distinct vregs, so nothing coalesces them away).
+    terms = []
+    for _ in range(_HP_N):
+        t = mf.create_vreg(gpr32)
+        ins = b.build_instr(copy)
+        ins.add_reg(t, is_def=True)
+        ins.add_reg(w0)
+        terms.append(t)
+
+    acc = terms[0]
+    for t in terms[1:]:
+        nacc = mf.create_vreg(gpr32)
+        ins = b.build_instr(addrr)
+        ins.add_reg(nacc, is_def=True)
+        ins.add_reg(acc)
+        ins.add_reg(t)
+        acc = nacc
+
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(acc)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def _emit(name, cls, builder=_build_selected_add, fn="add"):
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, fn)
+        builder(mmi)
+        return mmi.emit_object(regalloc=name)
+
+
+def _jit_call(sig, fn, obj):
+    j = jit.LLJIT()
+    j.add_object(obj)
+    return ctypes.CFUNCTYPE(*sig)(j.lookup(fn)), j
+
+
+# -- registration contract ---------------------------------------------------
+
+
 def test_register_regalloc_requires_regallocbase_subclass():
     class NotAnAllocator:
         def select_or_split(self, li): ...
 
     with pytest.raises(TypeError, match="RegAllocBase"):
         mir.register_regalloc("ra-bad", NotAnAllocator)
+
+
+def test_register_regalloc_requires_select_or_split():
+    class NoSelect(mir.RegAllocBase):
+        pass
+
+    with pytest.raises(TypeError, match="select_or_split"):
+        mir.register_regalloc("ra-nosel", NoSelect)
+
+
+def test_registered_regalloc_appears_in_registry():
+    mir.register_regalloc("ra-listed", mir.BasicRegAlloc)
+    assert "ra-listed" in mir.registered_regallocs()
+
+
+def test_unknown_regalloc_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        with pytest.raises(RuntimeError, match="unknown regalloc"):
+            mmi.emit_object(regalloc="ra-does-not-exist")
+    assert_no_leaks()
+
+
+# -- behavioral ---------------------------------------------------------------
+
+
+def test_basic_regalloc_emits_object():
+    mir.register_regalloc("ra-basic", mir.BasicRegAlloc)
+    obj = _emit("ra-basic", mir.BasicRegAlloc)
+    assert obj[:4] == b"\x7fELF"
+    assert b"add\x00" in obj
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_basic_regalloc_executes():
+    mir.register_regalloc("ra-basic-x", mir.BasicRegAlloc)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()  # host triple
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_selected_add(mmi)
+        obj = mmi.emit_object(regalloc="ra-basic-x")
+        add, j = _jit_call(
+            (ctypes.c_int32, ctypes.c_int32, ctypes.c_int32), "add", obj
+        )
+        assert add(2, 3) == 5
+        assert add(40, 2) == 42
+        del j
+    assert_no_leaks()
+
+
+def test_custom_select_or_split_drives_allocation():
+    """An allocator recording each (vreg, physreg) choice witnesses that Python
+    drove select_or_split."""
+    seen = []
+
+    class Recording(mir.RegAllocBase):
+        def select_or_split(self, li):
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    seen.append((li.reg, preg))
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-recording", Recording)
+    obj = _emit("ra-recording", Recording)
+    assert obj[:4] == b"\x7fELF"
+    assert seen, "select_or_split ran"
+    assert_no_leaks()
+
+
+def test_query_accessors_and_manual_assignment():
+    """Exercise the query/mutate surface: the analysis accessors, the interval
+    fields, and check_interference/assign/unassign driven from Python."""
+    saw = {}
+
+    class Manual(mir.RegAllocBase):
+        def select_or_split(self, li):
+            saw["lis"] = self.lis is not None
+            saw["vrm"] = self.vrm is not None
+            saw["mf"] = self.machine_function is not None
+            saw["weight"] = li.weight
+            saw["spillable"] = li.is_spillable
+            for preg in self.allocation_order(li):
+                if (
+                    self.matrix.check_interference(li, preg)
+                    == mir.InterferenceKind.IK_Free
+                ):
+                    self.matrix.assign(li, preg)
+                    self.matrix.unassign(li)
+                    self.matrix.assign(li, preg)
+                    return None
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-manual", Manual)
+    obj = _emit("ra-manual", Manual)
+    assert obj[:4] == b"\x7fELF"
+    assert saw["lis"] and saw["vrm"] and saw["mf"]
+    assert isinstance(saw["weight"], float)
+    assert saw["spillable"] is True
+    assert_no_leaks()
+
+
+def test_custom_enqueue_dequeue_queue():
+    """A Python-side FIFO queue via enqueue/dequeue drives the assignment order
+    instead of the native spill-weight queue."""
+
+    class ListQueue(mir.BasicRegAlloc):
+        def __init__(self):
+            super().__init__()
+            self.q = []
+
+        def enqueue(self, li):
+            self.q.append(li)
+
+        def dequeue(self):
+            if not self.q:
+                return None
+            return self.q.pop(0)
+
+    mir.register_regalloc("ra-listq", ListQueue)
+    obj = _emit("ra-listq", ListQueue)
+    assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
+def test_post_optimization_forwarded():
+    ran = []
+
+    class WithPost(mir.BasicRegAlloc):
+        def post_optimization(self):
+            ran.append(True)
+
+    mir.register_regalloc("ra-post", WithPost)
+    obj = _emit("ra-post", WithPost)
+    assert obj[:4] == b"\x7fELF"
+    assert ran, "post_optimization ran"
+    assert_no_leaks()
+
+
+def test_fresh_instance_per_emission():
+    instances = []
+
+    class Recorder(mir.BasicRegAlloc):
+        def __init__(self):
+            super().__init__()
+            instances.append(self)
+
+    mir.register_regalloc("ra-fresh", Recorder)
+    _emit("ra-fresh", Recorder)
+    _emit("ra-fresh", Recorder)
+    assert len(instances) == 2
+    assert instances[0] is not instances[1]
+    assert_no_leaks()
+
+
+# -- spilling -----------------------------------------------------------------
+
+
+def test_high_pressure_forces_spill():
+    """A function with more simultaneously-live vregs than the register file
+    forces BasicRegAlloc down the spill path; the emitted object stays valid."""
+    spilled = []
+
+    class Spilling(mir.RegAllocBase):
+        def select_or_split(self, li):
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            spilled.append(li.reg)
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-hp", Spilling)
+    obj = _emit("ra-hp", Spilling, builder=_build_high_pressure, fn="hp")
+    assert obj[:4] == b"\x7fELF"
+    assert spilled, "spill path exercised"
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_high_pressure_executes():
+    class Spilling(mir.RegAllocBase):
+        def select_or_split(self, li):
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-hp-x", Spilling)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        obj = mmi.emit_object(regalloc="ra-hp-x")
+        hp, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "hp", obj)
+        assert hp(3) == _hp_closed_form(3)
+        assert hp(0) == _hp_closed_form(0)
+        del j
+    assert_no_leaks()
+
+
+# -- exception matrix ---------------------------------------------------------
+
+
+def _expect_raise(name, cls, match, builder=_build_selected_add, fn="add"):
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, fn)
+        builder(mmi)
+        with pytest.raises(Exception, match=match):
+            mmi.emit_object(regalloc=name)
+    assert_no_leaks()
+
+
+def test_select_or_split_raise_propagates():
+    class Boom(mir.RegAllocBase):
+        def select_or_split(self, li):
+            raise ValueError("select boom")
+
+    mir.register_regalloc("ra-sel-boom", Boom)
+    _expect_raise("ra-sel-boom", Boom, "select boom")
+
+
+def test_select_or_split_bad_return_propagates():
+    class BadReturn(mir.RegAllocBase):
+        def select_or_split(self, li):
+            return "not an int"
+
+    mir.register_regalloc("ra-sel-bad", BadReturn)
+    _expect_raise("ra-sel-bad", BadReturn, "bad_cast")
+
+
+def test_enqueue_raise_propagates():
+    class Boom(mir.BasicRegAlloc):
+        def enqueue(self, li):
+            raise ValueError("enqueue boom")
+
+    mir.register_regalloc("ra-enq-boom", Boom)
+    _expect_raise("ra-enq-boom", Boom, "enqueue boom")
+
+
+def test_dequeue_raise_propagates():
+    class Boom(mir.BasicRegAlloc):
+        def dequeue(self):
+            raise ValueError("dequeue boom")
+
+    mir.register_regalloc("ra-deq-boom", Boom)
+    _expect_raise("ra-deq-boom", Boom, "dequeue boom")
+
+
+def test_init_raise_propagates():
+    class Boom(mir.RegAllocBase):
+        def __init__(self):
+            super().__init__()
+            raise ValueError("init boom")
+
+        def select_or_split(self, li):
+            return None
+
+    mir.register_regalloc("ra-init-boom", Boom)
+    _expect_raise("ra-init-boom", Boom, "init boom")
+
+
+def test_post_optimization_raise_propagates():
+    class Boom(mir.BasicRegAlloc):
+        def post_optimization(self):
+            raise ValueError("post boom")
+
+    mir.register_regalloc("ra-post-boom", Boom)
+    _expect_raise("ra-post-boom", Boom, "post boom")
+
+
+def test_native_fallback_spills_after_init_raise_under_pressure():
+    """When __init__ raises under high pressure, the C++ NativeRegAlloc fallback
+    still allocates (down its own spill path), so the MIR is valid and the
+    exception re-raises rather than aborting the rewriter on unallocated vregs."""
+
+    class Boom(mir.RegAllocBase):
+        def __init__(self):
+            super().__init__()
+            raise ValueError("hp init boom")
+
+        def select_or_split(self, li):
+            return None
+
+    mir.register_regalloc("ra-hp-init", Boom)
+    _expect_raise(
+        "ra-hp-init", Boom, "hp init boom", builder=_build_high_pressure, fn="hp"
+    )

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -338,6 +338,51 @@ def test_high_pressure_executes():
     assert_no_leaks()
 
 
+# -- SlotIndex / LiveIntervals accessors --------------------------------------
+
+
+def test_slot_index_and_live_intervals_accessors():
+    """Read the program-point surface from inside select_or_split: block
+    start/end indices are valid and ordered, the interval is present, and the
+    SlotIndex value methods round-trip."""
+    saw = {}
+
+    class Reader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            if not saw:
+                mbb = self.machine_function.blocks[0]
+                start = self.lis.mbb_start_index(mbb)
+                end = self.lis.mbb_end_index(mbb)
+                mi = list(mbb.instructions)[0]
+                idx = self.lis.instruction_index(mi)
+                saw["ordered"] = start < end
+                saw["eq"] = start == start
+                saw["valid"] = start.is_valid()
+                saw["idx_in_block"] = (start < idx) and (idx < end)
+                saw["reg_slot"] = idx.get_reg_slot().is_valid()
+                saw["base"] = idx.get_base_index().is_valid()
+                saw["boundary"] = idx.get_boundary_index().is_valid()
+                saw["next"] = idx.get_next_index().is_valid()
+                saw["repr"] = repr(start)
+                saw["has"] = self.lis.has_interval(li.reg)
+                saw["interval_reg"] = self.lis.interval(li.reg).reg
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-slots", Reader)
+    obj = _emit("ra-slots", Reader)
+    assert obj[:4] == b"\x7fELF"
+    assert saw["ordered"] and saw["eq"] and saw["valid"]
+    assert saw["idx_in_block"]
+    assert saw["reg_slot"] and saw["base"] and saw["boundary"] and saw["next"]
+    assert "SlotIndex" in saw["repr"]
+    assert saw["has"]
+    assert_no_leaks()
+
+
 # -- exception matrix ---------------------------------------------------------
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -174,9 +174,7 @@ def test_basic_regalloc_executes():
         mmi = mir.create_machine_function(mod, tm, "add")
         _build_selected_add(mmi)
         obj = mmi.emit_object(regalloc="ra-basic-x")
-        add, j = _jit_call(
-            (ctypes.c_int32, ctypes.c_int32, ctypes.c_int32), "add", obj
-        )
+        add, j = _jit_call((ctypes.c_int32, ctypes.c_int32, ctypes.c_int32), "add", obj)
         assert add(2, 3) == 5
         assert add(40, 2) == 42
         del j
@@ -461,6 +459,333 @@ def test_split_analysis_use_and_through_blocks():
     assert_no_leaks()
 
 
+# -- SplitEditor region splitting (the success bar) ---------------------------
+
+
+def _build_cbz(mmi):
+    """b0 defines v and uses it in a CBZW terminator (so v is live-out and its
+    last use sits at b0's last split point), b1 falls through, b2 uses v. This
+    is the shape that drives SplitEditor's overlap path."""
+    mf = mmi.machine_function("cbz")
+    b = mir.MachineIRBuilder(mf)
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    b0 = mf.blocks[0]
+    b1 = mf.create_block()
+    b2 = mf.create_block()
+    b0.add_livein(w0)
+    copy = mf.opcode("COPY")
+    b.set_block(b0)
+    v = mf.create_vreg(gpr32)
+    c = b.build_instr(copy)
+    c.add_reg(v, is_def=True)
+    c.add_reg(w0)
+    cbz = b.build_instr(mf.opcode("CBZW"))
+    cbz.add_reg(v)
+    cbz.add_mbb(b2)
+    b0.add_successor(b1)
+    b0.add_successor(b2)
+    b.set_block(b1)
+    j = b.build_instr(mf.opcode("B"))
+    j.add_mbb(b2)
+    b1.add_successor(b2)
+    b.set_block(b2)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+class _SingleBlockSplit(mir.RegAllocBase):
+    """Split around the last use block (enter_intv_before + leave_intv_after)."""
+
+    split = False
+
+    def select_or_split(self, li):
+        if not type(self).split:
+            sa = self.split_analysis
+            sa.analyze(li)
+            cand = [bi for bi in sa.use_blocks() if not bi.live_out]
+            if cand and sa.num_through_blocks() > 0:
+                bi = cand[-1]
+                se = self.split_editor
+                se.reset(self.new_live_range_edit(li))
+                se.open_intv()
+                start = se.enter_intv_before(bi.first_instr)
+                stop = se.leave_intv_after(bi.last_instr)
+                se.use_intv(start, stop)
+                se.finish()
+                type(self).split = True
+                return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_region_split_single_block_emits():
+    _SingleBlockSplit.split = False
+    mir.register_regalloc("ra-split-1", _SingleBlockSplit)
+    obj = _emit("ra-split-1", _SingleBlockSplit, builder=_build_three_block, fn="thru")
+    assert obj[:4] == b"\x7fELF"
+    assert _SingleBlockSplit.split, "the split path ran"
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_region_split_single_block_executes():
+    _SingleBlockSplit.split = False
+    mir.register_regalloc("ra-split-1x", _SingleBlockSplit)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "thru")
+        _build_three_block(mmi)
+        obj = mmi.emit_object(regalloc="ra-split-1x")
+        thru, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "thru", obj)
+        assert thru(5) == 5 and thru(-3) == -3
+        del j
+    assert_no_leaks()
+
+
+class _ThroughBlockSplit(mir.RegAllocBase):
+    """Keep the value in a register across the through block using the
+    block-level primitives (select_intv/enter_intv_at_end/use_intv_mbb/
+    leave_intv_at_top), with the SM_Size complement mode."""
+
+    split = False
+    new_vregs = 0
+
+    def select_or_split(self, li):
+        cls = type(self)
+        if not cls.split:
+            sa = self.split_analysis
+            sa.analyze(li)
+            if sa.num_through_blocks() > 0:
+                mf = self.machine_function
+                b0, b1, b2 = mf.blocks[0], mf.blocks[1], mf.blocks[2]
+                lre = self.new_live_range_edit(li)
+                se = self.split_editor
+                se.reset(lre, mir.ComplementSpillMode.SM_Size)
+                idx = se.open_intv()
+                se.select_intv(idx)
+                se.enter_intv_at_end(b0)
+                se.use_intv_mbb(b1)
+                se.leave_intv_at_top(b2)
+                se.finish()
+                cls.new_vregs = len(lre.new_vregs())
+                cls.split = True
+                return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_region_split_through_block_emits():
+    _ThroughBlockSplit.split = False
+    mir.register_regalloc("ra-split-thru", _ThroughBlockSplit)
+    obj = _emit(
+        "ra-split-thru", _ThroughBlockSplit, builder=_build_three_block, fn="thru"
+    )
+    assert obj[:4] == b"\x7fELF"
+    assert _ThroughBlockSplit.split
+    assert _ThroughBlockSplit.new_vregs > 0
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_region_split_through_block_executes():
+    _ThroughBlockSplit.split = False
+    mir.register_regalloc("ra-split-thru-x", _ThroughBlockSplit)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "thru")
+        _build_three_block(mmi)
+        obj = mmi.emit_object(regalloc="ra-split-thru-x")
+        thru, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "thru", obj)
+        assert thru(11) == 11
+        del j
+    assert_no_leaks()
+
+
+class _EnterAfterSplit(mir.RegAllocBase):
+    """Split out of the def block with enter_intv_after + leave_intv_before."""
+
+    split = False
+
+    def select_or_split(self, li):
+        cls = type(self)
+        if not cls.split:
+            sa = self.split_analysis
+            sa.analyze(li)
+            defblk = [bi for bi in sa.use_blocks() if bi.first_def.is_valid()]
+            if defblk and sa.num_through_blocks() > 0:
+                bi = defblk[0]
+                se = self.split_editor
+                se.reset(self.new_live_range_edit(li))
+                se.open_intv()
+                start = se.enter_intv_after(bi.first_def)
+                stop = se.leave_intv_before(sa.last_split_point(bi.mbb))
+                se.use_intv(start, stop)
+                se.finish()
+                cls.split = True
+                return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_split_enter_after_leave_before_emits():
+    _EnterAfterSplit.split = False
+    mir.register_regalloc("ra-split-after", _EnterAfterSplit)
+    obj = _emit(
+        "ra-split-after", _EnterAfterSplit, builder=_build_three_block, fn="thru"
+    )
+    assert obj[:4] == b"\x7fELF"
+    assert _EnterAfterSplit.split
+    assert_no_leaks()
+
+
+class _OverlapSplit(mir.RegAllocBase):
+    """Split the def block whose last use is its terminator, driving the
+    overlap_intv path (last use at the last split point, value live-out)."""
+
+    split = False
+
+    def select_or_split(self, li):
+        cls = type(self)
+        if not cls.split:
+            sa = self.split_analysis
+            sa.analyze(li)
+            b0 = self.machine_function.blocks[0]
+            cand = [
+                bi
+                for bi in sa.use_blocks()
+                if bi.mbb.number == b0.number and bi.live_out
+            ]
+            if cand:
+                bi = cand[0]
+                lsp = sa.last_split_point(b0)
+                se = self.split_editor
+                se.reset(self.new_live_range_edit(li))
+                se.open_intv()
+                start = bi.first_instr if bi.first_instr < lsp else lsp
+                seg_start = se.enter_intv_before(start)
+                seg_stop = se.leave_intv_before(lsp)
+                se.use_intv(seg_start, seg_stop)
+                se.overlap_intv(seg_stop, bi.last_instr)
+                se.finish()
+                cls.split = True
+                return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_split_overlap_intv_emits():
+    _OverlapSplit.split = False
+    mir.register_regalloc("ra-split-overlap", _OverlapSplit)
+    obj = _emit("ra-split-overlap", _OverlapSplit, builder=_build_cbz, fn="cbz")
+    assert obj[:4] == b"\x7fELF"
+    assert _OverlapSplit.split
+    assert_no_leaks()
+
+
+class _SplitRecordsRemoval(_ThroughBlockSplit):
+    """The through-block region split leaves the complement empty in a block, so
+    allocatePhysRegs drops that interval; an about_to_remove_interval override
+    witnesses the hook firing."""
+
+    removed = 0
+
+    def about_to_remove_interval(self, li):
+        type(self).removed += 1
+
+
+def test_about_to_remove_interval_forwarded_during_split():
+    _SplitRecordsRemoval.split = False
+    _SplitRecordsRemoval.removed = 0
+    mir.register_regalloc("ra-removal", _SplitRecordsRemoval)
+    obj = _emit(
+        "ra-removal",
+        _SplitRecordsRemoval,
+        builder=_build_three_block,
+        fn="thru",
+    )
+    assert obj[:4] == b"\x7fELF"
+    assert _SplitRecordsRemoval.removed > 0, "about_to_remove_interval fired"
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_split_overlap_intv_executes():
+    _OverlapSplit.split = False
+    mir.register_regalloc("ra-split-overlap-x", _OverlapSplit)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "cbz")
+        _build_cbz(mmi)
+        obj = mmi.emit_object(regalloc="ra-split-overlap-x")
+        cbz, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "cbz", obj)
+        assert cbz(5) == 5 and cbz(0) == 0
+        del j
+    assert_no_leaks()
+
+
+class _PreAssignAllocator(mir.RegAllocBase):
+    """Records enqueued regs (the native queue still drives dequeue) and, on its
+    first call, assigns a *different* still-queued interval out of order. When
+    the native queue later pops that already-assigned reg it is skipped -- the
+    stale-entry guard in the default dequeue."""
+
+    def __init__(self):
+        super().__init__()
+        self.queued = []
+        self.pre_assigned = False
+
+    def enqueue(self, li):
+        self.queued.append(li.reg)
+
+    def select_or_split(self, li):
+        if not self.pre_assigned:
+            for r in self.queued:
+                if r == li.reg or not self.lis.has_interval(r):
+                    continue
+                other = self.lis.interval(r)
+                for preg in self.allocation_order(other):
+                    if self.matrix.is_free(other, preg):
+                        self.matrix.assign(other, preg)
+                        self.pre_assigned = True
+                        break
+                if self.pre_assigned:
+                    break
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_default_dequeue_skips_already_assigned():
+    mir.register_regalloc("ra-preassign", _PreAssignAllocator)
+    obj = _emit("ra-preassign", _PreAssignAllocator)
+    assert obj[:4] == b"\x7fELF"
+    assert_no_leaks()
+
+
 # -- exception matrix ---------------------------------------------------------
 
 
@@ -522,6 +847,18 @@ def test_init_raise_propagates():
 
     mir.register_regalloc("ra-init-boom", Boom)
     _expect_raise("ra-init-boom", Boom, "init boom")
+
+
+def test_about_to_remove_interval_raise_propagates():
+    class Boom(_ThroughBlockSplit):
+        def about_to_remove_interval(self, li):
+            raise ValueError("atr boom")
+
+    Boom.split = False
+    mir.register_regalloc("ra-atr-boom", Boom)
+    _expect_raise(
+        "ra-atr-boom", Boom, "atr boom", builder=_build_three_block, fn="thru"
+    )
 
 
 def test_post_optimization_raise_propagates():

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1,0 +1,23 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import ctypes, math, platform
+import pytest
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked (EUDSL_LLVMPY_TARGETS)",
+)
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+_IS_AARCH64 = platform.machine() in ("arm64", "aarch64")
+
+
+def test_register_regalloc_requires_regallocbase_subclass():
+    class NotAnAllocator:
+        def select_or_split(self, li): ...
+
+    with pytest.raises(TypeError, match="RegAllocBase"):
+        mir.register_regalloc("ra-bad", NotAnAllocator)

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -383,6 +383,84 @@ def test_slot_index_and_live_intervals_accessors():
     assert_no_leaks()
 
 
+def _build_three_block(mmi):
+    """b0 defines v, b1 is empty (v live-through), b2 uses v: gives SplitAnalysis
+    one through block and two use blocks for v's interval."""
+    mf = mmi.machine_function("thru")
+    b = mir.MachineIRBuilder(mf)
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    b0 = mf.blocks[0]
+    b1 = mf.create_block()
+    b2 = mf.create_block()
+    b0.add_livein(w0)
+    copy = mf.opcode("COPY")
+    br = mf.opcode("B")
+
+    b.set_block(b0)
+    v = mf.create_vreg(gpr32)
+    c = b.build_instr(copy)
+    c.add_reg(v, is_def=True)
+    c.add_reg(w0)
+    j0 = b.build_instr(br)
+    j0.add_mbb(b1)
+    b0.add_successor(b1)
+
+    b.set_block(b1)
+    j1 = b.build_instr(br)
+    j1.add_mbb(b2)
+    b1.add_successor(b2)
+
+    b.set_block(b2)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+# -- SplitAnalysis ------------------------------------------------------------
+
+
+def test_split_analysis_use_and_through_blocks():
+    saw = {}
+
+    class Analyzer(mir.RegAllocBase):
+        def select_or_split(self, li):
+            if "use_blocks" not in saw:
+                sa = self.split_analysis
+                sa.analyze(li)
+                blocks = sa.use_blocks()
+                saw["use_blocks"] = len(blocks)
+                bi = blocks[0]
+                saw["mbb_num"] = bi.mbb.number
+                saw["first_valid"] = bi.first_instr.is_valid()
+                saw["last_valid"] = bi.last_instr.is_valid()
+                saw["first_def_valid"] = bi.first_def.is_valid()
+                saw["live_in"] = bi.live_in
+                saw["live_out"] = bi.live_out
+                saw["num_through"] = sa.num_through_blocks()
+                saw["through"] = sa.through_blocks()
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-split-analysis", Analyzer)
+    obj = _emit("ra-split-analysis", Analyzer, builder=_build_three_block, fn="thru")
+    assert obj[:4] == b"\x7fELF"
+    assert saw["use_blocks"] >= 1
+    assert saw["first_valid"] and saw["last_valid"]
+    assert saw["num_through"] == 1
+    assert len(saw["through"]) == 1
+    assert isinstance(saw["live_in"], bool) and isinstance(saw["live_out"], bool)
+    assert_no_leaks()
+
+
 # -- exception matrix ---------------------------------------------------------
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -235,26 +235,36 @@ def test_query_accessors_and_manual_assignment():
     assert_no_leaks()
 
 
+_listq_dequeued = []
+
+
 def test_custom_enqueue_dequeue_queue():
     """A Python-side FIFO queue via enqueue/dequeue drives the assignment order
-    instead of the native spill-weight queue."""
+    instead of the native spill-weight queue. enqueue/dequeue traffic in
+    register ids, not LiveInterval objects, which splitting would invalidate."""
+    _listq_dequeued.clear()
 
     class ListQueue(mir.BasicRegAlloc):
         def __init__(self):
             super().__init__()
             self.q = []
 
-        def enqueue(self, li):
-            self.q.append(li)
+        def enqueue(self, reg):
+            self.q.append(reg)
 
         def dequeue(self):
             if not self.q:
                 return None
-            return self.q.pop(0)
+            reg = self.q.pop(0)
+            _listq_dequeued.append(reg)
+            return reg
 
     mir.register_regalloc("ra-listq", ListQueue)
     obj = _emit("ra-listq", ListQueue)
     assert obj[:4] == b"\x7fELF"
+    # Witness that the Python dequeue (not the native drain) drove allocation:
+    # native dequeue would leave this list empty.
+    assert _listq_dequeued, "the Python queue drove dequeue"
     assert_no_leaks()
 
 
@@ -355,6 +365,7 @@ def test_slot_index_and_live_intervals_accessors():
                 idx = self.lis.instruction_index(mi)
                 saw["ordered"] = start < end
                 saw["eq"] = start == start
+                saw["ne"] = start == end  # distinct points compare unequal
                 saw["valid"] = start.is_valid()
                 saw["idx_in_block"] = (start < idx) and (idx < end)
                 saw["reg_slot"] = idx.get_reg_slot().is_valid()
@@ -374,6 +385,7 @@ def test_slot_index_and_live_intervals_accessors():
     obj = _emit("ra-slots", Reader)
     assert obj[:4] == b"\x7fELF"
     assert saw["ordered"] and saw["eq"] and saw["valid"]
+    assert saw["ne"] is False, "distinct SlotIndexes compare unequal"
     assert saw["idx_in_block"]
     assert saw["reg_slot"] and saw["base"] and saw["boundary"] and saw["next"]
     assert "SlotIndex" in saw["repr"]
@@ -437,7 +449,9 @@ def test_split_analysis_use_and_through_blocks():
                 saw["mbb_num"] = bi.mbb.number
                 saw["first_valid"] = bi.first_instr.is_valid()
                 saw["last_valid"] = bi.last_instr.is_valid()
-                saw["first_def_valid"] = bi.first_def.is_valid()
+                # The def block reports a valid first_def; the use-only block
+                # reports an invalid one.
+                saw["any_first_def"] = any(b.first_def.is_valid() for b in blocks)
                 saw["live_in"] = bi.live_in
                 saw["live_out"] = bi.live_out
                 saw["num_through"] = sa.num_through_blocks()
@@ -453,6 +467,7 @@ def test_split_analysis_use_and_through_blocks():
     assert obj[:4] == b"\x7fELF"
     assert saw["use_blocks"] >= 1
     assert saw["first_valid"] and saw["last_valid"]
+    assert saw["any_first_def"], "the def block reports a valid first_def"
     assert saw["num_through"] == 1
     assert len(saw["through"]) == 1
     assert isinstance(saw["live_in"], bool) and isinstance(saw["live_out"], bool)
@@ -656,6 +671,22 @@ def test_split_enter_after_leave_before_emits():
     assert_no_leaks()
 
 
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_split_enter_after_leave_before_executes():
+    _EnterAfterSplit.split = False
+    mir.register_regalloc("ra-split-after-x", _EnterAfterSplit)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "thru")
+        _build_three_block(mmi)
+        obj = mmi.emit_object(regalloc="ra-split-after-x")
+        thru, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "thru", obj)
+        assert thru(9) == 9 and thru(-4) == -4
+        del j
+    assert_no_leaks()
+
+
 class _OverlapSplit(mir.RegAllocBase):
     """Split the def block whose last use is its terminator, driving the
     overlap_intv path (last use at the last split point, value live-out)."""
@@ -745,22 +776,26 @@ def test_split_overlap_intv_executes():
     assert_no_leaks()
 
 
+_preassign = {}
+
+
 class _PreAssignAllocator(mir.RegAllocBase):
-    """Records enqueued regs (the native queue still drives dequeue) and, on its
-    first call, assigns a *different* still-queued interval out of order. When
-    the native queue later pops that already-assigned reg it is skipped -- the
-    stale-entry guard in the default dequeue."""
+    """Records enqueued register ids (the native queue still drives dequeue) and,
+    on its first call, assigns a *different* still-queued interval out of order.
+    When the native queue later pops that already-assigned reg it is skipped --
+    the stale-entry guard in the default dequeue -- so it never reaches
+    select_or_split."""
 
     def __init__(self):
         super().__init__()
         self.queued = []
-        self.pre_assigned = False
 
-    def enqueue(self, li):
-        self.queued.append(li.reg)
+    def enqueue(self, reg):
+        self.queued.append(reg)
 
     def select_or_split(self, li):
-        if not self.pre_assigned:
+        _preassign.setdefault("selected", []).append(li.reg)
+        if "assigned" not in _preassign:
             for r in self.queued:
                 if r == li.reg or not self.lis.has_interval(r):
                     continue
@@ -768,9 +803,9 @@ class _PreAssignAllocator(mir.RegAllocBase):
                 for preg in self.allocation_order(other):
                     if self.matrix.is_free(other, preg):
                         self.matrix.assign(other, preg)
-                        self.pre_assigned = True
+                        _preassign["assigned"] = r
                         break
-                if self.pre_assigned:
+                if "assigned" in _preassign:
                     break
         for preg in self.allocation_order(li):
             if self.matrix.is_free(li, preg):
@@ -780,9 +815,16 @@ class _PreAssignAllocator(mir.RegAllocBase):
 
 
 def test_default_dequeue_skips_already_assigned():
+    _preassign.clear()
     mir.register_regalloc("ra-preassign", _PreAssignAllocator)
     obj = _emit("ra-preassign", _PreAssignAllocator)
     assert obj[:4] == b"\x7fELF"
+    # The out-of-order assignment happened, and the native dequeue skipped that
+    # already-assigned reg: it is never handed to select_or_split.
+    assert "assigned" in _preassign, "pre-assigned an out-of-order interval"
+    assert (
+        _preassign["assigned"] not in _preassign["selected"]
+    ), "the already-assigned reg was skipped by the default dequeue"
     assert_no_leaks()
 
 
@@ -887,3 +929,107 @@ def test_native_fallback_spills_after_init_raise_under_pressure():
     _expect_raise(
         "ra-hp-init", Boom, "hp init boom", builder=_build_high_pressure, fn="hp"
     )
+
+
+# -- misuse guards (raise instead of segfault/abort) --------------------------
+
+
+def test_spill_outside_select_or_split_raises():
+    """self.spill is only valid inside select_or_split; calling it from another
+    callback raises rather than dereferencing the null split context."""
+
+    class Boom(mir.BasicRegAlloc):
+        def enqueue(self, reg):
+            self.spill(self.lis.interval(reg))
+
+    mir.register_regalloc("ra-spill-misuse", Boom)
+    _expect_raise("ra-spill-misuse", Boom, "only valid inside select_or_split")
+
+
+def test_new_live_range_edit_outside_select_or_split_raises():
+    class Boom(mir.BasicRegAlloc):
+        def enqueue(self, reg):
+            self.new_live_range_edit(self.lis.interval(reg))
+
+    mir.register_regalloc("ra-lre-misuse", Boom)
+    _expect_raise("ra-lre-misuse", Boom, "only valid inside select_or_split")
+
+
+def test_select_or_split_bad_physreg_raises():
+    """Returning a physreg that is not a free candidate raises rather than
+    aborting in Matrix::assign. The high-pressure vregs are all simultaneously
+    live, so handing a later one the register the first already got is an
+    occupied, interfering candidate."""
+
+    class ReturnsOccupied(mir.RegAllocBase):
+        def __init__(self):
+            super().__init__()
+            self.first = None
+
+        def select_or_split(self, li):
+            if self.first is None:
+                for preg in self.allocation_order(li):
+                    if self.matrix.is_free(li, preg):
+                        self.first = preg
+                        return preg
+            return self.first  # taken by an interfering vreg -> not free
+
+    mir.register_regalloc("ra-bad-phys", ReturnsOccupied)
+    _expect_raise(
+        "ra-bad-phys",
+        ReturnsOccupied,
+        "not a free candidate",
+        builder=_build_high_pressure,
+        fn="hp",
+    )
+
+
+_pyskip = {}
+
+
+class _StaleQueueAllocator(mir.BasicRegAlloc):
+    """Drives dequeue from a Python queue but assigns one still-queued interval
+    out of order, so when dequeue later yields that reg id it is already
+    assigned and the trampoline skips it (the Python-path stale-entry guard)."""
+
+    def __init__(self):
+        super().__init__()
+        self.q = []
+
+    def enqueue(self, reg):
+        self.q.append(reg)
+
+    def dequeue(self):
+        return self.q.pop(0) if self.q else None
+
+    def select_or_split(self, li):
+        if "assigned" not in _pyskip:
+            for r in self.q:
+                if not self.lis.has_interval(r):
+                    continue
+                other = self.lis.interval(r)
+                for preg in self.allocation_order(other):
+                    if self.matrix.is_free(other, preg):
+                        self.matrix.assign(other, preg)
+                        _pyskip["assigned"] = r
+                        break
+                if "assigned" in _pyskip:
+                    break
+        _pyskip.setdefault("selected", []).append(li.reg)
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_python_dequeue_skips_already_assigned():
+    _pyskip.clear()
+    mir.register_regalloc("ra-pyskip", _StaleQueueAllocator)
+    obj = _emit("ra-pyskip", _StaleQueueAllocator)
+    assert obj[:4] == b"\x7fELF"
+    assert "assigned" in _pyskip, "pre-assigned an out-of-order interval"
+    assert (
+        _pyskip["assigned"] not in _pyskip["selected"]
+    ), "the already-assigned reg id from Python dequeue was skipped"
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_strategy_classes.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_strategy_classes.py
@@ -1,0 +1,54 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Pure-Python unit tests for the convenience strategy classes in
+llvm.mir_strategies.
+
+These exercise the Python-side logic directly (no codegen), so they run
+everywhere -- including x86-only builds where the AArch64 backend is not linked
+and the emit/scheduler/regalloc tests skip. mir.ReadyQueueStrategy is a plain
+ready-queue helper whose methods do not touch the codegen pipeline, so it can be
+driven with placeholder nodes.
+"""
+
+from llvm import mir
+from llvm.testing import assert_no_leaks
+
+
+def test_ready_queue_strategy_default_pick_is_fifo():
+    s = mir.ReadyQueueStrategy()
+    s.initialize(None)  # dag unused; just resets the ready queue
+
+    policy = s.get_policy()
+    assert policy.only_top_down
+    assert not policy.should_track_pressure
+
+    a, b = object(), object()
+    s.release_top_node(a)
+    s.release_top_node(b)
+    s.release_bottom_node(a)  # top-down strategy ignores bottom releases
+    s.sched_node(a, True)  # no-op hook
+
+    # Default pick() takes the first ready node; pick_node returns (node, is_top)
+    # and removes it, then None once drained.
+    assert s.pick_node() == (a, True)
+    assert s.pick_node() == (b, True)
+    assert s.pick_node() is None
+    assert_no_leaks()
+
+
+def test_ready_queue_strategy_pick_override():
+    class LastReady(mir.ReadyQueueStrategy):
+        def pick(self, ready):
+            return ready[-1]
+
+    s = LastReady()
+    s.initialize(None)
+    a, b, c = object(), object(), object()
+    for su in (a, b, c):
+        s.release_top_node(su)
+    assert s.pick_node() == (c, True)
+    assert s.pick_node() == (b, True)
+    assert s.pick_node() == (a, True)
+    assert s.pick_node() is None
+    assert_no_leaks()


### PR DESCRIPTION
Stacked on #647 (SplitKit.h vendoring).

Lets Python subclass `llvm::RegAllocBase` and implement an arbitrary register
allocator, including RAGreedy-style live-range region splitting via raw
`SplitEditor` primitives, selected with `emit_object(regalloc="name")`.

## Design

- `mir.RegAllocBase` binds the trampoline **as the value type** (not
  `nb::class_<RegAllocBase, Py...>`), because `llvm::RegAllocBase` has a
  protected destructor — nanobind keys destructor registration off the value
  type's destructibility, so binding it directly aborts when a Python-owned
  instance is freed.
- A pure-C++ `NativeRegAlloc` (first-free-or-spill on a spill-weight queue) is
  both the base the trampoline defers to (default queue + post-stash fallback)
  and the standalone allocator the harness runs when a Python `__init__` raises,
  so the MIR stays valid and the exception re-raises instead of aborting the
  rewriter.
- `PyRegAllocDriver` is a fixed `MachineFunctionPass` occupying the codegen
  allocator slot; it fetches analyses (set modeled on RABasic), builds the
  InlineSpiller + `VirtRegAuxInfo` + `SplitAnalysis`/`SplitEditor`, constructs a
  fresh Python allocator per `MachineFunction`, and drives it via
  `pyInit`/`pyAllocate`.
- `emit_object(regalloc="name")` overrides `RegisterRegAlloc::getDefault()` (the
  process-global the pipeline caches via `call_once`; the `-regalloc` cl::opt is
  ignored once cached) and restores it, mirroring the scheduler's `-misched`.

## Surface

`select_or_split` (required) returning a physreg id or `None`; optional
`enqueue`/`dequeue`/`post_optimization`/`about_to_remove_interval`. Helpers:
`allocation_order`, `spill`, `matrix`, `lis`, `vrm`, `machine_function`,
`split_analysis`, `split_editor`, `new_live_range_edit`. Supporting bindings:
`LiveInterval`, `LiveRegMatrix` + `InterferenceKind`, `VirtRegMap`, `Spiller`,
`LiveIntervals`, `SlotIndex`, `SplitAnalysis` + `BlockInfo`, `SplitEditor` +
`ComplementSpillMode`, `LiveRangeEdit`. `mir.BasicRegAlloc` is the trivial
first-free-or-spill allocator.

## Tests

A 32-test suite: registration contract, query/mutate surface, native + custom
queues, spilling, fresh-instance-per-emission, the exception matrix, and four
region-split choreographies that exercise every `SplitEditor` primitive and
JIT-execute to the correct result. `src/IR` + `src/MIR` C++ coverage is 100%
line + function.

Supersedes #644.