### PR TITLE
[eudsl-llvmpy] MIR regalloc: rematerialization write-path (#652 follow-up)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -489,6 +489,19 @@ prefs) from the live-through use blocks, iterate the network, and read the
 in-register edge bundles out of the `mir.BitVector` passed to `prepare` to
 choose split boundaries.
 
+For rematerialization (recomputing a value at its use instead of keeping it
+live), a value's def is reached through its value number: `li.get_vni_at(idx)` /
+`li.get_val_num_info(i)` return a `VNInfo` (`def_index`, `is_phi_def`,
+`is_unused`), and `self.lis.instr_from_index(vni.def_index)` gives the defining
+instruction. Build a `mir.LiveRangeEdit.Remat(vni)` with its `orig_mi` set, then
+`lre.rematerialize_at(mbb, before, dest_reg, remat)` clones the def into a fresh
+`lre.create()` vreg before a use; redirect the use with
+`use_mi.substitute_register(old, new)`, compute the clone's interval with
+`self.lis.compute_interval(new)`, and drop the now-dead original with
+`self.lis.shrink_to_uses(old)` feeding `lre.eliminate_dead_defs(dead)`. (Note the
+built-in spiller already rematerializes trivially-rematerializable defs inside
+`self.spill()`; this surface is for driving remat yourself.)
+
 A fresh allocator instance is constructed per `MachineFunction`. Because this
 build has assertions enabled, an invalid split aborts with a diagnostic rather
 than emitting bad code, and an exception raised in any override propagates out

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -929,6 +929,19 @@ void populate_mir(nb::module_ &m) {
             return &self.getOperand(i);
           },
           "index"_a, nb::rv_policy::reference_internal)
+      .def(
+          "substitute_register",
+          [](llvm::MachineInstr &self, unsigned fromReg, unsigned toReg,
+             unsigned subIdx) {
+            const llvm::TargetRegisterInfo *tri =
+                self.getMF()->getSubtarget().getRegisterInfo();
+            self.substituteRegister(llvm::Register(fromReg),
+                                    llvm::Register(toReg), subIdx, *tri);
+          },
+          "from_reg"_a, "to_reg"_a, "sub_idx"_a = 0,
+          "Replace every use/def of `from_reg` in this instruction with "
+          "`to_reg` (composing `sub_idx` where set); redirects a use onto a "
+          "rematerialized register.")
       .def_prop_ro(
           "parent",
           [](llvm::MachineInstr &self) -> const llvm::MachineBasicBlock * {

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -35,6 +35,7 @@
 #include <llvm/CodeGen/Spiller.h>
 #include <llvm/CodeGen/TargetRegisterInfo.h>
 #include <llvm/CodeGen/VirtRegMap.h>
+#include <llvm/MC/LaneBitmask.h>
 #include <llvm/PassRegistry.h>
 
 #include <nanobind/nanobind.h>
@@ -64,7 +65,26 @@ thread_local std::exception_ptr pendingCodegenError;
 
 namespace {
 
-// The Python strategy class emit_object selected for the current run. Set
+// llvm::LiveIntervals::computeVirtRegInterval is private, but computing the
+// interval of a register whose def we just rematerialized (and whose empty
+// interval LiveRangeEdit::create already made) is exactly what the remat flow
+// needs. Reach it with the explicit-instantiation access trick: access control
+// is not applied to a pointer-to-member named as a template argument of an
+// explicit instantiation (per [temp.explicit], the "access checks that apply to
+// template-arguments" carve-out), so instantiating this emits a namespace-scope
+// friend that forwards to the private member.
+template <auto Member>
+struct AccessComputeVirtRegInterval {
+  friend bool eudslComputeVirtRegInterval(llvm::LiveIntervals &lis,
+                                          llvm::LiveInterval &li) {
+    return (lis.*Member)(li);
+  }
+};
+template struct AccessComputeVirtRegInterval<
+    &llvm::LiveIntervals::computeVirtRegInterval>;
+bool eudslComputeVirtRegInterval(llvm::LiveIntervals &lis,
+                                 llvm::LiveInterval &li);
+
 // (under the GIL) before the pipeline runs and cleared after, so the shared
 // registry ctor knows which class to instantiate per MachineFunction.
 // GIL-serialized, matching the process-global -misched handling in Machine.cpp.
@@ -1058,6 +1078,19 @@ void populate_python_codegen(nb::module_ &m) {
           "(the machinery RAGreedy's splitAroundRegion drives). Borrowed and "
           "valid only within an allocator callback; do not retain.");
 
+  // A value number: one definition of a virtual register's live interval.
+  // Rematerialization is keyed on the VNInfo whose defining instruction is
+  // re-cloned at a use.
+  nb::class_<llvm::VNInfo>(m, "VNInfo")
+      .def_prop_ro("id", [](const llvm::VNInfo &v) { return v.id; })
+      .def_prop_ro(
+          "def_index", [](const llvm::VNInfo &v) { return v.def; },
+          "SlotIndex where this value is defined.")
+      .def_prop_ro("is_phi_def",
+                   [](const llvm::VNInfo &v) { return v.isPHIDef(); })
+      .def_prop_ro("is_unused",
+                   [](const llvm::VNInfo &v) { return v.isUnused(); });
+
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
   nb::class_<llvm::LiveInterval>(m, "LiveInterval")
@@ -1089,7 +1122,25 @@ void populate_python_codegen(nb::module_ &m) {
           "Highest (exclusive) SlotIndex covered by this interval.")
       .def_prop_ro(
           "size", [](const llvm::LiveInterval &li) { return li.getSize(); },
-          "Total size in slot-index units (RAGreedy ranks priority by this).");
+          "Total size in slot-index units (RAGreedy ranks priority by this).")
+      .def(
+          "get_vni_at",
+          [](llvm::LiveInterval &li, llvm::SlotIndex idx) {
+            return li.getVNInfoAt(idx);
+          },
+          nb::rv_policy::reference, "idx"_a,
+          "The value number live at `idx`, or None. Borrowed; do not retain "
+          "across shrink_to_uses/eliminate_dead_defs, which recompute the "
+          "interval and free its value numbers.")
+      .def_prop_ro("num_val_nums", &llvm::LiveInterval::getNumValNums)
+      .def(
+          "get_val_num_info",
+          [](llvm::LiveInterval &li, unsigned i) {
+            return li.getValNumInfo(i);
+          },
+          nb::rv_policy::reference, "i"_a,
+          "Value number #`i` of this interval. Borrowed; do not retain across "
+          "shrink_to_uses/eliminate_dead_defs (see get_vni_at).");
 
   // The virtual-to-physical assignment map. get_phys/has_phys let an eviction
   // policy read which physreg an interfering vreg currently holds before
@@ -1353,7 +1404,40 @@ void populate_python_codegen(nb::module_ &m) {
           [](llvm::LiveIntervals &l, unsigned reg) -> llvm::LiveInterval & {
             return l.getInterval(llvm::Register(reg));
           },
-          nb::rv_policy::reference_internal, "reg"_a);
+          nb::rv_policy::reference_internal, "reg"_a)
+      .def(
+          "instr_from_index",
+          [](llvm::LiveIntervals &l, llvm::SlotIndex idx) {
+            return l.getInstructionFromIndex(idx);
+          },
+          nb::rv_policy::reference, "idx"_a,
+          "The MachineInstr at `idx`, or None. Borrowed; do not retain.")
+      .def(
+          "compute_interval",
+          [](llvm::LiveIntervals &l, unsigned reg) {
+            if (!l.hasInterval(llvm::Register(reg)))
+              throw nb::value_error("register has no live interval to compute");
+            return eudslComputeVirtRegInterval(
+                l, l.getInterval(llvm::Register(reg)));
+          },
+          "reg"_a,
+          "Compute `reg`'s (already-created) interval from its defs/uses -- "
+          "e.g. after rematerializing a def into the empty interval from "
+          "LiveRangeEdit.create and redirecting a use onto it. Returns True if "
+          "the interval needs splitting.")
+      .def(
+          "shrink_to_uses",
+          [](llvm::LiveIntervals &l, unsigned reg) {
+            if (!l.hasInterval(llvm::Register(reg)))
+              throw nb::value_error("register has no live interval to shrink");
+            llvm::SmallVector<llvm::MachineInstr *, 8> dead;
+            l.shrinkToUses(&l.getInterval(llvm::Register(reg)), &dead);
+            return std::vector<llvm::MachineInstr *>(dead.begin(), dead.end());
+          },
+          "reg"_a,
+          "Recompute `reg`'s interval from its remaining uses after "
+          "redirecting some, marking now-dead defs; returns those dead "
+          "instructions (feed them to LiveRangeEdit.eliminate_dead_defs).");
 
   // Splitting analysis: after analyze(li), it describes how `li` is used per
   // block, guiding where the split editor should open/close intervals.
@@ -1400,14 +1484,85 @@ void populate_python_codegen(nb::module_ &m) {
         return v;
       });
 
+  // A set of subregister lanes (llvm::LaneBitmask), forwarded to
+  // rematerialize_at to say which lanes are live at the remat point.
+  nb::class_<llvm::LaneBitmask>(m, "LaneBitmask")
+      .def(nb::init<uint64_t>(), "mask"_a)
+      .def_static("get_all", &llvm::LaneBitmask::getAll,
+                  "All lanes (the default when the whole register is live).")
+      .def_static("get_none", &llvm::LaneBitmask::getNone, "No lanes.")
+      .def("get_as_integer", &llvm::LaneBitmask::getAsInteger)
+      .def("none", &llvm::LaneBitmask::none)
+      .def("any", &llvm::LaneBitmask::any)
+      .def(nb::self == nb::self, "other"_a)
+      .def(nb::self != nb::self, "other"_a);
+
   // The edit buffer the split editor writes new vregs into.
-  nb::class_<llvm::LiveRangeEdit>(m, "LiveRangeEdit")
-      .def("new_vregs", [](llvm::LiveRangeEdit &e) {
-        std::vector<unsigned> v;
-        for (llvm::Register r : e.regs())
-          v.push_back(r.id());
-        return v;
-      });
+  nb::class_<llvm::LiveRangeEdit> lre(m, "LiveRangeEdit");
+  lre.def("new_vregs",
+          [](llvm::LiveRangeEdit &e) {
+            std::vector<unsigned> v;
+            for (llvm::Register r : e.regs())
+              v.push_back(r.id());
+            return v;
+          })
+      .def(
+          "create", [](llvm::LiveRangeEdit &e) { return e.create().id(); },
+          "Create a new vreg (same class as the parent) and append it for "
+          "re-enqueue; the destination for a rematerialized def.")
+      .def(
+          "rematerialize_at",
+          [](llvm::LiveRangeEdit &e, llvm::MachineBasicBlock *mbb,
+             llvm::MachineInstr *before, unsigned destReg,
+             const llvm::LiveRangeEdit::Remat &rm, bool late, unsigned subIdx,
+             llvm::MachineInstr *replaceIndexMI, llvm::LaneBitmask usedLanes) {
+            const llvm::TargetRegisterInfo *tri =
+                mbb->getParent()->getSubtarget().getRegisterInfo();
+            return e.rematerializeAt(*mbb, before->getIterator(),
+                                     llvm::Register(destReg), rm, *tri, late,
+                                     subIdx, replaceIndexMI, usedLanes);
+          },
+          "mbb"_a, "before"_a, "dest_reg"_a, "remat"_a, "late"_a = false,
+          "sub_idx"_a = 0, "replace_index_mi"_a.none() = nullptr,
+          "used_lanes"_a = llvm::LaneBitmask::getAll(),
+          "Clone rm's defining instruction into `dest_reg` just before "
+          "`before`; returns the def SlotIndex. `late` inserts after other "
+          "defs at the same slot, `sub_idx` writes a subregister, "
+          "`replace_index_mi` (if given) is replaced in the index map by the "
+          "new instruction, and `used_lanes` is the lane mask live at the "
+          "remat "
+          "point (forwarded to the target). Liveness is not updated -- call "
+          "compute_interval(dest_reg) after.")
+      .def(
+          "eliminate_dead_defs",
+          [](llvm::LiveRangeEdit &e, std::vector<llvm::MachineInstr *> dead,
+             std::vector<unsigned> regsBeingSpilled) {
+            llvm::SmallVector<llvm::MachineInstr *, 8> deadVec(dead.begin(),
+                                                               dead.end());
+            llvm::SmallVector<llvm::Register, 4> spilled;
+            for (unsigned r : regsBeingSpilled)
+              spilled.push_back(llvm::Register(r));
+            e.eliminateDeadDefs(deadVec, spilled);
+          },
+          "dead"_a, "regs_being_spilled"_a = std::vector<unsigned>(),
+          "Delete the given now-dead defining instructions and trim their "
+          "intervals (e.g. the original def after all its uses were "
+          "rematerialized). `regs_being_spilled` lists registers currently "
+          "being spilled, which must not be split into new intervals.");
+
+  // Information needed to rematerialize a value at a new location: the value
+  // number and (set by the caller) its defining instruction.
+  nb::class_<llvm::LiveRangeEdit::Remat>(lre, "Remat")
+      .def(nb::init<const llvm::VNInfo *>(), "parent_vni"_a)
+      .def_prop_rw(
+          "orig_mi",
+          [](const llvm::LiveRangeEdit::Remat &r) { return r.OrigMI; },
+          [](llvm::LiveRangeEdit::Remat &r, llvm::MachineInstr *mi) {
+            r.OrigMI = mi;
+          },
+          nb::rv_policy::reference,
+          "The instruction defining the value (its real expression); set "
+          "from lis.instr_from_index(vni.def_index).");
 
   nb::enum_<llvm::SplitEditor::ComplementSpillMode>(m, "ComplementSpillMode")
       .value("SM_Partition", llvm::SplitEditor::SM_Partition)

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1498,3 +1498,181 @@ def test_ragreedy_completion_accessors():
     assert saw["cost_oob_raised"], "register_cost bounds-checks the physreg id"
     assert_no_leaks()
     assert_no_leaks()
+
+
+# -- rematerialization write-path ---------------------------------------------
+
+
+_REMAT_CONST = 42
+_remat_log = {}
+
+
+def _build_remat_const(mmi):
+    """x in w0; v = MOVi32imm 42 (a rematerializable constant); r = x + v;
+    return r. v feeds an ADDWrr (not a copy to a physreg) so it survives
+    coalescing and reaches the allocator as a vreg needing a register."""
+    mf = mmi.machine_function("rematc")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    x0, v, r = (mf.create_vreg(gpr32) for _ in range(3))
+    c = b.build_instr(mf.opcode("COPY"))
+    c.add_reg(x0, is_def=True)
+    c.add_reg(w0)
+    mov = b.build_instr(mf.opcode("MOVi32imm"))
+    mov.add_reg(v, is_def=True)
+    mov.add_imm(_REMAT_CONST)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(r, is_def=True)
+    add.add_reg(x0)
+    add.add_reg(v)
+    rc = b.build_instr(mf.opcode("COPY"))
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(r)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+class _RematAllocator(mir.RegAllocBase):
+    """When an interval's value is a rematerializable constant (a non-PHI
+    MOVi32imm def), rematerialize it at its use rather than keeping it in a
+    register: clone the def into a fresh vreg just before the use, redirect the
+    use onto it, compute the new interval, and eliminate the now-dead original
+    def. Every other interval allocates first-free."""
+
+    def select_or_split(self, li):
+        vni = li.get_vni_at(li.begin_index)
+        def_mi = self.lis.instr_from_index(vni.def_index)
+        remattable = (
+            def_mi is not None
+            and def_mi.opcode_name == "MOVi32imm"
+            and not vni.is_phi_def
+        )
+        if remattable and not _remat_log.get("done"):
+            entry = self.machine_function.blocks[0]
+            # Read the value-number surface before mutating -- shrink_to_uses /
+            # eliminate_dead_defs below invalidate li's value numbers.
+            vn_info = dict(
+                vni_id=vni.id,
+                num_val_nums=li.num_val_nums,
+                valno0_id=li.get_val_num_info(0).id,
+                is_unused=vni.is_unused,
+            )
+            # compute_interval/shrink_to_uses reject a reg with no interval
+            # instead of aborting (this virtual-register id -- high bit set,
+            # huge index -- has none).
+            bogus = (1 << 31) | (1 << 20)
+            guard_raised = 0
+            for probe in (self.lis.compute_interval, self.lis.shrink_to_uses):
+                try:
+                    probe(bogus)
+                except ValueError:
+                    guard_raised += 1
+            use_mi = None
+            for mi in entry.instructions:
+                for i in range(mi.num_operands):
+                    op = mi.operand(i)
+                    if (
+                        op.is_reg
+                        and op.is_use
+                        and op.reg.is_virtual
+                        and op.reg.id == li.reg
+                    ):
+                        use_mi = mi
+            assert use_mi is not None, "the constant's single use was located"
+            lre = self.new_live_range_edit(li)
+            rm = mir.LiveRangeEdit.Remat(vni)
+            rm.orig_mi = def_mi
+            orig_is_movi = rm.orig_mi.opcode_name == "MOVi32imm"
+            new_reg = lre.create()
+            slot = lre.rematerialize_at(
+                entry, use_mi, new_reg, rm, used_lanes=mir.LaneBitmask.get_all()
+            )
+            # A real rematerialized MOVi32imm was inserted at `slot` -- the
+            # structural proof remat happened (independent of the arithmetic).
+            remat_mi = self.lis.instr_from_index(slot)
+            remat_is_movi = remat_mi is not None and remat_mi.opcode_name == "MOVi32imm"
+            use_mi.substitute_register(li.reg, new_reg)
+            needs_split = self.lis.compute_interval(new_reg)
+            # The new reg's own value is defined exactly at the remat slot.
+            new_li = self.lis.interval(new_reg)
+            new_def_at_remat = new_li.get_vni_at(new_li.begin_index).def_index == slot
+            dead = self.lis.shrink_to_uses(li.reg)
+            lre.eliminate_dead_defs(dead, regs_being_spilled=[li.reg])
+            _remat_log.update(
+                done=True,
+                new_reg=new_reg,
+                slot_valid=slot.is_valid(),
+                ndead=len(dead),
+                needs_split=needs_split,
+                orig_is_movi=orig_is_movi,
+                remat_is_movi=remat_is_movi,
+                new_def_at_remat=new_def_at_remat,
+                guard_raised=guard_raised,
+                **vn_info,
+            )
+            return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_rematerialize_constant_at_use_emits():
+    _remat_log.clear()
+    mir.register_regalloc("ra-remat", _RematAllocator)
+    obj = _emit("ra-remat", _RematAllocator, builder=_build_remat_const, fn="rematc")
+    assert obj[:4] == b"\x7fELF"
+    assert _remat_log["done"], "the rematerialization path ran"
+    assert _remat_log["slot_valid"], "the rematerialized def has a valid slot"
+    assert _remat_log["ndead"] >= 1, "the original constant def was eliminated"
+    # Structural proof (independent of the arithmetic result) that remat
+    # happened: a fresh MOVi32imm was inserted at the remat slot, and the new
+    # register's value is defined there.
+    assert _remat_log["remat_is_movi"], "a MOVi32imm was rematerialized at the use"
+    assert _remat_log["new_def_at_remat"], "the new reg is defined at the remat slot"
+    assert _remat_log["guard_raised"] == 2, "compute_interval/shrink_to_uses guard"
+    assert _remat_log["needs_split"] is False
+    assert _remat_log["num_val_nums"] == 1
+    assert _remat_log["valno0_id"] == _remat_log["vni_id"]
+    assert _remat_log["is_unused"] is False
+    assert _remat_log["orig_is_movi"], "orig_mi round-trips to the constant def"
+    assert_no_leaks()
+
+
+def test_lane_bitmask_surface():
+    """LaneBitmask (forwarded to rematerialize_at's used_lanes) is a usable
+    value type: all/none lanes, integer round-trip, and comparisons."""
+    all_lanes = mir.LaneBitmask.get_all()
+    no_lanes = mir.LaneBitmask.get_none()
+    assert all_lanes.any() and not all_lanes.none()
+    assert no_lanes.none() and not no_lanes.any()
+    assert all_lanes.get_as_integer() != 0
+    assert no_lanes.get_as_integer() == 0
+    assert all_lanes == mir.LaneBitmask(all_lanes.get_as_integer())
+    assert all_lanes != no_lanes
+    assert_no_leaks()
+
+
+@pytest.mark.skipif(not _IS_AARCH64, reason="executing hand-built AArch64 MIR")
+def test_rematerialize_constant_at_use_executes():
+    _remat_log.clear()
+    mir.register_regalloc("ra-remat-x", _RematAllocator)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine()
+        mmi = mir.create_machine_function(mod, tm, "rematc")
+        _build_remat_const(mmi)
+        obj = mmi.emit_object(regalloc="ra-remat-x")
+        fn, j = _jit_call((ctypes.c_int32, ctypes.c_int32), "rematc", obj)
+        assert fn(5) == 5 + _REMAT_CONST
+        assert fn(100) == 100 + _REMAT_CONST
+        del j
+    assert _remat_log["done"], "the remat path drove the executed emission"
+    assert_no_leaks()


### PR DESCRIPTION
Bind the explicit rematerialization surface so a Python allocator can recompute
a value at its use rather than keep it live (what InlineSpiller/SplitKit do
internally). Completes the "faithful RAGreedy" surface.

- VNInfo bound (id, def_index, is_phi_def, is_unused); LiveInterval gains
  get_vni_at(idx), num_val_nums, get_val_num_info(i).
- LiveIntervals: instr_from_index(idx), compute_interval(reg) (the interval of
  a freshly-created remat reg), shrink_to_uses(reg) (returns now-dead defs).
- LiveRangeEdit: create(), nested Remat(parent_vni) with orig_mi,
  rematerialize_at(mbb, before, dest_reg, remat, late=, sub_idx=),
  eliminate_dead_defs(dead).
- MachineInstr.substitute_register(from_reg, to_reg, sub_idx=0) to redirect a
  use onto the rematerialized register.
- llvm::LiveIntervals::computeVirtRegInterval is private; reached via the
  explicit-instantiation access trick ([temp.explicit] does not apply access
  control to a pointer-to-member named as a template argument) rather than a
  remove-and-recreate workaround.
- Test rematerializes a MOVi32imm constant at its ADDWrr use, redirects the
  use, recomputes liveness, eliminates the dead original def, and JIT-executes
  to the correct result.

cc #600