### PR TITLE
[eudsl-llvmpy] MIR regalloc: RAGreedy-completion accessors (#652 gap 4, reframed)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -418,6 +418,7 @@ mutates state through `self`: `allocation_order(li)` (physregs to try, in target
 order), `interfering_vregs(li, physreg)` (ids of vregs whose ranges interfere
 with `li` on that physreg -- assigned to it or to an aliasing physreg; the
 eviction candidates),
+`register_cost(physreg)` (per-use cost, the CostPerUseLimit heuristic),
 `self.matrix` (`is_free`/`check_interference`/`assign`/`unassign`),
 `self.lis` (LiveIntervals: `instruction_index`, `mbb_start_index`,
 `mbb_end_index`, `has_interval`, `interval`), `self.vrm` (VirtRegMap:
@@ -425,7 +426,9 @@ eviction candidates),
 it),
 `self.machine_function`, and `self.mbfi` (MachineBlockFrequencyInfo:
 `block_freq`, `block_freq_relative_to_entry_block`, `entry_freq`, for
-frequency-weighted spill/split cost models). Optional overrides: `enqueue(reg)`/`dequeue()` (drive
+frequency-weighted spill/split cost models). The `li` passed in is a
+`LiveInterval` exposing `reg`, `weight`, `is_spillable`, and its own extent
+(`begin_index`/`end_index`/`size`). Optional overrides: `enqueue(reg)`/`dequeue()` (drive
 the assignment order; both traffic in register ids -- stable across splitting,
 unlike interval objects -- and `dequeue` returns a reg id or `None`; the default
 is a spill-weight priority queue), `post_optimization()`, and
@@ -449,7 +452,7 @@ obj = mmi.emit_object(regalloc="first-free")   # drives FirstFree instead of gre
 
 For RAGreedy-style live-range splitting, `self.split_analysis` (a
 `SplitAnalysis`: `analyze(li)`, `use_blocks()`, `num_through_blocks()`,
-`through_blocks()`, `last_split_point(mbb)`) plans the split and
+`through_blocks()`, `get_use_slots()`, `last_split_point(mbb)`) plans the split and
 `self.split_editor` (a `SplitEditor`: `reset`, `open_intv`, `enter_intv_*`,
 `use_intv`/`use_intv_mbb`, `leave_intv_*`, `overlap_intv`, `finish`) applies it,
 writing into `self.new_live_range_edit(li)`:

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -519,6 +519,7 @@ public:
     blockFreqInfo = mbfi;
     edgeBundles = eb;
     spillPlacer = spl;
+    regCosts = mfn.getSubtarget().getRegisterInfo()->getRegisterCosts(mfn);
     NativeRegAlloc::pyInit(vrm, lis, mat, sp, mfn);
   }
 
@@ -568,6 +569,16 @@ public:
       }
     }
     return ids;
+  }
+
+  // Per-use cost of `physreg` (the CostPerUseLimit heuristic RAGreedy uses to
+  // decide whether a register is worth allocating). Indexed by physreg id. The
+  // cost table is an ArrayRef into the target's static tables (fixed for this
+  // function), cached in pyInit.
+  unsigned registerCost(unsigned physreg) {
+    if (physreg >= regCosts.size())
+      throw nb::index_error("physreg id out of range");
+    return regCosts[physreg];
   }
 
   // Spill `li` into the current select_or_split's split-vreg vector.
@@ -628,6 +639,7 @@ private:
   llvm::MachineBlockFrequencyInfo *blockFreqInfo = nullptr;
   llvm::EdgeBundles *edgeBundles = nullptr;
   llvm::SpillPlacement *spillPlacer = nullptr;
+  llvm::ArrayRef<uint8_t> regCosts;
   std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
 
@@ -975,6 +987,9 @@ void populate_python_codegen(nb::module_ &m) {
            "`physreg` -- those assigned to `physreg` or to a physreg aliasing "
            "it. Alias/subregister correct (queries every reg unit of "
            "`physreg`, de-duplicating). These are the eviction candidates.")
+      .def("register_cost", &PyRegAllocBase::registerCost, "physreg"_a,
+           "Per-use cost of `physreg` (the CostPerUseLimit heuristic; 0 on "
+           "targets with uniform register cost).")
       .def("spill", &PyRegAllocBase::spill, "li"_a,
            "Spill `li`; new split vregs are appended for re-enqueue. Only "
            "valid inside select_or_split.")
@@ -1050,9 +1065,31 @@ void populate_python_codegen(nb::module_ &m) {
                    [](const llvm::LiveInterval &li) { return li.reg().id(); })
       .def_prop_ro("weight",
                    [](const llvm::LiveInterval &li) { return li.weight(); })
-      .def_prop_ro("is_spillable", [](const llvm::LiveInterval &li) {
-        return li.isSpillable();
-      });
+      .def_prop_ro(
+          "is_spillable",
+          [](const llvm::LiveInterval &li) { return li.isSpillable(); })
+      .def_prop_ro(
+          "begin_index",
+          [](const llvm::LiveInterval &li) {
+            // beginIndex/endIndex assert on an empty range; raise a catchable
+            // error instead of aborting. Intervals reaching Python from
+            // select_or_split are always non-empty, so the guard is defensive.
+            if (li.empty())
+              throw nb::value_error("live interval is empty"); // LCOV_EXCL_LINE
+            return li.beginIndex();
+          },
+          "Lowest SlotIndex covered by this interval.")
+      .def_prop_ro(
+          "end_index",
+          [](const llvm::LiveInterval &li) {
+            if (li.empty())
+              throw nb::value_error("live interval is empty"); // LCOV_EXCL_LINE
+            return li.endIndex();
+          },
+          "Highest (exclusive) SlotIndex covered by this interval.")
+      .def_prop_ro(
+          "size", [](const llvm::LiveInterval &li) { return li.getSize(); },
+          "Total size in slot-index units (RAGreedy ranks priority by this).");
 
   // The virtual-to-physical assignment map. get_phys/has_phys let an eviction
   // policy read which physreg an interfering vreg currently holds before
@@ -1342,6 +1379,14 @@ void populate_python_codegen(nb::module_ &m) {
                  s.getUseBlocks().begin(), s.getUseBlocks().end());
            })
       .def("num_through_blocks", &llvm::SplitAnalysis::getNumThroughBlocks)
+      .def(
+          "get_use_slots",
+          [](llvm::SplitAnalysis &s) {
+            llvm::ArrayRef<llvm::SlotIndex> slots = s.getUseSlots();
+            return std::vector<llvm::SlotIndex>(slots.begin(), slots.end());
+          },
+          "SlotIndexes of the instructions using the analyzed interval "
+          "(needed for local/instruction splitting). Valid after analyze().")
       .def(
           "last_split_point",
           [](llvm::SplitAnalysis &s, llvm::MachineBasicBlock *mbb) {

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1432,3 +1432,69 @@ def test_spill_placement_guided_region_split_executes():
         del j
     assert _SpillPlacementSplit.split, "the guided split drove the executed emission"
     assert_no_leaks()
+
+
+# -- RAGreedy-completion accessors (interval extent, use slots, reg cost) -----
+
+
+def test_ragreedy_completion_accessors():
+    """The read-only surface a faithful RAGreedy still needs: a LiveInterval's
+    own extent/size (RAGreedy ranks priority by size), the per-use SlotIndexes
+    (local/instruction splitting), and per-physreg cost (CostPerUseLimit)."""
+    saw = {}
+
+    class Reader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            if not saw:
+                begin, end = li.begin_index, li.end_index
+                saw["ordered"] = begin < end
+                saw["begin_valid"] = begin.is_valid()
+                saw["end_valid"] = end.is_valid()
+                saw["size"] = li.size
+                sa = self.split_analysis
+                sa.analyze(li)
+                slots = sa.get_use_slots()
+                saw["num_use_slots"] = len(slots)
+                saw["slots_valid"] = all(s.is_valid() for s in slots)
+                # Every use lies within the interval's own extent (the last
+                # use sits at the exclusive end boundary).
+                saw["slots_in_extent"] = all(
+                    (begin < s or begin == s) and (s < end or s == end) for s in slots
+                )
+                # get_use_slots is sorted and (for this SSA value) spans the def
+                # contribution through the killing use, so its endpoints
+                # coincide with the interval's own begin/end -- a strong cross-
+                # binding check that begin_index/end_index track real slots.
+                saw["begin_is_first_slot"] = begin == slots[0]
+                saw["end_is_last_slot"] = end == slots[-1]
+                order = self.allocation_order(li)
+                saw["cost"] = self.register_cost(order[0])
+                # register_cost bounds-checks a fabricated physreg id.
+                try:
+                    self.register_cost(1 << 30)
+                    saw["cost_oob_raised"] = False
+                except IndexError:
+                    saw["cost_oob_raised"] = True
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-greedy-accessors", Reader)
+    obj = _emit("ra-greedy-accessors", Reader, builder=_build_three_block, fn="thru")
+    assert obj[:4] == b"\x7fELF"
+    assert saw["ordered"] and saw["begin_valid"] and saw["end_valid"]
+    assert saw["size"] > 0
+    # _build_three_block's value has exactly one def contribution + one killing
+    # use, so SplitAnalysis reports exactly two use slots.
+    assert saw["num_use_slots"] == 2
+    assert saw["slots_valid"] and saw["slots_in_extent"]
+    assert saw["begin_is_first_slot"] and saw["end_is_last_slot"]
+    # AArch64 has uniform register cost (all 0), so this is a smoke check that
+    # the accessor returns a valid non-negative cost; the OOB guard below is the
+    # meaningful behavioral assertion.
+    assert isinstance(saw["cost"], int) and saw["cost"] >= 0
+    assert saw["cost_oob_raised"], "register_cost bounds-checks the physreg id"
+    assert_no_leaks()
+    assert_no_leaks()


### PR DESCRIPTION
Gap 4 was scoped as binding RegAllocEvictionAdvisor/RegAllocPriorityAdvisor,
but those are infeasible and unnecessary: their (and DefaultEviction/
PriorityAdvisor's) constructors take a const RAGreedy&, RAGreedy is defined
only in the private lib/CodeGen header, and a Python allocator computes its own
priority/eviction anyway. This PR instead binds the read-only accessors a
faithful Python RAGreedy actually still needs:

- LiveInterval.begin_index / end_index / size -- the interval's own extent
  (RAGreedy ranks enqueue priority by size; split strategies need the range).
- SplitAnalysis.get_use_slots() -- per-use SlotIndexes, required for
  local/instruction splitting's gap analysis.
- RegAllocBase.register_cost(physreg) -- per-use register cost, the
  CostPerUseLimit heuristic (the genuinely useful residual of the advisor area,
  via TargetRegisterInfo::getRegisterCosts).
- Test reads all three from select_or_split and asserts extent ordering, use
  slots within the extent, and a non-negative cost.

Not included: the explicit rematerialization write-path
(LiveRangeEdit::canRematerializeAt/rematerializeAt), which needs a VNInfo /
Remat value-numbering surface -- a separate follow-up. InlineSpiller already
rematerializes automatically inside self.spill(), so a competent RAGreedy is
achievable without it.

cc #600