### PR TITLE
[eudsl-llvmpy] MIR regalloc: SpillPlacement + EdgeBundles for global splitting (#652 gap 3)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -475,6 +475,17 @@ class RegionSplit(mir.RegAllocBase):
         return None
 ```
 
+For global (region) splitting, `self.edge_bundles` (an `EdgeBundles`:
+`get_bundle(mbb, out)`, `num_bundles()`, `get_blocks(bundle)`) and
+`self.spill_placer` (a `SpillPlacement` Hopfield network: `prepare(bit_vector)`,
+`add_constraints([BlockConstraint])`, `add_pref_spill`, `add_links`,
+`scan_active_bundles`, `iterate`, `get_recent_positive`, `finish`,
+`get_block_frequency`) expose the machinery RAGreedy's `splitAroundRegion`
+drives. Build `mir.BlockConstraint`s (with `mir.BorderConstraint` entry/exit
+prefs) from the live-through use blocks, iterate the network, and read the
+in-register edge bundles out of the `mir.BitVector` passed to `prepare` to
+choose split boundaries.
+
 A fresh allocator instance is constructed per `MachineFunction`. Because this
 build has assertions enabled, an invalid split aborts with a diagnostic rather
 than emitting bad code, and an exception raised in any override propagates out

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -8,9 +8,11 @@
 #include "MIR/RegAllocBase.h"
 #include "MIR/SplitKit.h"
 
+#include <llvm/ADT/BitVector.h>
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/ProfileSummaryInfo.h>
 #include <llvm/CodeGen/CalcSpillWeights.h>
+#include <llvm/CodeGen/EdgeBundles.h>
 #include <llvm/CodeGen/LiveDebugVariables.h>
 #include <llvm/CodeGen/LiveInterval.h>
 #include <llvm/CodeGen/LiveIntervals.h>
@@ -29,6 +31,7 @@
 #include <llvm/CodeGen/ScheduleDAG.h>
 #include <llvm/CodeGen/ScheduleDAGMutation.h>
 #include <llvm/CodeGen/SlotIndexes.h>
+#include <llvm/CodeGen/SpillPlacement.h>
 #include <llvm/CodeGen/Spiller.h>
 #include <llvm/CodeGen/TargetRegisterInfo.h>
 #include <llvm/CodeGen/VirtRegMap.h>
@@ -509,10 +512,13 @@ public:
   void pyInit(llvm::VirtRegMap &vrm, llvm::LiveIntervals &lis,
               llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
               llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
-              llvm::SplitEditor *se, llvm::MachineBlockFrequencyInfo *mbfi) {
+              llvm::SplitEditor *se, llvm::MachineBlockFrequencyInfo *mbfi,
+              llvm::EdgeBundles *eb, llvm::SpillPlacement *spl) {
     splitAnalysis = sa;
     splitEditor = se;
     blockFreqInfo = mbfi;
+    edgeBundles = eb;
+    spillPlacer = spl;
     NativeRegAlloc::pyInit(vrm, lis, mat, sp, mfn);
   }
 
@@ -530,6 +536,8 @@ public:
   llvm::MachineBlockFrequencyInfo *blockFrequencyInfo() {
     return blockFreqInfo;
   }
+  llvm::EdgeBundles *edgeBundlesPtr() { return edgeBundles; }
+  llvm::SpillPlacement *spillPlacerPtr() { return spillPlacer; }
 
   // Physregs, in target allocation order, that Python may try for `li`.
   std::vector<unsigned> allocationOrder(const llvm::LiveInterval &li) {
@@ -618,6 +626,8 @@ private:
   llvm::SplitAnalysis *splitAnalysis = nullptr;
   llvm::SplitEditor *splitEditor = nullptr;
   llvm::MachineBlockFrequencyInfo *blockFreqInfo = nullptr;
+  llvm::EdgeBundles *edgeBundles = nullptr;
+  llvm::SpillPlacement *spillPlacer = nullptr;
   std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
 
@@ -697,6 +707,8 @@ public:
     au.addPreserved<llvm::VirtRegMapWrapperLegacy>();
     au.addRequired<llvm::LiveRegMatrixWrapperLegacy>();
     au.addPreserved<llvm::LiveRegMatrixWrapperLegacy>();
+    au.addRequired<llvm::EdgeBundlesWrapperLegacy>();
+    au.addRequired<llvm::SpillPlacementWrapperLegacy>();
     llvm::MachineFunctionPass::getAnalysisUsage(au);
   }
 
@@ -722,6 +734,10 @@ public:
         getAnalysis<llvm::MachineLoopInfoWrapperPass>().getLI();
     llvm::ProfileSummaryInfo &psi =
         getAnalysis<llvm::ProfileSummaryInfoWrapperPass>().getPSI();
+    llvm::EdgeBundles &edgeBundles =
+        getAnalysis<llvm::EdgeBundlesWrapperLegacy>().getEdgeBundles();
+    llvm::SpillPlacement &spillPlacer =
+        getAnalysis<llvm::SpillPlacementWrapperLegacy>().getResult();
 
     nb::gil_scoped_acquire gil;
     // LCOV_EXCL_START -- emit_object always sets the active class before
@@ -770,7 +786,8 @@ public:
     }
     auto *base =
         static_cast<PyRegAllocBase *>(nb::inst_ptr<PyRegAllocBase>(obj));
-    base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se, &mbfi);
+    base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se, &mbfi, &edgeBundles,
+                 &spillPlacer);
     base->pyAllocate();
     // Hold the instance until the pass is destroyed so its C++ subobject (and
     // any Python-recorded witness state) outlives this call; dropped under the
@@ -817,6 +834,8 @@ INITIALIZE_PASS_DEPENDENCY(VirtRegMapWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachineBlockFrequencyInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(EdgeBundlesWrapperLegacy)
+INITIALIZE_PASS_DEPENDENCY(SpillPlacementWrapperLegacy)
 INITIALIZE_PASS_END(PyRegAllocDriver, "eudsl-python-regalloc",
                     "eudsl Python register allocator", false, false)
 
@@ -1008,7 +1027,21 @@ void populate_python_codegen(nb::module_ &m) {
           nb::rv_policy::reference,
           "The MachineBlockFrequencyInfo for frequency-weighted cost models. "
           "Borrowed and valid only within an allocator callback; do not "
-          "retain.");
+          "retain.")
+      .def_prop_ro(
+          "edge_bundles",
+          [](PyRegAllocBase &self) { return self.edgeBundlesPtr(); },
+          nb::rv_policy::reference,
+          "The EdgeBundles partition of CFG edges, mapping blocks to the "
+          "bundles global splitting reasons about. Borrowed and valid only "
+          "within an allocator callback; do not retain.")
+      .def_prop_ro(
+          "spill_placer",
+          [](PyRegAllocBase &self) { return self.spillPlacerPtr(); },
+          nb::rv_policy::reference,
+          "The SpillPlacement network for choosing global-split boundaries "
+          "(the machinery RAGreedy's splitAroundRegion drives). Borrowed and "
+          "valid only within an allocator callback; do not retain.");
 
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
@@ -1087,6 +1120,142 @@ void populate_python_codegen(nb::module_ &m) {
           },
           "Frequency of the entry block (the denominator of the relative "
           "frequencies).");
+
+  // CFG edges partitioned into bundles: all edges leaving a block share one
+  // bundle, all edges entering it share another. Global region splitting
+  // reasons about which bundles keep the value in a register.
+  nb::class_<llvm::EdgeBundles>(m, "EdgeBundles")
+      .def(
+          "get_bundle",
+          [](llvm::EdgeBundles &eb, llvm::MachineBasicBlock *mbb, bool out) {
+            return eb.getBundle(mbb->getNumber(), out);
+          },
+          "mbb"_a, "out"_a,
+          "Bundle number for `mbb`'s incoming (out=False) or outgoing "
+          "(out=True) edges. Taking the block (not a raw number) keeps the "
+          "index in range by construction.")
+      .def("num_bundles", &llvm::EdgeBundles::getNumBundles,
+           "Total number of edge bundles in the CFG.")
+      .def(
+          "get_blocks",
+          [](llvm::EdgeBundles &eb, unsigned bundle) {
+            if (bundle >= eb.getNumBundles())
+              throw nb::index_error("bundle number out of range");
+            llvm::ArrayRef<unsigned> blocks = eb.getBlocks(bundle);
+            return std::vector<unsigned>(blocks.begin(), blocks.end());
+          },
+          "bundle"_a,
+          "Block numbers connected to `bundle` (0 <= bundle < "
+          "num_bundles).");
+
+  // The bit vector SpillPlacement writes its per-bundle register/spill decision
+  // into. prepare() retains it and finish() fills it, so the Python caller must
+  // keep it alive across the placement calls.
+  nb::class_<llvm::BitVector>(m, "BitVector")
+      .def(nb::init<>())
+      .def(
+          "test", [](llvm::BitVector &bv, unsigned i) { return bv.test(i); },
+          "i"_a, "Whether bit `i` is set.")
+      .def("count", &llvm::BitVector::count, "Number of set bits.")
+      .def("size", &llvm::BitVector::size, "Number of bits.")
+      .def(
+          "set_bits",
+          [](llvm::BitVector &bv) {
+            std::vector<unsigned> v;
+            for (unsigned i : bv.set_bits())
+              v.push_back(i);
+            return v;
+          },
+          "Indices of the set bits (the in-register edge bundles after "
+          "finish()).");
+
+  // Per-block entry/exit constraints for the spill-placement network.
+  nb::enum_<llvm::SpillPlacement::BorderConstraint>(m, "BorderConstraint")
+      .value("DontCare", llvm::SpillPlacement::DontCare)
+      .value("PrefReg", llvm::SpillPlacement::PrefReg)
+      .value("PrefSpill", llvm::SpillPlacement::PrefSpill)
+      .value("PrefBoth", llvm::SpillPlacement::PrefBoth)
+      .value("MustSpill", llvm::SpillPlacement::MustSpill);
+
+  nb::class_<llvm::SpillPlacement::BlockConstraint>(m, "BlockConstraint")
+      .def(nb::init<>())
+      .def_rw("number", &llvm::SpillPlacement::BlockConstraint::Number,
+              "Basic block number this constraint applies to.")
+      // Entry/Exit are bitfields, so bind them through accessors (their address
+      // cannot be taken for def_rw).
+      .def_prop_rw(
+          "entry",
+          [](const llvm::SpillPlacement::BlockConstraint &c) {
+            return c.Entry;
+          },
+          [](llvm::SpillPlacement::BlockConstraint &c,
+             llvm::SpillPlacement::BorderConstraint v) { c.Entry = v; },
+          "Constraint on block entry.")
+      .def_prop_rw(
+          "exit",
+          [](const llvm::SpillPlacement::BlockConstraint &c) { return c.Exit; },
+          [](llvm::SpillPlacement::BlockConstraint &c,
+             llvm::SpillPlacement::BorderConstraint v) { c.Exit = v; },
+          "Constraint on block exit.")
+      .def_rw("changes_value",
+              &llvm::SpillPlacement::BlockConstraint::ChangesValue,
+              "True when the block has a non-PHI def of the live range.");
+
+  // The Hopfield-network spill-placement solver RAGreedy uses to pick global
+  // split boundaries: prepare a result vector, add block constraints and
+  // transparent links, iterate to convergence, and finish to get the optimal
+  // per-bundle register/spill assignment.
+  nb::class_<llvm::SpillPlacement>(m, "SpillPlacement")
+      .def(
+          "prepare",
+          [](llvm::SpillPlacement &sp, llvm::BitVector &regBundles) {
+            sp.prepare(regBundles);
+          },
+          "reg_bundles"_a,
+          "Reset for a new computation; `reg_bundles` receives the result and "
+          "is retained (keep it alive until after finish()).")
+      .def(
+          "add_constraints",
+          [](llvm::SpillPlacement &sp,
+             const std::vector<llvm::SpillPlacement::BlockConstraint>
+                 &constraints) { sp.addConstraints(constraints); },
+          "constraints"_a,
+          "Add entry/exit constraints for blocks where the value is live.")
+      .def(
+          "add_pref_spill",
+          [](llvm::SpillPlacement &sp, const std::vector<unsigned> &blocks,
+             bool strong) { sp.addPrefSpill(blocks, strong); },
+          "blocks"_a, "strong"_a,
+          "Bias the listed blocks toward spilling on entry and exit.")
+      .def(
+          "add_links",
+          [](llvm::SpillPlacement &sp, const std::vector<unsigned> &links) {
+            sp.addLinks(links);
+          },
+          "links"_a, "Add transparent (through) blocks by number.")
+      .def("scan_active_bundles", &llvm::SpillPlacement::scanActiveBundles,
+           "Initial scan of activated bundles; returns whether any prefer a "
+           "register.")
+      .def("iterate", &llvm::SpillPlacement::iterate,
+           "Update the network until convergence.")
+      .def(
+          "get_recent_positive",
+          [](llvm::SpillPlacement &sp) {
+            llvm::ArrayRef<unsigned> pos = sp.getRecentPositive();
+            return std::vector<unsigned>(pos.begin(), pos.end());
+          },
+          "Bundles that turned positive during the last scan/iterate.")
+      .def("finish", &llvm::SpillPlacement::finish,
+           "Compute the optimal placement into the prepared vector; returns "
+           "True if a perfect (all-register) solution was found.")
+      .def(
+          "get_block_frequency",
+          [](llvm::SpillPlacement &sp, llvm::MachineBasicBlock *mbb) {
+            return sp.getBlockFrequency(mbb->getNumber());
+          },
+          "mbb"_a,
+          "Estimated execution frequency of `mbb` (per function invocation). "
+          "Taking the block keeps the index in range by construction.");
 
   // A program point. Live ranges and the split editor are expressed in terms of
   // these; they order the instructions of a function.

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1241,3 +1241,194 @@ def test_python_dequeue_skips_already_assigned():
         _pyskip["assigned"] not in _pyskip["selected"]
     ), "the already-assigned reg id from Python dequeue was skipped"
     assert_no_leaks()
+
+
+# -- SpillPlacement / EdgeBundles (global region splitting) -------------------
+
+
+_sp_saw = {}
+# When True, the allocator feeds the network a spill preference so it recommends
+# spilling (the value is kept on the stack, not split into a register).
+_sp_spill_bias = False
+
+
+class _SpillPlacementSplit(mir.RegAllocBase):
+    """Global-split allocator that consults the spill-placement network the way
+    RAGreedy's splitAroundRegion does: build entry/exit BlockConstraints from
+    the live-through use blocks, add the through blocks as transparent links,
+    iterate the Hopfield network to convergence, and read back which edge
+    bundles want a register. If the entry block's outgoing bundle is
+    recommended in-register, keep the value live across the through block with
+    a real SplitEditor region split; otherwise (e.g. under a spill bias) the
+    network recommends spilling and we fall through to first-free."""
+
+    split = False
+    planned = False
+
+    def select_or_split(self, li):
+        cls = type(self)
+        if not cls.planned:
+            sa = self.split_analysis
+            sa.analyze(li)
+            if sa.num_through_blocks() > 0:
+                cls.planned = True
+                cls.split = self._plan_and_split(li, sa)
+                if cls.split:
+                    return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+    def _plan_and_split(self, li, sa):
+        eb = self.edge_bundles
+        sp = self.spill_placer
+        mf = self.machine_function
+        b0, b1, b2 = mf.blocks[0], mf.blocks[1], mf.blocks[2]
+        pref = (
+            mir.BorderConstraint.PrefSpill
+            if _sp_spill_bias
+            else mir.BorderConstraint.PrefReg
+        )
+
+        reg_bundles = mir.BitVector()
+        sp.prepare(reg_bundles)
+        constraints = []
+        for b in sa.use_blocks():
+            bc = mir.BlockConstraint()
+            bc.number = b.mbb.number
+            bc.entry = pref if b.live_in else mir.BorderConstraint.DontCare
+            bc.exit = pref if b.live_out else mir.BorderConstraint.DontCare
+            bc.changes_value = b.first_def.is_valid()
+            constraints.append(bc)
+        sp.add_constraints(constraints)
+        # Read the constraint fields back (round-trips the entry/exit getters).
+        _sp_saw["c0_entry"] = constraints[0].entry
+        _sp_saw["c0_exit"] = constraints[0].exit
+        _sp_saw["c0_number"] = constraints[0].number
+        _sp_saw["c0_changes"] = constraints[0].changes_value
+        through = sa.through_blocks()
+        sp.add_links(through)
+        if _sp_spill_bias:
+            # Strongly bias the through blocks to spill so the network drops
+            # them from the in-register set.
+            sp.add_pref_spill(through, True)
+        any_positive = sp.scan_active_bundles()
+        recent = sp.get_recent_positive()
+        sp.iterate()
+        perfect = sp.finish()
+        inreg = reg_bundles.set_bits()
+
+        entry_out_bundle = eb.get_bundle(b0, True)
+        # get_blocks rejects an out-of-range bundle rather than reading OOB.
+        try:
+            eb.get_blocks(eb.num_bundles())
+            _sp_saw["get_blocks_oob_raised"] = False
+        except IndexError:
+            _sp_saw["get_blocks_oob_raised"] = True
+        _sp_saw.update(
+            num_bundles=eb.num_bundles(),
+            bundle_blocks=eb.get_blocks(entry_out_bundle),
+            entry_out_bundle=entry_out_bundle,
+            any_positive=any_positive,
+            recent=list(recent),
+            perfect=perfect,
+            inreg=inreg,
+            entry_freq=sp.get_block_frequency(b0),
+            bv_size=reg_bundles.size(),
+            bv_count=reg_bundles.count(),
+        )
+
+        # The network's recommendation gates the split: only keep the value in a
+        # register when its entry-out bundle is in the recommended set.
+        if entry_out_bundle not in inreg:
+            return False
+        _sp_saw["bv_test"] = reg_bundles.test(entry_out_bundle)
+        se = self.split_editor
+        se.reset(self.new_live_range_edit(li), mir.ComplementSpillMode.SM_Size)
+        idx = se.open_intv()
+        se.select_intv(idx)
+        se.enter_intv_at_end(b0)
+        se.use_intv_mbb(b1)
+        se.leave_intv_at_top(b2)
+        se.finish()
+        return True
+
+
+def test_spill_placement_guided_region_split_emits():
+    global _sp_spill_bias
+    _sp_spill_bias = False
+    _SpillPlacementSplit.split = False
+    _SpillPlacementSplit.planned = False
+    _sp_saw.clear()
+    mir.register_regalloc("ra-sp-split", _SpillPlacementSplit)
+    obj = _emit(
+        "ra-sp-split", _SpillPlacementSplit, builder=_build_three_block, fn="thru"
+    )
+    assert obj[:4] == b"\x7fELF"
+    assert _SpillPlacementSplit.split, "the spill-placement-guided split ran"
+    # The network was really consulted and returned a usable recommendation.
+    assert _sp_saw["num_bundles"] > 0
+    assert _sp_saw["any_positive"] is True
+    assert _sp_saw["perfect"] is True, "no pressure -> a perfect all-reg solution"
+    # scan_active_bundles found positive bundles, so recent is non-empty.
+    assert len(_sp_saw["recent"]) >= 1
+    assert _sp_saw["entry_out_bundle"] in _sp_saw["inreg"], "entry bundle in-reg"
+    assert _sp_saw["bv_test"] is True and _sp_saw["bv_count"] >= 1
+    assert _sp_saw["bv_size"] == _sp_saw["num_bundles"]
+    assert 0 in _sp_saw["bundle_blocks"], "entry block connects to its out bundle"
+    assert _sp_saw["entry_freq"].get_frequency() > 0
+    assert _sp_saw["get_blocks_oob_raised"], "get_blocks bounds-checks the bundle"
+    # The first use block is the def block (b0): live-out, not live-in, defs v.
+    assert _sp_saw["c0_number"] == 0
+    assert _sp_saw["c0_entry"] == mir.BorderConstraint.DontCare
+    assert _sp_saw["c0_exit"] == mir.BorderConstraint.PrefReg
+    assert _sp_saw["c0_changes"] is True
+    assert_no_leaks()
+
+
+def test_spill_placement_recommends_spill_and_falls_through():
+    """With a spill preference (PrefSpill + a strong add_pref_spill on the
+    through blocks), the network drops the entry bundle from the in-register
+    set, so the recommendation-gated split is *not* taken -- the negative
+    branch. The emission still succeeds via first-free allocation."""
+    global _sp_spill_bias
+    _sp_spill_bias = True
+    _SpillPlacementSplit.split = False
+    _SpillPlacementSplit.planned = False
+    _sp_saw.clear()
+    try:
+        mir.register_regalloc("ra-sp-spill", _SpillPlacementSplit)
+        obj = _emit(
+            "ra-sp-spill", _SpillPlacementSplit, builder=_build_three_block, fn="thru"
+        )
+    finally:
+        _sp_spill_bias = False
+    assert obj[:4] == b"\x7fELF"
+    assert _SpillPlacementSplit.planned, "the network was consulted"
+    assert _SpillPlacementSplit.split is False, "spill recommended -> no split"
+    assert _sp_saw["entry_out_bundle"] not in _sp_saw["inreg"], "bundle dropped"
+    assert _sp_saw["c0_exit"] == mir.BorderConstraint.PrefSpill
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_spill_placement_guided_region_split_executes():
+    global _sp_spill_bias
+    _sp_spill_bias = False
+    _SpillPlacementSplit.split = False
+    _SpillPlacementSplit.planned = False
+    _sp_saw.clear()
+    mir.register_regalloc("ra-sp-split-x", _SpillPlacementSplit)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "thru")
+        _build_three_block(mmi)
+        obj = mmi.emit_object(regalloc="ra-sp-split-x")
+        thru, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "thru", obj)
+        assert thru(13) == 13 and thru(-6) == -6
+        del j
+    assert _SpillPlacementSplit.split, "the guided split drove the executed emission"
+    assert_no_leaks()


### PR DESCRIPTION
Add the cost-model-driven global region splitting surface RAGreedy's
splitAroundRegion uses. In this LLVM both headers are public
(include/llvm/CodeGen), so no vendoring is needed:

- PyRegAllocDriver now requires EdgeBundlesWrapperLegacy and
  SpillPlacementWrapperLegacy (moving past RABasic's analysis set toward
  RAGreedy's) and threads them into the allocator.
- EdgeBundles bound: get_bundle(block, out), num_bundles(), get_blocks(bundle).
- SpillPlacement bound: prepare(bit_vector), add_constraints, add_pref_spill,
  add_links, scan_active_bundles, iterate, get_recent_positive, finish,
  get_block_frequency, plus BlockConstraint (bitfield entry/exit via
  accessors), the BorderConstraint enum, and a minimal BitVector.
- self.edge_bundles / self.spill_placer accessors.
- Test: an allocator consults the Hopfield network on a cross-block live
  range (constraints from use blocks, through blocks as links), reads the
  recommended in-register bundles, and lets that gate a real SplitEditor
  region split that JIT-executes correctly.

cc #600