### PR TITLE
[eudsl-llvmpy] MIR regalloc: bind MachineBlockFrequencyInfo + self.mbfi (#652 gap 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 /mlir_wheel/
 /mlir_wheel-*.whl
 /mlir_wheel-*.dist-info/
+docs/superpowers/

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -417,8 +417,10 @@ append new virtual registers that get re-enqueued). The allocator queries and
 mutates state through `self`: `allocation_order(li)` (physregs to try, in target
 order), `self.matrix` (`is_free`/`check_interference`/`assign`/`unassign`),
 `self.lis` (LiveIntervals: `instruction_index`, `mbb_start_index`,
-`mbb_end_index`, `has_interval`, `interval`), `self.vrm`, and
-`self.machine_function`. Optional overrides: `enqueue(reg)`/`dequeue()` (drive
+`mbb_end_index`, `has_interval`, `interval`), `self.vrm`,
+`self.machine_function`, and `self.mbfi` (MachineBlockFrequencyInfo:
+`block_freq`, `block_freq_relative_to_entry_block`, `entry_freq`, for
+frequency-weighted spill/split cost models). Optional overrides: `enqueue(reg)`/`dequeue()` (drive
 the assignment order; both traffic in register ids -- stable across splitting,
 unlike interval objects -- and `dequeue` returns a reg id or `None`; the default
 is a spill-weight priority queue), `post_optimization()`, and

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -34,6 +34,7 @@
 #include <llvm/PassRegistry.h>
 
 #include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
@@ -506,9 +507,10 @@ public:
   void pyInit(llvm::VirtRegMap &vrm, llvm::LiveIntervals &lis,
               llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
               llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
-              llvm::SplitEditor *se) {
+              llvm::SplitEditor *se, llvm::MachineBlockFrequencyInfo *mbfi) {
     splitAnalysis = sa;
     splitEditor = se;
+    blockFreqInfo = mbfi;
     NativeRegAlloc::pyInit(vrm, lis, mat, sp, mfn);
   }
 
@@ -523,6 +525,9 @@ public:
   llvm::MachineFunction *machineFunction() { return mf; }
   llvm::SplitAnalysis *splitAnalysisPtr() { return splitAnalysis; }
   llvm::SplitEditor *splitEditorPtr() { return splitEditor; }
+  llvm::MachineBlockFrequencyInfo *blockFrequencyInfo() {
+    return blockFreqInfo;
+  }
 
   // Physregs, in target allocation order, that Python may try for `li`.
   std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
@@ -589,6 +594,7 @@ private:
   llvm::SmallVectorImpl<llvm::Register> *currentSplit = nullptr;
   llvm::SplitAnalysis *splitAnalysis = nullptr;
   llvm::SplitEditor *splitEditor = nullptr;
+  llvm::MachineBlockFrequencyInfo *blockFreqInfo = nullptr;
   std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
 
@@ -741,7 +747,7 @@ public:
     }
     auto *base =
         static_cast<PyRegAllocBase *>(nb::inst_ptr<PyRegAllocBase>(obj));
-    base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se);
+    base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se, &mbfi);
     base->pyAllocate();
     // Hold the instance until the pass is destroyed so its C++ subobject (and
     // any Python-recorded witness state) outlives this call; dropped under the
@@ -966,7 +972,14 @@ void populate_python_codegen(nb::module_ &m) {
           nb::rv_policy::reference, "li"_a,
           "A LiveRangeEdit over the current split-vreg vector, for "
           "split_editor.reset. Only valid inside select_or_split; do not "
-          "retain past the call.");
+          "retain past the call.")
+      .def_prop_ro(
+          "mbfi",
+          [](PyRegAllocBase &self) { return self.blockFrequencyInfo(); },
+          nb::rv_policy::reference,
+          "The MachineBlockFrequencyInfo for frequency-weighted cost models. "
+          "Borrowed and valid only within an allocator callback; do not "
+          "retain.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
@@ -981,6 +994,53 @@ void populate_python_codegen(nb::module_ &m) {
 
   nb::class_<llvm::VirtRegMap>(m, "VirtRegMap");
   nb::class_<llvm::Spiller>(m, "Spiller");
+
+  // A block's estimated execution frequency as a fixed-point number scaled by
+  // the entry frequency (llvm::BlockFrequency). Comparable and additive so a
+  // cost model can weigh and combine frequencies directly.
+  nb::class_<llvm::BlockFrequency>(m, "BlockFrequency")
+      .def(nb::init<uint64_t>(), "freq"_a)
+      .def_static("max", &llvm::BlockFrequency::max,
+                  "The saturation value (maximum possible frequency).")
+      .def("get_frequency", &llvm::BlockFrequency::getFrequency,
+           "The raw fixed-point frequency value.")
+      .def(nb::self < nb::self, "other"_a)
+      .def(nb::self <= nb::self, "other"_a)
+      .def(nb::self > nb::self, "other"_a)
+      .def(nb::self >= nb::self, "other"_a)
+      .def(nb::self == nb::self, "other"_a)
+      .def(nb::self != nb::self, "other"_a)
+      .def(nb::self + nb::self, "other"_a)
+      .def(nb::self - nb::self, "other"_a)
+      .def("__repr__", [](const llvm::BlockFrequency &f) {
+        return "BlockFrequency(" + std::to_string(f.getFrequency()) + ")";
+      });
+
+  // Frequency estimates per block, driving frequency-weighted spill/split cost
+  // models (the weighting RAGreedy applies). Frequencies are relative to the
+  // entry block; block_freq_relative_to_entry_block gives the ratio directly.
+  nb::class_<llvm::MachineBlockFrequencyInfo>(m, "MachineBlockFrequencyInfo")
+      .def(
+          "block_freq",
+          [](llvm::MachineBlockFrequencyInfo &mbfi,
+             llvm::MachineBasicBlock *mbb) { return mbfi.getBlockFreq(mbb); },
+          "mbb"_a,
+          "Estimated frequency of `mbb` (compare against other blocks or "
+          "entry_freq).")
+      .def(
+          "block_freq_relative_to_entry_block",
+          [](llvm::MachineBlockFrequencyInfo &mbfi,
+             llvm::MachineBasicBlock *mbb) {
+            return mbfi.getBlockFreqRelativeToEntryBlock(mbb);
+          },
+          "mbb"_a, "Frequency of `mbb` as a ratio to the entry block (1.0).")
+      .def(
+          "entry_freq",
+          [](llvm::MachineBlockFrequencyInfo &mbfi) {
+            return mbfi.getEntryFreq();
+          },
+          "Frequency of the entry block (the denominator of the relative "
+          "frequencies).");
 
   // A program point. Live ranges and the split editor are expressed in terms of
   // these; they order the instructions of a function.

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -346,6 +346,65 @@ def test_high_pressure_executes():
     assert_no_leaks()
 
 
+# -- MachineBlockFrequencyInfo ------------------------------------------------
+
+
+def test_block_frequency_info_accessors():
+    """Read block frequencies from inside select_or_split: the entry block's
+    relative frequency is 1.0 and its BlockFrequency equals entry_freq, and a
+    conditionally-reached block is strictly less frequent than the entry (both
+    as a ratio and as a raw BlockFrequency)."""
+    saw = {}
+
+    class FreqReader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            if not saw:
+                mbfi = self.mbfi
+                mf = self.machine_function
+                entry, b1 = mf.blocks[0], mf.blocks[1]
+                saw["entry_rel"] = mbfi.block_freq_relative_to_entry_block(entry)
+                saw["b1_rel"] = mbfi.block_freq_relative_to_entry_block(b1)
+                saw["entry_freq"] = mbfi.entry_freq()
+                saw["entry_block_freq"] = mbfi.block_freq(entry)
+                saw["b1_block_freq"] = mbfi.block_freq(b1)
+                # Exercise the BlockFrequency arithmetic/limit surface.
+                saw["sum"] = mbfi.block_freq(entry) + mbfi.block_freq(b1)
+                saw["diff"] = mbfi.block_freq(entry) - mbfi.block_freq(b1)
+                saw["max"] = mir.BlockFrequency.max()
+                saw["repr"] = repr(mbfi.block_freq(entry))
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-mbfi", FreqReader)
+    obj = _emit("ra-mbfi", FreqReader, builder=_build_cbz, fn="cbz")
+    assert obj[:4] == b"\x7fELF"
+    assert saw["entry_rel"] == 1.0
+    assert saw["entry_freq"].get_frequency() > 0
+    # The entry block's BlockFrequency equals the relative denominator
+    # (exercises BlockFrequency.__eq__).
+    assert saw["entry_block_freq"] == saw["entry_freq"]
+    # b1 is only reached on the not-taken branch, so it cannot exceed entry.
+    assert 0.0 < saw["b1_rel"] <= saw["entry_rel"]
+    # block_freq must actually depend on its mbb argument: the conditionally
+    # reached b1 is strictly less frequent than the entry (BlockFrequency.__lt__).
+    assert saw["b1_block_freq"] < saw["entry_block_freq"]
+    assert saw["b1_block_freq"] != saw["entry_block_freq"]
+    assert saw["entry_block_freq"] > saw["b1_block_freq"]
+    assert saw["entry_block_freq"] >= saw["b1_block_freq"]
+    assert saw["b1_block_freq"] <= saw["entry_block_freq"]
+    # BlockFrequency arithmetic and saturation limit.
+    ef = saw["entry_block_freq"].get_frequency()
+    bf = saw["b1_block_freq"].get_frequency()
+    assert saw["sum"].get_frequency() == ef + bf
+    assert saw["diff"].get_frequency() == ef - bf
+    assert saw["max"].get_frequency() > ef
+    assert saw["repr"] == f"BlockFrequency({ef})"
+    assert_no_leaks()
+
+
 # -- SlotIndex / LiveIntervals accessors --------------------------------------
 
 


### PR DESCRIPTION
Expose the block-frequency surface a frequency-weighted spill/split cost
model needs (the weighting RAGreedy applies). The driver already builds
MBFI and threads it into VirtRegAuxInfo/InlineSpiller/SplitEditor, so this
adds a binding + accessor with no new analysis wiring:

- MachineBlockFrequencyInfo bound with block_frequency(mbb) (raw),
  block_freq_relative_to_entry(mbb) (ratio to entry), and entry_freq().
- self.mbfi accessor on RegAllocBase, threaded through PyRegAllocBase::pyInit.
- Test reads frequencies from select_or_split: entry relative freq == 1.0
  equals entry_freq, and a conditionally-reached block is <= entry.

cc #600