### PR TITLE
[eudsl-llvmpy] MIR regalloc: live-range segments + spill-weight recompute (#652)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -430,13 +430,17 @@ and `self.last_callee_saved_alias(physreg)`),
 `self.machine_function`, and `self.mbfi` (MachineBlockFrequencyInfo:
 `block_freq`, `block_freq_relative_to_entry_block`, `entry_freq`, for
 frequency-weighted spill/split cost models). The `li` passed in is a
-`LiveInterval` exposing `reg`, `weight`, `is_spillable`, and its own extent
+`LiveInterval` exposing `reg`, `weight`, `is_spillable`, its own extent
 (`begin_index`/`end_index`/`size`; `SlotIndex.distance` measures raw slot-space
 distance and `SlotIndex.get_approx_instr_distance` measures instruction-space
-gaps). For priority/pressure heuristics,
+gaps), its value numbers (`get_vni_at`, `num_val_nums`, `get_val_num_info`), and
+its `segments()` (each a `[start, end)` with a `valno`, for reconstructing
+per-block/per-gap interference). For priority/pressure heuristics,
 `self.reg_class(reg)` (a `TargetRegisterClass` with `id`),
-`self.num_allocatable_regs(reg_class)`, and
-`self.is_trivially_rematerializable(mi)`. Optional overrides: `enqueue(reg)`/`dequeue()` (drive
+`self.num_allocatable_regs(reg_class)`,
+`self.is_trivially_rematerializable(mi)`, and
+`self.calculate_spill_weight_and_hint(reg)` (recompute a split product's
+weight). Optional overrides: `enqueue(reg)`/`dequeue()` (drive
 the assignment order; both traffic in register ids -- stable across splitting,
 unlike interval objects -- and `dequeue` returns a reg id or `None`; the default
 is a spill-weight priority queue), `post_optimization()`, and

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -535,12 +535,14 @@ public:
               llvm::LiveRegMatrix &mat, llvm::Spiller &sp,
               llvm::MachineFunction &mfn, llvm::SplitAnalysis *sa,
               llvm::SplitEditor *se, llvm::MachineBlockFrequencyInfo *mbfi,
-              llvm::EdgeBundles *eb, llvm::SpillPlacement *spl) {
+              llvm::EdgeBundles *eb, llvm::SpillPlacement *spl,
+              llvm::VirtRegAuxInfo *vrai) {
     splitAnalysis = sa;
     splitEditor = se;
     blockFreqInfo = mbfi;
     edgeBundles = eb;
     spillPlacer = spl;
+    auxInfo = vrai;
     regCosts = mfn.getSubtarget().getRegisterInfo()->getRegisterCosts(mfn);
     NativeRegAlloc::pyInit(vrm, lis, mat, sp, mfn);
   }
@@ -647,6 +649,13 @@ public:
     return RegClassInfo.getLastCalleeSavedAlias(llvm::MCRegister(physreg)).id();
   }
 
+  // Recompute the spill weight (and hint) of `reg` from its current defs/uses.
+  // RAGreedy does this for the vregs produced by a split so their enqueue
+  // priority reflects the new, shorter ranges.
+  void calculateSpillWeightAndHint(unsigned reg) {
+    auxInfo->calculateSpillWeightAndHint(LIS->getInterval(llvm::Register(reg)));
+  }
+
   // Spill `li` into the current select_or_split's split-vreg vector.
   void spill(const llvm::LiveInterval &li) {
     if (!currentSplit)
@@ -705,6 +714,7 @@ private:
   llvm::MachineBlockFrequencyInfo *blockFreqInfo = nullptr;
   llvm::EdgeBundles *edgeBundles = nullptr;
   llvm::SpillPlacement *spillPlacer = nullptr;
+  llvm::VirtRegAuxInfo *auxInfo = nullptr;
   llvm::ArrayRef<uint8_t> regCosts;
   std::unique_ptr<llvm::LiveRangeEdit> heldEdit;
 };
@@ -865,7 +875,7 @@ public:
     auto *base =
         static_cast<PyRegAllocBase *>(nb::inst_ptr<PyRegAllocBase>(obj));
     base->pyInit(vrm, lis, mat, *spiller, mfn, &sa, &se, &mbfi, &edgeBundles,
-                 &spillPlacer);
+                 &spillPlacer, &vrai);
     base->pyAllocate();
     // Hold the instance until the pass is destroyed so its C++ subobject (and
     // any Python-recorded witness state) outlives this call; dropped under the
@@ -1082,6 +1092,11 @@ void populate_python_codegen(nb::module_ &m) {
            "physreg"_a,
            "The last callee-saved register aliasing `physreg` (id, or 0) -- "
            "biases against introducing a callee-saved spill.")
+      .def("calculate_spill_weight_and_hint",
+           &PyRegAllocBase::calculateSpillWeightAndHint, "reg"_a,
+           "Recompute `reg`'s spill weight and hint from its current defs/uses "
+           "-- for the vregs a split produced, so their enqueue priority "
+           "reflects the new ranges.")
       .def("spill", &PyRegAllocBase::spill, "li"_a,
            "Spill `li`; new split vregs are appended for re-enqueue. Only "
            "valid inside select_or_split.")
@@ -1149,13 +1164,23 @@ void populate_python_codegen(nb::module_ &m) {
       .def_prop_ro("is_unused",
                    [](const llvm::VNInfo &v) { return v.isUnused(); });
 
+  nb::class_<llvm::LiveRange::Segment>(m, "LiveRangeSegment")
+      .def_ro("start", &llvm::LiveRange::Segment::start)
+      .def_ro("end", &llvm::LiveRange::Segment::end)
+      .def_prop_ro(
+          "valno", [](const llvm::LiveRange::Segment &s) { return s.valno; },
+          nb::rv_policy::reference,
+          "The value number this segment carries. Borrowed; do not retain "
+          "across interval-recomputing calls.");
+
   // A virtual register's live interval: the allocator receives one per
   // select_or_split call and queries/assigns it against the matrix.
   nb::class_<llvm::LiveInterval>(m, "LiveInterval")
       .def_prop_ro("reg",
                    [](const llvm::LiveInterval &li) { return li.reg().id(); })
-      .def_prop_ro("weight",
-                   [](const llvm::LiveInterval &li) { return li.weight(); })
+      .def_prop_rw(
+          "weight", [](const llvm::LiveInterval &li) { return li.weight(); },
+          [](llvm::LiveInterval &li, float w) { li.setWeight(w); })
       .def_prop_ro(
           "is_spillable",
           [](const llvm::LiveInterval &li) { return li.isSpillable(); })
@@ -1198,7 +1223,14 @@ void populate_python_codegen(nb::module_ &m) {
           },
           nb::rv_policy::reference, "i"_a,
           "Value number #`i` of this interval. Borrowed; do not retain across "
-          "shrink_to_uses/eliminate_dead_defs (see get_vni_at).");
+          "shrink_to_uses/eliminate_dead_defs (see get_vni_at).")
+      .def(
+          "segments",
+          [](const llvm::LiveInterval &li) {
+            return std::vector<llvm::LiveRange::Segment>(li.begin(), li.end());
+          },
+          "The [start, end) segments of this interval (each with its value "
+          "number) -- walk them to place interference per block/gap.");
 
   // The virtual-to-physical assignment map. get_phys/has_phys let an eviction
   // policy read which physreg an interfering vreg currently holds before

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -11,7 +11,7 @@ test-visible object witnesses that Python drove it; JIT-executed tests prove the
 result stays correct.
 """
 
-import ctypes, platform
+import ctypes, math, platform
 import pytest
 import llvm
 from llvm import ir, jit, mir
@@ -1790,4 +1790,101 @@ def test_eviction_cost_accessors():
     # The "none" contracts: no ids, type 0, and simple_hint 0.
     (u_type, u_ids), u_sh = hints[unhinted[0]]
     assert u_type == 0 and u_ids == [] and u_sh == 0
+    assert_no_leaks()
+
+
+# -- segments + spill-weight recompute (calcGapWeights / split products) -------
+
+
+_seg_saw = {}
+
+
+class _SegWeightSplit(mir.RegAllocBase):
+    """Reads the parent interval's segments (the surface calcGapWeights /
+    InterferenceCache reconstruction walk), performs a through-block split, and
+    recomputes a split product's spill weight the way RAGreedy does."""
+
+    done = False
+
+    def select_or_split(self, li):
+        cls = type(self)
+        if not cls.done:
+            sa = self.split_analysis
+            sa.analyze(li)
+            if sa.num_through_blocks() > 0:
+                cls.done = True
+                b, e = li.begin_index, li.end_index
+                segs = li.segments()
+                _seg_saw["nsegs"] = len(segs)
+                _seg_saw["ordered"] = all(s.start < s.end for s in segs)
+                # Boundaries pin the segments to the interval's own extent (not a
+                # tautology: b/e are the interval endpoints, and the segments
+                # must start/end exactly there) and successive segments must not
+                # overlap.
+                _seg_saw["starts_at_begin"] = segs[0].start == b
+                _seg_saw["ends_at_end"] = segs[-1].end == e
+                _seg_saw["non_overlapping"] = all(
+                    segs[i].end <= segs[i + 1].start for i in range(len(segs) - 1)
+                )
+                # Each segment's value number must be one of the interval's own.
+                own_vnos = {li.get_val_num_info(i).id for i in range(li.num_val_nums)}
+                _seg_saw["valno_ok"] = all(s.valno.id in own_vnos for s in segs)
+                mf = self.machine_function
+                b0, b1, b2 = mf.blocks[0], mf.blocks[1], mf.blocks[2]
+                lre = self.new_live_range_edit(li)
+                se = self.split_editor
+                se.reset(lre, mir.ComplementSpillMode.SM_Size)
+                idx = se.open_intv()
+                se.select_intv(idx)
+                se.enter_intv_at_end(b0)
+                se.use_intv_mbb(b1)
+                se.leave_intv_at_top(b2)
+                se.finish()
+                nvs = lre.new_vregs()
+                _seg_saw["nnew"] = len(nvs)
+                nv = nvs[0]
+                iv = self.lis.interval(nv)
+                # SplitEditor already gave the product a weight. Capture it as an
+                # independent oracle, poison the stored weight, then confirm the
+                # recompute writes the correct value back -- so a no-op binding
+                # (which would leave the poison value) is caught.
+                _seg_saw["framework_weight"] = iv.weight
+                iv.weight = -1.0
+                self.calculate_spill_weight_and_hint(nv)
+                _seg_saw["new_weight"] = self.lis.interval(nv).weight
+                # the recomputed product has segments of its own
+                _seg_saw["new_nsegs"] = len(self.lis.interval(nv).segments())
+                return None
+        for preg in self.allocation_order(li):
+            if self.matrix.is_free(li, preg):
+                return preg
+        self.spill(li)
+        return None
+
+
+def test_segments_and_spill_weight_recompute():
+    _SegWeightSplit.done = False
+    _seg_saw.clear()
+    mir.register_regalloc("ra-seg-weight", _SegWeightSplit)
+    obj = _emit("ra-seg-weight", _SegWeightSplit, builder=_build_three_block, fn="thru")
+    assert obj[:4] == b"\x7fELF"
+    # The through-block split branch (the only path that exercises the new
+    # surface) must actually have run -- otherwise the assertions below would
+    # vacuously pass on a stale/empty _seg_saw.
+    assert _SegWeightSplit.done, "through-block split path did not execute"
+    # Parent interval segments: the def-in-b0/through-b1/use-in-b2 shape is a
+    # single contiguous segment spanning the whole interval.
+    assert _seg_saw["nsegs"] == 1
+    assert _seg_saw["ordered"]
+    assert _seg_saw["starts_at_begin"] and _seg_saw["ends_at_end"]
+    assert _seg_saw["non_overlapping"]
+    assert _seg_saw["valno_ok"]
+    # The split produced new vregs; recomputing a product's weight overwrote
+    # the poisoned value with the same positive weight the framework's own
+    # calculation produced (so a no-op binding would fail here).
+    assert _seg_saw["nnew"] > 0
+    assert _seg_saw["new_nsegs"] >= 1
+    w = _seg_saw["new_weight"]
+    assert isinstance(w, float) and math.isfinite(w) and w > 0
+    assert w == _seg_saw["framework_weight"]
     assert_no_leaks()


### PR DESCRIPTION
The last surface a faithful RAGreedy needs -- segment-level interference
inspection and split-product weights:

- LiveInterval.segments() returning LiveRangeSegment{start, end, valno}. Walking
  segments is how a Python allocator reconstructs RAGreedy's InterferenceCache
  (per-block first/last interference) and calcGapWeights (per-gap interference),
  from the interferers that interfering_vregs already returns -- so the private
  InterferenceCache class does not need binding.
- RegAllocBase.calculate_spill_weight(reg) (VirtRegAuxInfo, threaded into the
  driver) recomputes a vreg's spill weight/hint -- RAGreedy does this for split
  products so their enqueue priority reflects the new, shorter ranges.
- Test: reads the parent interval's segments (ordered, within extent, valno
  defined), performs a through-block split, and recomputes a product's weight
  to a finite positive value over its own segments.

cc #600