### PR TITLE
[eudsl-llvmpy] MIR regalloc: eviction cost surface for faithful RAGreedy (#652)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -423,7 +423,10 @@ eviction candidates),
 `self.lis` (LiveIntervals: `instruction_index`, `mbb_start_index`,
 `mbb_end_index`, `has_interval`, `interval`), `self.vrm` (VirtRegMap:
 `has_phys`/`get_phys`, to read an interferer's current physreg before evicting
-it),
+it; and, for the eviction cost model, `self.reg_allocation_hints(reg)` (a
+`(type, [ids])` pair) / `self.simple_hint(reg)` (broken-hint accounting),
+`self.matrix.is_phys_reg_used`,
+and `self.last_callee_saved_alias(physreg)`),
 `self.machine_function`, and `self.mbfi` (MachineBlockFrequencyInfo:
 `block_freq`, `block_freq_relative_to_entry_block`, `entry_freq`, for
 frequency-weighted spill/split cost models). The `li` passed in is a

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -615,6 +615,38 @@ public:
     return mf->getSubtarget().getInstrInfo()->isTriviallyReMaterializable(*mi);
   }
 
+  // Copy-hint registers for `reg` (physregs and/or vregs it is copy-related
+  // The register-allocation hints for virtual register `reg`: a (type, [ids])
+  // pair. `type` is the hint kind (0 = target-independent copy hints; nonzero
+  // = a target-specific hint the target expands), `ids` the hinted physregs.
+  // RAGreedy prefers a hinted physreg and counts "broken hints" in eviction
+  // cost. `reg` must be a virtual register. (0, []) if it has no hints.
+  std::pair<unsigned, std::vector<unsigned>> regAllocationHints(unsigned reg) {
+    unsigned type = 0;
+    std::vector<unsigned> ids;
+    const auto *hints =
+        mf->getRegInfo().getRegAllocationHints(llvm::Register(reg));
+    if (hints) {
+      type = hints->first;
+      for (llvm::Register h : hints->second)
+        ids.push_back(h.id());
+    }
+    return {type, ids};
+  }
+
+  // The single "simple" copy hint for virtual register `reg` (id, or 0 if
+  // none). `reg` must be a virtual register.
+  unsigned simpleHint(unsigned reg) {
+    return mf->getRegInfo().getSimpleHint(llvm::Register(reg)).id();
+  }
+
+  // The last callee-saved register aliasing `physreg` (id, or 0 if none) --
+  // RAGreedy's isUnusedCalleeSavedReg check, which biases against introducing a
+  // CSR spill.
+  unsigned lastCalleeSavedAlias(unsigned physreg) {
+    return RegClassInfo.getLastCalleeSavedAlias(llvm::MCRegister(physreg)).id();
+  }
+
   // Spill `li` into the current select_or_split's split-vreg vector.
   void spill(const llvm::LiveInterval &li) {
     if (!currentSplit)
@@ -1037,6 +1069,19 @@ void populate_python_codegen(nb::module_ &m) {
           &PyRegAllocBase::isTriviallyRematerializable, "mi"_a,
           "Whether `mi` (e.g. an interval's defining instruction) is trivially "
           "rematerializable.")
+      .def("reg_allocation_hints", &PyRegAllocBase::regAllocationHints, "reg"_a,
+           "The (type, [ids]) allocation hints for virtual register `reg`: "
+           "`type` is the hint kind (0 = target-independent copy hints), "
+           "`ids` the hinted physregs (a hinted physreg is preferred; evicting "
+           "a hinted assignment is a 'broken hint' in eviction cost). (0, []) "
+           "if none. `reg` must be a virtual register.")
+      .def("simple_hint", &PyRegAllocBase::simpleHint, "reg"_a,
+           "The single simple copy-hint reg id for virtual register `reg`, or "
+           "0 if none. `reg` must be a virtual register.")
+      .def("last_callee_saved_alias", &PyRegAllocBase::lastCalleeSavedAlias,
+           "physreg"_a,
+           "The last callee-saved register aliasing `physreg` (id, or 0) -- "
+           "biases against introducing a callee-saved spill.")
       .def("spill", &PyRegAllocBase::spill, "li"_a,
            "Spill `li`; new split vregs are appended for re-enqueue. Only "
            "valid inside select_or_split.")
@@ -1660,7 +1705,15 @@ void populate_python_codegen(nb::module_ &m) {
           [](llvm::LiveRegMatrix &mat, const llvm::LiveInterval &li) {
             mat.unassign(li);
           },
-          "li"_a);
+          "li"_a)
+      .def(
+          "is_phys_reg_used",
+          [](llvm::LiveRegMatrix &mat, unsigned physreg) {
+            return mat.isPhysRegUsed(llvm::MCRegister(physreg));
+          },
+          "physreg"_a,
+          "Whether any virtual register has been assigned to `physreg` yet "
+          "(used by the callee-saved eviction bias).");
 
   m.def("register_regalloc", &registerRegAlloc, "name"_a, "cls"_a,
         "Register a RegAllocBase subclass under `name` so "

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1731,3 +1731,63 @@ def test_priority_pressure_accessors():
     assert remat["MOVi32imm"] is True
     assert remat["COPY"] is False
     assert_no_leaks()
+
+
+# -- eviction cost surface (canEvictInterference / isUnusedCalleeSavedReg) -----
+
+
+def test_eviction_cost_accessors():
+    """The read-only surface RAGreedy's eviction cost model uses: copy hints
+    (broken-hint accounting), callee-saved aliasing, and whether a physreg has
+    been used yet."""
+    saw = {}
+    hints = {}
+
+    class Reader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            hints[li.reg] = (
+                self.reg_allocation_hints(li.reg),
+                self.simple_hint(li.reg),
+            )
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    if "used_after" not in saw:
+                        # is_phys_reg_used flips False->True across the assign.
+                        saw["used_before"] = self.matrix.is_phys_reg_used(preg)
+                        self.matrix.assign(li, preg)
+                        saw["used_after"] = self.matrix.is_phys_reg_used(preg)
+                        # The GPR32 order mixes callee-saved and caller-saved.
+                        csr = [
+                            self.last_callee_saved_alias(p)
+                            for p in self.allocation_order(li)
+                        ]
+                        saw["csr_nonzero"] = any(x != 0 for x in csr)
+                        saw["csr_zero"] = any(x == 0 for x in csr)
+                        return None  # assigned manually
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-evict-cost", Reader)
+    # _build_remat_const has both a copy-related vreg (x0 = COPY w0, hinted) and
+    # a non-copy vreg (v = MOVi32imm, no hint), so both the hinted and "none"
+    # contracts are exercised.
+    obj = _emit("ra-evict-cost", Reader, builder=_build_remat_const, fn="rematc")
+    assert obj[:4] == b"\x7fELF"
+    assert saw["used_before"] is False and saw["used_after"] is True
+    assert saw["csr_nonzero"] and saw["csr_zero"]
+    # The copy of a physreg carries an allocation hint; the constant def does not.
+    hinted = [r for r, ((_t, ids), _sh) in hints.items() if ids]
+    unhinted = [r for r, ((_t, ids), _sh) in hints.items() if not ids]
+    assert hinted, "a copy-related vreg has an allocation hint"
+    assert unhinted, "a non-copy vreg has no allocation hint"
+    (htype, hids), sh = hints[hinted[0]]
+    # A plain copy hint is target-independent (type 0). getSimpleHint returns a
+    # nonzero id only when there is exactly one simple hint -- true for this
+    # single-copy fixture, so simple_hint is that one hinted physreg.
+    assert htype == 0
+    assert sh != 0 and sh in hids, "simple_hint is the copy-hinted physreg"
+    # The "none" contracts: no ids, type 0, and simple_hint 0.
+    (u_type, u_ids), u_sh = hints[unhinted[0]]
+    assert u_type == 0 and u_ids == [] and u_sh == 0
+    assert_no_leaks()


### PR DESCRIPTION
Bind the read-only inputs RAGreedy's canEvictInterference / isUnusedCalleeSavedReg
weigh, so a Python allocator can reproduce its eviction cost model:

- RegAllocBase.reg_allocation_hints(reg) / simple_hint(reg) (MRI) -- copy hints,
  for preferring a hinted physreg and counting broken hints in eviction cost.
- LiveRegMatrix.is_phys_reg_used(physreg) -- whether any vreg is assigned there
  yet (the callee-saved eviction bias).
- RegAllocBase.last_callee_saved_alias(physreg) (RegisterClassInfo) -- detect a
  callee-saved register to bias against introducing a CSR spill.
- Test: is_phys_reg_used flips False->True across an assign, the GPR32 order
  mixes callee-saved and caller-saved regs, and a copy-related vreg carries an
  allocation hint whose simple_hint is the hinted physreg.

cc #600