### PR TITLE
[eudsl-llvmpy] MIR regalloc: priority/pressure surface for faithful RAGreedy (#652)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -428,7 +428,12 @@ it),
 `block_freq`, `block_freq_relative_to_entry_block`, `entry_freq`, for
 frequency-weighted spill/split cost models). The `li` passed in is a
 `LiveInterval` exposing `reg`, `weight`, `is_spillable`, and its own extent
-(`begin_index`/`end_index`/`size`). Optional overrides: `enqueue(reg)`/`dequeue()` (drive
+(`begin_index`/`end_index`/`size`; `SlotIndex.distance` measures raw slot-space
+distance and `SlotIndex.get_approx_instr_distance` measures instruction-space
+gaps). For priority/pressure heuristics,
+`self.reg_class(reg)` (a `TargetRegisterClass` with `id`),
+`self.num_allocatable_regs(reg_class)`, and
+`self.is_trivially_rematerializable(mi)`. Optional overrides: `enqueue(reg)`/`dequeue()` (drive
 the assignment order; both traffic in register ids -- stable across splitting,
 unlike interval objects -- and `dequeue` returns a reg id or `None`; the default
 is a spill-weight priority queue), `post_optimization()`, and

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -700,8 +700,10 @@ void populate_mir(nb::module_ &m) {
 
   // A target register class (e.g. AArch64 GPR32), looked up by name via
   // MachineFunction.reg_class. Opaque handle used when creating typed vregs for
-  // already-selected MIR.
-  nb::class_<llvm::TargetRegisterClass>(m, "TargetRegisterClass");
+  // already-selected MIR; `id` identifies the class (e.g. to compare two).
+  nb::class_<llvm::TargetRegisterClass>(m, "TargetRegisterClass")
+      .def_prop_ro(
+          "id", [](const llvm::TargetRegisterClass &rc) { return rc.getID(); });
 
   // MachineFunctionProperties::Property -- the flags a MachineFunction carries
   // (set with MachineFunction.set_property). Some mark progress through the

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -25,6 +25,7 @@
 #include <llvm/CodeGen/MachineFunctionPass.h>
 #include <llvm/CodeGen/MachineInstr.h>
 #include <llvm/CodeGen/MachineLoopInfo.h>
+#include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
 #include <llvm/CodeGen/Passes.h>
 #include <llvm/CodeGen/RegAllocRegistry.h>
@@ -33,6 +34,7 @@
 #include <llvm/CodeGen/SlotIndexes.h>
 #include <llvm/CodeGen/SpillPlacement.h>
 #include <llvm/CodeGen/Spiller.h>
+#include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetRegisterInfo.h>
 #include <llvm/CodeGen/VirtRegMap.h>
 #include <llvm/MC/LaneBitmask.h>
@@ -601,6 +603,18 @@ public:
     return regCosts[physreg];
   }
 
+  const llvm::TargetRegisterClass *regClass(unsigned reg) {
+    return mf->getRegInfo().getRegClass(llvm::Register(reg));
+  }
+
+  unsigned numAllocatableRegs(const llvm::TargetRegisterClass *rc) {
+    return RegClassInfo.getNumAllocatableRegs(rc);
+  }
+
+  bool isTriviallyRematerializable(llvm::MachineInstr *mi) {
+    return mf->getSubtarget().getInstrInfo()->isTriviallyReMaterializable(*mi);
+  }
+
   // Spill `li` into the current select_or_split's split-vreg vector.
   void spill(const llvm::LiveInterval &li) {
     if (!currentSplit)
@@ -1010,69 +1024,68 @@ void populate_python_codegen(nb::module_ &m) {
       .def("register_cost", &PyRegAllocBase::registerCost, "physreg"_a,
            "Per-use cost of `physreg` (the CostPerUseLimit heuristic; 0 on "
            "targets with uniform register cost).")
+      .def("reg_class", &PyRegAllocBase::regClass, nb::rv_policy::reference,
+           "reg"_a,
+           "The register class of virtual register `reg` (target-static; "
+           "borrowed).")
+      .def("num_allocatable_regs", &PyRegAllocBase::numAllocatableRegs,
+           "reg_class"_a,
+           "Number of actually-allocatable registers in `reg_class` (the "
+           "register-pressure denominator; reserved registers excluded).")
+      .def(
+          "is_trivially_rematerializable",
+          &PyRegAllocBase::isTriviallyRematerializable, "mi"_a,
+          "Whether `mi` (e.g. an interval's defining instruction) is trivially "
+          "rematerializable.")
       .def("spill", &PyRegAllocBase::spill, "li"_a,
            "Spill `li`; new split vregs are appended for re-enqueue. Only "
            "valid inside select_or_split.")
       .def_prop_ro(
-          "matrix", [](PyRegAllocBase &self) { return self.matrix(); },
-          nb::rv_policy::reference,
+          "matrix", &PyRegAllocBase::matrix, nb::rv_policy::reference,
           "The LiveRegMatrix for interference queries and assignment. Borrowed "
           "and valid only within an allocator callback; do not retain.")
       .def_prop_ro(
-          "lis", [](PyRegAllocBase &self) { return self.intervals(); },
-          nb::rv_policy::reference,
+          "lis", &PyRegAllocBase::intervals, nb::rv_policy::reference,
           "The LiveIntervals analysis for this function. Borrowed and valid "
           "only within an allocator callback; do not retain.")
       .def_prop_ro(
-          "vrm", [](PyRegAllocBase &self) { return self.virtRegMap(); },
-          nb::rv_policy::reference,
+          "vrm", &PyRegAllocBase::virtRegMap, nb::rv_policy::reference,
           "The VirtRegMap being populated with assignments. Borrowed and valid "
           "only within an allocator callback; do not retain.")
       .def_prop_ro(
-          "machine_function",
-          [](PyRegAllocBase &self) { return self.machineFunction(); },
+          "machine_function", &PyRegAllocBase::machineFunction,
           nb::rv_policy::reference,
           "The MachineFunction being allocated. Borrowed and valid only within "
           "an allocator callback; do not retain.")
       .def_prop_ro(
-          "split_analysis",
-          [](PyRegAllocBase &self) { return self.splitAnalysisPtr(); },
+          "split_analysis", &PyRegAllocBase::splitAnalysisPtr,
           nb::rv_policy::reference,
           "The SplitAnalysis for planning live-range splits. Borrowed and "
           "valid only within an allocator callback; do not retain.")
       .def_prop_ro(
-          "split_editor",
-          [](PyRegAllocBase &self) { return self.splitEditorPtr(); },
+          "split_editor", &PyRegAllocBase::splitEditorPtr,
           nb::rv_policy::reference,
           "The SplitEditor for applying live-range splits (call reset(...) "
           "before open_intv/use_intv). Borrowed and valid only within an "
           "allocator callback; do not retain.")
-      .def(
-          "new_live_range_edit",
-          [](PyRegAllocBase &self, const llvm::LiveInterval &li) {
-            return self.newLiveRangeEdit(li);
-          },
-          nb::rv_policy::reference, "li"_a,
-          "A LiveRangeEdit over the current split-vreg vector, for "
-          "split_editor.reset. Only valid inside select_or_split; do not "
-          "retain past the call.")
+      .def("new_live_range_edit", &PyRegAllocBase::newLiveRangeEdit,
+           nb::rv_policy::reference, "li"_a,
+           "A LiveRangeEdit over the current split-vreg vector, for "
+           "split_editor.reset. Only valid inside select_or_split; do not "
+           "retain past the call.")
       .def_prop_ro(
-          "mbfi",
-          [](PyRegAllocBase &self) { return self.blockFrequencyInfo(); },
-          nb::rv_policy::reference,
+          "mbfi", &PyRegAllocBase::blockFrequencyInfo, nb::rv_policy::reference,
           "The MachineBlockFrequencyInfo for frequency-weighted cost models. "
           "Borrowed and valid only within an allocator callback; do not "
           "retain.")
       .def_prop_ro(
-          "edge_bundles",
-          [](PyRegAllocBase &self) { return self.edgeBundlesPtr(); },
+          "edge_bundles", &PyRegAllocBase::edgeBundlesPtr,
           nb::rv_policy::reference,
           "The EdgeBundles partition of CFG edges, mapping blocks to the "
           "bundles global splitting reasons about. Borrowed and valid only "
           "within an allocator callback; do not retain.")
       .def_prop_ro(
-          "spill_placer",
-          [](PyRegAllocBase &self) { return self.spillPlacerPtr(); },
+          "spill_placer", &PyRegAllocBase::spillPlacerPtr,
           nb::rv_policy::reference,
           "The SpillPlacement network for choosing global-split boundaries "
           "(the machinery RAGreedy's splitAroundRegion drives). Borrowed and "
@@ -1369,6 +1382,13 @@ void populate_python_codegen(nb::module_ &m) {
            [](const llvm::SlotIndex &i) { return i.getBoundaryIndex(); })
       .def("get_next_index",
            [](const llvm::SlotIndex &i) { return i.getNextIndex(); })
+      .def("distance", &llvm::SlotIndex::distance, "other"_a,
+           "Number of slots between this and `other` (a raw distance in the "
+           "slot-index space).")
+      .def("get_approx_instr_distance",
+           &llvm::SlotIndex::getApproxInstrDistance, "other"_a,
+           "Approximate number of instructions between this and `other` (what "
+           "RAGreedy's size/gap heuristics measure).")
       .def("__repr__", [](const llvm::SlotIndex &i) {
         return i.isValid() ? std::string("SlotIndex(valid)")
                            : std::string("SlotIndex(invalid)");

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1676,3 +1676,58 @@ def test_rematerialize_constant_at_use_executes():
         del j
     assert _remat_log["done"], "the remat path drove the executed emission"
     assert_no_leaks()
+
+
+# -- priority / pressure surface (getPriority) --------------------------------
+
+
+def test_priority_pressure_accessors():
+    """The read-only surface RAGreedy's getPriority weighs: a vreg's register
+    class + allocatable-reg count, the trivial-remat gate, and the distance
+    between program points in both slot and instruction space."""
+    saw = {}
+    remat = {}
+
+    class Reader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            vni = li.get_vni_at(li.begin_index)
+            def_mi = self.lis.instr_from_index(vni.def_index)
+            # MOVi32imm (a constant def) is trivially rematerializable; the COPY
+            # of the live-in physreg is not.
+            remat[def_mi.opcode_name] = self.is_trivially_rematerializable(def_mi)
+            if not saw:
+                mf = self.machine_function
+                rc = self.reg_class(li.reg)
+                # Oracle: the class of a GPR32 vreg is exactly the name-resolved
+                # GPR32 class, and distinct from GPR64 -- a broken reg_class/id
+                # returning a constant fails one of these.
+                saw["is_gpr32"] = rc.id == mf.reg_class("GPR32").id
+                saw["not_gpr64"] = rc.id != mf.reg_class("GPR64").id
+                # Oracle: the allocatable-reg count equals the length of the
+                # allocation order (an independent path through AllocationOrder),
+                # so a wrong count can't hide inside a loose bound.
+                saw["num_alloc"] = self.num_allocatable_regs(rc)
+                saw["order_len"] = sum(1 for _ in self.allocation_order(li))
+                begin, end = li.begin_index, li.end_index
+                saw["distance"] = begin.distance(end)
+                saw["approx"] = begin.get_approx_instr_distance(end)
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-priority", Reader)
+    obj = _emit("ra-priority", Reader, builder=_build_remat_const, fn="rematc")
+    assert obj[:4] == b"\x7fELF"
+    assert saw["is_gpr32"] and saw["not_gpr64"]
+    assert saw["num_alloc"] > 0
+    assert saw["num_alloc"] == saw["order_len"]
+    # Slot space counts several slots per instruction, so the raw slot distance
+    # strictly exceeds the instruction-space distance -- a copy/paste swap that
+    # wired both to the same underlying method would collapse this.
+    assert saw["distance"] > saw["approx"] > 0
+    # The remat gate distinguishes a rematerializable def from a non-remat one.
+    assert remat["MOVi32imm"] is True
+    assert remat["COPY"] is False
+    assert_no_leaks()


### PR DESCRIPTION
Bind the read-only inputs RAGreedy's getPriority weighs, so a Python allocator
can reproduce its enqueue priority and pressure heuristics:

- RegAllocBase.reg_class_of(reg) (MRI.getRegClass) returning a
  TargetRegisterClass (now exposing `id`), and num_allocatable_regs(reg_class)
  (RegisterClassInfo.getNumAllocatableRegs) -- the register-pressure denominator.
- RegAllocBase.is_trivially_rematerializable(mi) (TII) -- the remat gate.
- SlotIndex.distance / approx_instr_distance -- instruction-space gap sizes
  (getPriority ranks by size; tryLocalSplit measures gaps).
- Test reads all of them: GPR32's allocatable count is bounded, same-class
  vregs share an id, distances are positive, and the MOVi32imm def is trivially
  rematerializable while COPY/ADDWrr are not.

cc #600