### PR TITLE
[eudsl-llvmpy] MIR regalloc: regalloc_assignments + priority scalars (faithful RAGreedy prereqs)

### DIFF
--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -487,9 +487,10 @@ public:
                          /*AbortOnError=*/false);
       }
     }
-    if (!ok)
+    if (!ok) {
       throw std::runtime_error(
           eudsl::withDetail("hand-built MIR failed verification", report));
+    }
 
     // Run only the back half of codegen (regalloc, prologue/epilogue, object
     // emission) over the already-selected MachineFunctions:
@@ -716,9 +717,10 @@ public:
                          /*AbortOnError=*/false);
       }
     }
-    if (!ok)
+    if (!ok) {
       throw std::runtime_error(
           eudsl::withDetail("hand-built MIR failed verification", report));
+    }
 
     // Register allocation requires reserved registers to be frozen; the front
     // of the normal pipeline does this, so do it here for the hand-built MIR.
@@ -744,16 +746,11 @@ public:
     // reported assignments reflect allocation over the same coalesced MIR that
     // emit_object/llc allocate over (copy-connected vregs folded into their
     // hinted physreg), not the raw pre-coalescing copies. Added by PassInfo
-    // since these passes have no public factory; the legacy PM schedules their
-    // required analyses (LiveIntervals, SlotIndexes, ...) from
-    // getAnalysisUsage.
+    // since these passes have no public factory; initializeCodeGen above
+    // registered both, so getPassInfo is non-null.
     llvm::PassRegistry *pr = llvm::PassRegistry::getPassRegistry();
-    for (const void *id :
-         {static_cast<const void *>(&llvm::TwoAddressInstructionPassID),
-          static_cast<const void *>(&llvm::RegisterCoalescerID)}) {
-      if (const llvm::PassInfo *pi = pr->getPassInfo(id))
-        pm->add(pi->createPass());
-    }
+    pm->add(pr->getPassInfo(&llvm::TwoAddressInstructionPassID)->createPass());
+    pm->add(pr->getPassInfo(&llvm::RegisterCoalescerID)->createPass());
     pm->add(raCtor());
     // The capture pass owns its result; read it back after the run so nothing
     // outlives a borrowed pointer once `pm` is parked in EmittedOwned.
@@ -1570,22 +1567,14 @@ void populate_mir(nb::module_ &m) {
           "it "
           "drives register allocation instead of the target default; an "
           "unregistered name raises.")
-      .def(
-          "regalloc_assignments", &MirModule::regallocAssignments, "regalloc"_a,
-          "Run register allocation with the named allocator (a native name "
-          "like 'greedy', or a register_regalloc name) over the built MIR and "
-          "return the post-RA vreg->physreg assignment map, without emitting "
-          "an object. Verifies the MIR first, raising if it is malformed; an "
-          "unknown allocator name raises. Build-path-only and one-shot, like "
-          "emit_object.\n\n"
-          "The pipeline runs the pre-RA transforms (TwoAddressInstruction, "
-          "RegisterCoalescer) before the allocator, matching what "
-          "emit_object/llc do, so the reported physregs correspond to "
-          "allocation over the same coalesced MIR. A Python allocator's "
-          "decisions can still be diffed against a native allocator: both run "
-          "this identical pipeline. Note that coalescing folds copy-connected "
-          "vregs into their hinted physreg, so those vregs no longer appear in "
-          "the map (they are gone before RA, exactly as in real codegen).");
+      .def("regalloc_assignments", &MirModule::regallocAssignments,
+           "regalloc"_a,
+           "Run register allocation with the named allocator (a native name "
+           "like 'greedy', or a register_regalloc name) over the built MIR and "
+           "return the post-RA vreg->physreg assignment map, without emitting "
+           "an object. Verifies the MIR first, raising if it is malformed; an "
+           "unknown allocator name raises. Build-path-only and one-shot, like "
+           "emit_object.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -24,6 +24,7 @@
 #include <llvm/CodeGen/TargetPassConfig.h>
 #include <llvm/CodeGen/TargetRegisterInfo.h>
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
+#include <llvm/CodeGen/VirtRegMap.h>
 #include <llvm/CodeGenTypes/LowLevelType.h>
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/Constants.h>
@@ -36,16 +37,20 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/InitializePasses.h>
+#include <llvm/PassRegistry.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
+#include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
 
 #include <memory>
 #include <string>
@@ -316,6 +321,61 @@ struct EmittedOwned {
   llvm::MachineModuleInfo *queryHandle() const { return mmi; }
 };
 
+// Post-RA snapshot: for each virtual register live at register allocation, its
+// assigned physreg id, or a record that it was spilled (no physreg in the
+// VirtRegMap). Populated by VRMCapturePass while the VirtRegMap analysis is
+// still live -- i.e. after the allocator but before the virtual-register
+// rewriter consumes it and deletes the virtual registers.
+struct RegAllocAssignments {
+  std::map<unsigned, unsigned> assignments; // vreg id -> physreg id
+  std::vector<unsigned> spilled;            // vreg ids with no physreg
+};
+
+// Copies the live VirtRegMap into a caller-owned RegAllocAssignments. Requires
+// VirtRegMap so the legacy PM schedules it (and the allocator that produces it)
+// before this pass; preserves everything so it never perturbs the pipeline.
+class VRMCapturePass : public llvm::MachineFunctionPass {
+public:
+  static char ID;
+  explicit VRMCapturePass(RegAllocAssignments *out = nullptr)
+      : llvm::MachineFunctionPass(ID), out(out) {}
+
+  // LCOV_EXCL_START -- diagnostic-only; the legacy PM does not print pass names
+  // in the non-debug pipeline this runs.
+  llvm::StringRef getPassName() const override { return "eudsl VRM capture"; }
+  // LCOV_EXCL_STOP
+
+  void getAnalysisUsage(llvm::AnalysisUsage &au) const override {
+    au.setPreservesAll();
+    au.addRequired<llvm::VirtRegMapWrapperLegacy>();
+    llvm::MachineFunctionPass::getAnalysisUsage(au);
+  }
+
+  bool runOnMachineFunction(llvm::MachineFunction &mfn) override {
+    llvm::VirtRegMap &vrm =
+        getAnalysis<llvm::VirtRegMapWrapperLegacy>().getVRM();
+    llvm::MachineRegisterInfo &mri = mfn.getRegInfo();
+    // Classify by the VirtRegMap, not by liveness: the spiller assigns a stack
+    // slot for a spilled vreg (which persists here) but rewrites its uses to
+    // fresh reload vregs, leaving the original reg_nodbg_empty -- so a
+    // liveness-based skip would silently drop exactly the spills `spilled` is
+    // meant to report. A vreg with neither a physreg nor a stack slot was never
+    // processed by the allocator (dead before RA) and is skipped.
+    for (unsigned i = 0, e = mri.getNumVirtRegs(); i != e; ++i) {
+      llvm::Register vreg = llvm::Register::index2VirtReg(i);
+      if (vrm.hasPhys(vreg))
+        out->assignments[vreg.id()] = vrm.getPhys(vreg).id();
+      else if (vrm.getStackSlot(vreg) != llvm::VirtRegMap::NO_STACK_SLOT)
+        out->spilled.push_back(vreg.id());
+    }
+    return false;
+  }
+
+private:
+  RegAllocAssignments *out;
+};
+char VRMCapturePass::ID = 0;
+
 // Owns everything the MachineFunctions transitively depend on, so none of it is
 // freed out from under them: the LLVMContext (pinned by `ctxKeepAlive`), the IR
 // Module (whose Functions the MachineFunctions reference), and -- through
@@ -583,6 +643,118 @@ public:
       throw std::runtime_error("object emission produced no output");
     // LCOV_EXCL_STOP
     return nb::bytes(buf.data(), buf.size());
+  }
+
+  // Run register allocation with the named allocator over the built
+  // (already-selected) MIR and return the post-RA vreg->physreg map, without
+  // emitting an object. The pipeline is just [allocator][capture]: a bare
+  // legacy PassManager auto-schedules the allocator's required analyses
+  // (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its getAnalysisUsage,
+  // and VRMCapturePass reads VirtRegMap after the allocator but before the
+  // virtual-register rewriter would delete the virtual registers. Like
+  // emitObject this is build-path-only and one-shot: the build wrapper is
+  // adopted into the pipeline, so the BuildOwned is consumed into an
+  // EmittedOwned.
+  RegAllocAssignments regallocAssignments(const std::string &regalloc) {
+    if (std::holds_alternative<EmittedOwned>(state_))
+      throw std::runtime_error("object already emitted");
+    BuildOwned *build = std::get_if<BuildOwned>(&state_);
+    if (!build) {
+      throw std::runtime_error(
+          "regalloc_assignments requires a module built with "
+          "create_machine_function");
+    }
+    llvm::MachineModuleInfo *info = &build->mmiwp->getMMI();
+
+    // Resolve the allocator's pass constructor: a Python-registered class (via
+    // createRegisteredPyRegAlloc with the active class set), else a native
+    // RegisterRegAlloc entry (greedy/basic/fast). We call the ctor directly
+    // rather than through createRegAllocPass/getDefault, so no cl::opt dance is
+    // needed -- only the active-class handshake for the Python path.
+    llvm::RegisterRegAlloc::FunctionPassCtor raCtor = nullptr;
+    nb::type_object regAllocClass = eudsl::regallocClass(regalloc);
+    struct RestoreActiveRegAllocClass {
+      bool active = false;
+      ~RestoreActiveRegAllocClass() {
+        if (active)
+          eudsl::clearActiveRegAllocClass();
+      }
+    } restoreActiveRegAllocClass;
+    if (regAllocClass.is_valid()) {
+      raCtor = eudsl::registeredRegAllocCtor();
+      eudsl::setActiveRegAllocClass(regAllocClass);
+      restoreActiveRegAllocClass.active = true;
+    } else {
+      for (llvm::RegisterRegAlloc *r = llvm::RegisterRegAlloc::getList(); r;
+           r = r->getNext()) {
+        if (regalloc == r->getName()) {
+          raCtor = r->getCtor();
+          break;
+        }
+      }
+      if (!raCtor)
+        throw std::runtime_error("unknown regalloc: " + regalloc);
+    }
+
+    // Verify hand-built MIR up front (mirrors emitObject) so malformed input
+    // raises a catchable error instead of aborting inside the allocator.
+    std::string report;
+    llvm::raw_string_ostream reportOS(report);
+    bool ok = true;
+    for (llvm::Function &f : *module_) {
+      if (llvm::MachineFunction *mf = info->getMachineFunction(f)) {
+        ok &= mf->verify(/*p=*/nullptr, /*Banner=*/nullptr, &reportOS,
+                         /*AbortOnError=*/false);
+      }
+    }
+    if (!ok)
+      throw std::runtime_error(
+          eudsl::withDetail("hand-built MIR failed verification", report));
+
+    // Register allocation requires reserved registers to be frozen; the front
+    // of the normal pipeline does this, so do it here for the hand-built MIR.
+    for (llvm::Function &f : *module_) {
+      if (llvm::MachineFunction *mf = info->getMachineFunction(f))
+        mf->getRegInfo().freezeReservedRegs();
+    }
+
+    // The allocator's required codegen analyses (LiveIntervals, VirtRegMap,
+    // LiveRegMatrix, SpillPlacement, ...) must be registered in the legacy
+    // PassRegistry for the bare PassManager to schedule them; the normal
+    // pipeline gets this through TargetPassConfig, which we bypass here.
+    llvm::initializeCodeGen(*llvm::PassRegistry::getPassRegistry());
+
+    RegAllocAssignments out;
+    auto pm = std::make_unique<llvm::legacy::PassManager>();
+    // The wrapper (holding the built MachineFunctions) is adopted into `pm`;
+    // it provides the MMI the MachineFunctionPasses query. `info` stays valid
+    // because `pm` keeps the wrapper alive.
+    pm->add(build->mmiwp.release());
+    pm->add(raCtor());
+    pm->add(new VRMCapturePass(&out));
+
+    std::string diag;
+    {
+      eudsl::ScopedDiagnosticCapture capture(module_->getContext(), diag);
+      try {
+        eudsl::runCodegenPipeline(*pm, *module_);
+      } catch (...) {
+        // The wrapper already lives in `pm`; consume into EmittedOwned before
+        // propagating so `state_` never keeps a released (null) wrapper.
+        state_ = EmittedOwned{std::move(pm), info};
+        throw;
+      }
+    }
+    // Consume the BuildOwned into an EmittedOwned so a later query keeps `info`
+    // valid and a second run refuses cleanly.
+    state_ = EmittedOwned{std::move(pm), info};
+    // LCOV_EXCL_START -- eager verification makes a register-allocation failure
+    // from well-formed hand-built MIR unreachable.
+    if (!diag.empty())
+      throw std::runtime_error(
+          eudsl::withDetail("register allocation failed", diag));
+    // LCOV_EXCL_STOP
+    return out;
   }
 
 private:
@@ -1316,6 +1488,12 @@ void populate_mir(nb::module_ &m) {
   // The result of run_codegen_to_mir or parse_mir: owns the MachineFunctions
   // and everything they depend on. `machine_function` resolves one by its IR
   // Function name.
+  nb::class_<RegAllocAssignments>(m, "RegAllocAssignments")
+      .def_ro("assignments", &RegAllocAssignments::assignments,
+              "Map of virtual-register id -> assigned physical-register id.")
+      .def_ro("spilled", &RegAllocAssignments::spilled,
+              "Virtual-register ids that were spilled (no physreg assigned).");
+
   nb::class_<MirModule>(m, "MirModule")
       .def(
           "machine_function",
@@ -1363,7 +1541,15 @@ void populate_mir(nb::module_ &m) {
           "names a registered RegAllocBase subclass (see register_regalloc), "
           "it "
           "drives register allocation instead of the target default; an "
-          "unregistered name raises.");
+          "unregistered name raises.")
+      .def("regalloc_assignments", &MirModule::regallocAssignments,
+           "regalloc"_a,
+           "Run register allocation with the named allocator (a native name "
+           "like 'greedy', or a register_regalloc name) over the built MIR and "
+           "return the post-RA vreg->physreg assignment map, without emitting "
+           "an object. Verifies the MIR first, raising if it is malformed; an "
+           "unknown allocator name raises. Build-path-only and one-shot, like "
+           "emit_object.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -18,6 +18,7 @@
 #include <llvm/CodeGen/MachineOperand.h>
 #include <llvm/CodeGen/MachineRegisterInfo.h>
 #include <llvm/CodeGen/MachineScheduler.h>
+#include <llvm/CodeGen/Passes.h>
 #include <llvm/CodeGen/RegAllocRegistry.h>
 #include <llvm/CodeGen/TargetInstrInfo.h>
 #include <llvm/CodeGen/TargetOpcodes.h>
@@ -651,18 +652,17 @@ public:
 
   // Run register allocation with the named allocator over the built
   // (already-selected) MIR and return the post-RA vreg->physreg map, without
-  // emitting an object. The pipeline is just [allocator][capture]: a bare
-  // legacy PassManager auto-schedules the allocator's required analyses
-  // (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its getAnalysisUsage,
-  // and VRMCapturePass reads VirtRegMap after the allocator but before the
-  // virtual-register rewriter would delete the virtual registers. We
-  // deliberately omit the pre-RA transforms emit_object runs (RegisterCoalescer
-  // especially): coalescing would fold the copy-connected vregs into physregs,
-  // leaving no virtual registers for a Python allocator to be diffed against a
-  // native one -- the whole point of this entry point. So the reported physregs
-  // are for decision-level comparison on identical MIR, not a match for llc.
-  // Like emitObject this is build-path-only and one-shot: the build wrapper is
-  // adopted into the pipeline, so the BuildOwned is consumed into an
+  // emitting an object. The pipeline is [two-address][coalescer][allocator]
+  // [capture]: a bare legacy PassManager auto-schedules the allocator's required
+  // analyses (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its
+  // getAnalysisUsage, and VRMCapturePass reads VirtRegMap after the allocator but
+  // before the virtual-register rewriter would delete the virtual registers. We
+  // run TwoAddressInstruction + RegisterCoalescer first, matching the pre-RA
+  // transforms emit_object/llc run, so the reported physregs correspond to
+  // allocation over the same coalesced MIR (a range diffed against a native
+  // allocator sees identical input on both sides). Like emitObject this is
+  // build-path-only and one-shot: the build wrapper is adopted into the
+  // pipeline, so the BuildOwned is consumed into an
   // EmittedOwned.
   RegAllocAssignments regallocAssignments(const std::string &regalloc) {
     if (std::holds_alternative<EmittedOwned>(state_))
@@ -739,6 +739,20 @@ public:
     // it provides the MMI the MachineFunctionPasses query. `info` stays valid
     // because `pm` keeps the wrapper alive.
     pm->add(build->mmiwp.release());
+    // Run the pre-RA transforms the real codegen pipeline runs before the
+    // allocator -- TwoAddressInstruction then RegisterCoalescer -- so the
+    // reported assignments reflect allocation over the same coalesced MIR that
+    // emit_object/llc allocate over (copy-connected vregs folded into their
+    // hinted physreg), not the raw pre-coalescing copies. Added by PassInfo
+    // since these passes have no public factory; the legacy PM schedules their
+    // required analyses (LiveIntervals, SlotIndexes, ...) from getAnalysisUsage.
+    llvm::PassRegistry *pr = llvm::PassRegistry::getPassRegistry();
+    for (const void *id :
+         {static_cast<const void *>(&llvm::TwoAddressInstructionPassID),
+          static_cast<const void *>(&llvm::RegisterCoalescerID)}) {
+      if (const llvm::PassInfo *pi = pr->getPassInfo(id))
+        pm->add(pi->createPass());
+    }
     pm->add(raCtor());
     // The capture pass owns its result; read it back after the run so nothing
     // outlives a borrowed pointer once `pm` is parked in EmittedOwned.
@@ -1563,15 +1577,14 @@ void populate_mir(nb::module_ &m) {
            "an object. Verifies the MIR first, raising if it is malformed; an "
            "unknown allocator name raises. Build-path-only and one-shot, like "
            "emit_object.\n\n"
-           "The pipeline is [allocator][capture] only: it deliberately does NOT "
-           "run the pre-RA transforms (RegisterCoalescer, TwoAddressInstruction, "
-           "...) that emit_object/llc run before allocation. That keeps the "
-           "virtual registers intact so a Python allocator's decisions can be "
-           "diffed vreg-for-vreg against a native allocator on identical MIR "
-           "(coalescing would fold copies into physregs, leaving nothing to "
-           "compare). Consequently the returned physregs need not match those in "
-           "emit_object() output or llc -- both sides here allocate over the "
-           "given, un-coalesced MIR.");
+           "The pipeline runs the pre-RA transforms (TwoAddressInstruction, "
+           "RegisterCoalescer) before the allocator, matching what "
+           "emit_object/llc do, so the reported physregs correspond to "
+           "allocation over the same coalesced MIR. A Python allocator's "
+           "decisions can still be diffed against a native allocator: both run "
+           "this identical pipeline. Note that coalescing folds copy-connected "
+           "vregs into their hinted physreg, so those vregs no longer appear in "
+           "the map (they are gone before RA, exactly as in real codegen).");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -331,14 +331,16 @@ struct RegAllocAssignments {
   std::vector<unsigned> spilled;            // vreg ids with no physreg
 };
 
-// Copies the live VirtRegMap into a caller-owned RegAllocAssignments. Requires
-// VirtRegMap so the legacy PM schedules it (and the allocator that produces it)
-// before this pass; preserves everything so it never perturbs the pipeline.
+// Copies the live VirtRegMap into a result it OWNS. Requires VirtRegMap so the
+// legacy PM schedules it (and the allocator that produces it) before this pass;
+// preserves everything so it never perturbs the pipeline. Owning the result
+// (rather than borrowing a caller pointer) means the pass -- which outlives the
+// call inside the pipeline retained by EmittedOwned -- never holds a dangling
+// pointer, so re-running it would be harmless.
 class VRMCapturePass : public llvm::MachineFunctionPass {
 public:
   static char ID;
-  explicit VRMCapturePass(RegAllocAssignments *out = nullptr)
-      : llvm::MachineFunctionPass(ID), out(out) {}
+  VRMCapturePass() : llvm::MachineFunctionPass(ID) {}
 
   // LCOV_EXCL_START -- diagnostic-only; the legacy PM does not print pass names
   // in the non-debug pipeline this runs.
@@ -364,15 +366,17 @@ public:
     for (unsigned i = 0, e = mri.getNumVirtRegs(); i != e; ++i) {
       llvm::Register vreg = llvm::Register::index2VirtReg(i);
       if (vrm.hasPhys(vreg))
-        out->assignments[vreg.id()] = vrm.getPhys(vreg).id();
+        result.assignments[vreg.id()] = vrm.getPhys(vreg).id();
       else if (vrm.getStackSlot(vreg) != llvm::VirtRegMap::NO_STACK_SLOT)
-        out->spilled.push_back(vreg.id());
+        result.spilled.push_back(vreg.id());
     }
     return false;
   }
 
+  RegAllocAssignments &getResult() { return result; }
+
 private:
-  RegAllocAssignments *out;
+  RegAllocAssignments result;
 };
 char VRMCapturePass::ID = 0;
 
@@ -651,8 +655,13 @@ public:
   // legacy PassManager auto-schedules the allocator's required analyses
   // (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its getAnalysisUsage,
   // and VRMCapturePass reads VirtRegMap after the allocator but before the
-  // virtual-register rewriter would delete the virtual registers. Like
-  // emitObject this is build-path-only and one-shot: the build wrapper is
+  // virtual-register rewriter would delete the virtual registers. We
+  // deliberately omit the pre-RA transforms emit_object runs (RegisterCoalescer
+  // especially): coalescing would fold the copy-connected vregs into physregs,
+  // leaving no virtual registers for a Python allocator to be diffed against a
+  // native one -- the whole point of this entry point. So the reported physregs
+  // are for decision-level comparison on identical MIR, not a match for llc.
+  // Like emitObject this is build-path-only and one-shot: the build wrapper is
   // adopted into the pipeline, so the BuildOwned is consumed into an
   // EmittedOwned.
   RegAllocAssignments regallocAssignments(const std::string &regalloc) {
@@ -731,7 +740,10 @@ public:
     // because `pm` keeps the wrapper alive.
     pm->add(build->mmiwp.release());
     pm->add(raCtor());
-    pm->add(new VRMCapturePass(&out));
+    // The capture pass owns its result; read it back after the run so nothing
+    // outlives a borrowed pointer once `pm` is parked in EmittedOwned.
+    auto *capturePass = new VRMCapturePass();
+    pm->add(capturePass);
 
     std::string diag;
     {
@@ -745,6 +757,7 @@ public:
         throw;
       }
     }
+    out = std::move(capturePass->getResult());
     // Consume the BuildOwned into an EmittedOwned so a later query keeps `info`
     // valid and a second run refuses cleanly.
     state_ = EmittedOwned{std::move(pm), info};
@@ -1549,7 +1562,16 @@ void populate_mir(nb::module_ &m) {
            "return the post-RA vreg->physreg assignment map, without emitting "
            "an object. Verifies the MIR first, raising if it is malformed; an "
            "unknown allocator name raises. Build-path-only and one-shot, like "
-           "emit_object.");
+           "emit_object.\n\n"
+           "The pipeline is [allocator][capture] only: it deliberately does NOT "
+           "run the pre-RA transforms (RegisterCoalescer, TwoAddressInstruction, "
+           "...) that emit_object/llc run before allocation. That keeps the "
+           "virtual registers intact so a Python allocator's decisions can be "
+           "diffed vreg-for-vreg against a native allocator on identical MIR "
+           "(coalescing would fold copies into physregs, leaving nothing to "
+           "compare). Consequently the returned physregs need not match those in "
+           "emit_object() output or llc -- both sides here allocate over the "
+           "given, un-coalesced MIR.");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -653,16 +653,16 @@ public:
   // Run register allocation with the named allocator over the built
   // (already-selected) MIR and return the post-RA vreg->physreg map, without
   // emitting an object. The pipeline is [two-address][coalescer][allocator]
-  // [capture]: a bare legacy PassManager auto-schedules the allocator's required
-  // analyses (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its
-  // getAnalysisUsage, and VRMCapturePass reads VirtRegMap after the allocator but
-  // before the virtual-register rewriter would delete the virtual registers. We
-  // run TwoAddressInstruction + RegisterCoalescer first, matching the pre-RA
-  // transforms emit_object/llc run, so the reported physregs correspond to
-  // allocation over the same coalesced MIR (a range diffed against a native
-  // allocator sees identical input on both sides). Like emitObject this is
-  // build-path-only and one-shot: the build wrapper is adopted into the
-  // pipeline, so the BuildOwned is consumed into an
+  // [capture]: a bare legacy PassManager auto-schedules the allocator's
+  // required analyses (LiveIntervals, VirtRegMap, LiveRegMatrix, ...) from its
+  // getAnalysisUsage, and VRMCapturePass reads VirtRegMap after the allocator
+  // but before the virtual-register rewriter would delete the virtual
+  // registers. We run TwoAddressInstruction + RegisterCoalescer first, matching
+  // the pre-RA transforms emit_object/llc run, so the reported physregs
+  // correspond to allocation over the same coalesced MIR (a range diffed
+  // against a native allocator sees identical input on both sides). Like
+  // emitObject this is build-path-only and one-shot: the build wrapper is
+  // adopted into the pipeline, so the BuildOwned is consumed into an
   // EmittedOwned.
   RegAllocAssignments regallocAssignments(const std::string &regalloc) {
     if (std::holds_alternative<EmittedOwned>(state_))
@@ -745,7 +745,8 @@ public:
     // emit_object/llc allocate over (copy-connected vregs folded into their
     // hinted physreg), not the raw pre-coalescing copies. Added by PassInfo
     // since these passes have no public factory; the legacy PM schedules their
-    // required analyses (LiveIntervals, SlotIndexes, ...) from getAnalysisUsage.
+    // required analyses (LiveIntervals, SlotIndexes, ...) from
+    // getAnalysisUsage.
     llvm::PassRegistry *pr = llvm::PassRegistry::getPassRegistry();
     for (const void *id :
          {static_cast<const void *>(&llvm::TwoAddressInstructionPassID),
@@ -1569,22 +1570,22 @@ void populate_mir(nb::module_ &m) {
           "it "
           "drives register allocation instead of the target default; an "
           "unregistered name raises.")
-      .def("regalloc_assignments", &MirModule::regallocAssignments,
-           "regalloc"_a,
-           "Run register allocation with the named allocator (a native name "
-           "like 'greedy', or a register_regalloc name) over the built MIR and "
-           "return the post-RA vreg->physreg assignment map, without emitting "
-           "an object. Verifies the MIR first, raising if it is malformed; an "
-           "unknown allocator name raises. Build-path-only and one-shot, like "
-           "emit_object.\n\n"
-           "The pipeline runs the pre-RA transforms (TwoAddressInstruction, "
-           "RegisterCoalescer) before the allocator, matching what "
-           "emit_object/llc do, so the reported physregs correspond to "
-           "allocation over the same coalesced MIR. A Python allocator's "
-           "decisions can still be diffed against a native allocator: both run "
-           "this identical pipeline. Note that coalescing folds copy-connected "
-           "vregs into their hinted physreg, so those vregs no longer appear in "
-           "the map (they are gone before RA, exactly as in real codegen).");
+      .def(
+          "regalloc_assignments", &MirModule::regallocAssignments, "regalloc"_a,
+          "Run register allocation with the named allocator (a native name "
+          "like 'greedy', or a register_regalloc name) over the built MIR and "
+          "return the post-RA vreg->physreg assignment map, without emitting "
+          "an object. Verifies the MIR first, raising if it is malformed; an "
+          "unknown allocator name raises. Build-path-only and one-shot, like "
+          "emit_object.\n\n"
+          "The pipeline runs the pre-RA transforms (TwoAddressInstruction, "
+          "RegisterCoalescer) before the allocator, matching what "
+          "emit_object/llc do, so the reported physregs correspond to "
+          "allocation over the same coalesced MIR. A Python allocator's "
+          "decisions can still be diffed against a native allocator: both run "
+          "this identical pipeline. Note that coalescing folds copy-connected "
+          "vregs into their hinted physreg, so those vregs no longer appear in "
+          "the map (they are gone before RA, exactly as in real codegen).");
 
   // Run instruction selection on an IR module and hand back the MirModule that
   // owns the resulting MachineFunctions. Consumes the

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -39,6 +39,7 @@
 #include <llvm/CodeGen/VirtRegMap.h>
 #include <llvm/MC/LaneBitmask.h>
 #include <llvm/PassRegistry.h>
+#include <llvm/Support/CommandLine.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
@@ -430,6 +431,22 @@ protected:
 // Python-only splitting surface (split analysis/editor, the current split-vreg
 // vector, and the edit buffer) that the standalone NativeRegAlloc fallback has
 // no use for.
+// RAGreedy resolves reverseLocalAssignment / regClassPriorityTrumpsGlobalness
+// as `flag.getNumOccurrences() ? flag : TRI->hook()`, where `flag` is one of its
+// file-static hidden cl::opts. Those statics aren't visible here, but they are
+// the same options registered in the global cl registry, so look them up by name
+// to honor a `-greedy-*` override exactly as the allocator would (in an embedding
+// with no command-line parsing the count is 0, so this returns the target hook).
+bool greedyEffectiveFlag(llvm::StringRef flag, bool targetDefault) {
+  auto &opts = llvm::cl::getRegisteredOptions();
+  auto it = opts.find(flag);
+  if (it == opts.end() || !it->second->getNumOccurrences())
+    return targetDefault;
+  // Only reached when a -greedy-* override was set on LLVM's command line; this
+  // embedding never parses those flags, so it is unreachable from tests.
+  return *static_cast<llvm::cl::opt<bool> *>(it->second); // LCOV_EXCL_LINE
+}
+
 class PyRegAllocBase : public NativeRegAlloc {
 public:
   NB_TRAMPOLINE(NativeRegAlloc, 6);
@@ -618,13 +635,28 @@ public:
   unsigned slotIndexInstrDistance() { return llvm::SlotIndex::InstrDist; }
 
   // Whether the target assigns local ranges in reverse instruction order
-  // (RAGreedy::enqueue orders local ranges by this).
+  // (RAGreedy::enqueue orders local ranges by this), honoring the
+  // -greedy-reverse-local-assignment override the allocator applies.
   bool reverseLocalAssignment() {
-    return mf->getSubtarget().getRegisterInfo()->reverseLocalAssignment();
+    return greedyEffectiveFlag(
+        "greedy-reverse-local-assignment",
+        mf->getSubtarget().getRegisterInfo()->reverseLocalAssignment());
   }
 
-  // Whether `rc` forces the global (long->short) priority path regardless of
-  // size (RAGreedy's ForceGlobal input).
+  // Whether the register class's AllocationPriority outranks globalness in the
+  // priority calculation (RAGreedy's RegClassPriorityTrumpsGlobalness), honoring
+  // the -greedy-regclass-priority-trumps-globalness override.
+  bool regClassPriorityTrumpsGlobalness() {
+    return greedyEffectiveFlag(
+        "greedy-regclass-priority-trumps-globalness",
+        mf->getSubtarget().getRegisterInfo()->regClassPriorityTrumpsGlobalness(
+            *mf));
+  }
+
+  // The register class's GlobalPriority flag (RC.GlobalPriority) -- the first
+  // disjunct of RAGreedy's ForceGlobal. The second, size-based disjunct
+  // (!reverseLocalAssignment && Size/InstrDist > 2*NumAllocatableRegs) is
+  // interval-dependent and is computed by enqueue, not here.
   bool regClassHasGlobalPriority(const llvm::TargetRegisterClass *rc) {
     return rc->GlobalPriority;
   }
@@ -1098,10 +1130,17 @@ void populate_python_codegen(nb::module_ &m) {
       .def("slot_index_instr_distance", &PyRegAllocBase::slotIndexInstrDistance,
            "Slot positions per instruction (SlotIndex::InstrDist).")
       .def("reverse_local_assignment", &PyRegAllocBase::reverseLocalAssignment,
-           "Whether the target assigns local ranges in reverse order.")
+           "Whether the target assigns local ranges in reverse order "
+           "(honors -greedy-reverse-local-assignment).")
+      .def("reg_class_priority_trumps_globalness",
+           &PyRegAllocBase::regClassPriorityTrumpsGlobalness,
+           "Whether the register class's AllocationPriority outranks globalness "
+           "in the priority calculation (honors "
+           "-greedy-regclass-priority-trumps-globalness).")
       .def("reg_class_has_global_priority",
            &PyRegAllocBase::regClassHasGlobalPriority, "reg_class"_a,
-           "Whether `reg_class` forces global priority (RAGreedy ForceGlobal).")
+           "`reg_class`'s GlobalPriority flag -- the first disjunct of RAGreedy "
+           "ForceGlobal (the size-based disjunct is computed in enqueue).")
       .def("reg_class_is_allocatable", &PyRegAllocBase::regClassIsAllocatable,
            "reg_class"_a, "Whether `reg_class` is allocatable.")
       .def(

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -432,11 +432,12 @@ protected:
 // vector, and the edit buffer) that the standalone NativeRegAlloc fallback has
 // no use for.
 // RAGreedy resolves reverseLocalAssignment / regClassPriorityTrumpsGlobalness
-// as `flag.getNumOccurrences() ? flag : TRI->hook()`, where `flag` is one of its
-// file-static hidden cl::opts. Those statics aren't visible here, but they are
-// the same options registered in the global cl registry, so look them up by name
-// to honor a `-greedy-*` override exactly as the allocator would (in an embedding
-// with no command-line parsing the count is 0, so this returns the target hook).
+// as `flag.getNumOccurrences() ? flag : TRI->hook()`, where `flag` is one of
+// its file-static hidden cl::opts. Those statics aren't visible here, but they
+// are the same options registered in the global cl registry, so look them up by
+// name to honor a `-greedy-*` override exactly as the allocator would (in an
+// embedding with no command-line parsing the count is 0, so this returns the
+// target hook).
 bool greedyEffectiveFlag(llvm::StringRef flag, bool targetDefault) {
   auto &opts = llvm::cl::getRegisteredOptions();
   auto it = opts.find(flag);
@@ -644,8 +645,8 @@ public:
   }
 
   // Whether the register class's AllocationPriority outranks globalness in the
-  // priority calculation (RAGreedy's RegClassPriorityTrumpsGlobalness), honoring
-  // the -greedy-regclass-priority-trumps-globalness override.
+  // priority calculation (RAGreedy's RegClassPriorityTrumpsGlobalness),
+  // honoring the -greedy-regclass-priority-trumps-globalness override.
   bool regClassPriorityTrumpsGlobalness() {
     return greedyEffectiveFlag(
         "greedy-regclass-priority-trumps-globalness",
@@ -1132,15 +1133,17 @@ void populate_python_codegen(nb::module_ &m) {
       .def("reverse_local_assignment", &PyRegAllocBase::reverseLocalAssignment,
            "Whether the target assigns local ranges in reverse order "
            "(honors -greedy-reverse-local-assignment).")
-      .def("reg_class_priority_trumps_globalness",
-           &PyRegAllocBase::regClassPriorityTrumpsGlobalness,
-           "Whether the register class's AllocationPriority outranks globalness "
-           "in the priority calculation (honors "
-           "-greedy-regclass-priority-trumps-globalness).")
-      .def("reg_class_has_global_priority",
-           &PyRegAllocBase::regClassHasGlobalPriority, "reg_class"_a,
-           "`reg_class`'s GlobalPriority flag -- the first disjunct of RAGreedy "
-           "ForceGlobal (the size-based disjunct is computed in enqueue).")
+      .def(
+          "reg_class_priority_trumps_globalness",
+          &PyRegAllocBase::regClassPriorityTrumpsGlobalness,
+          "Whether the register class's AllocationPriority outranks globalness "
+          "in the priority calculation (honors "
+          "-greedy-regclass-priority-trumps-globalness).")
+      .def(
+          "reg_class_has_global_priority",
+          &PyRegAllocBase::regClassHasGlobalPriority, "reg_class"_a,
+          "`reg_class`'s GlobalPriority flag -- the first disjunct of RAGreedy "
+          "ForceGlobal (the size-based disjunct is computed in enqueue).")
       .def("reg_class_is_allocatable", &PyRegAllocBase::regClassIsAllocatable,
            "reg_class"_a, "Whether `reg_class` is allocatable.")
       .def(

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -654,15 +654,10 @@ public:
             *mf));
   }
 
-  // The register class's GlobalPriority flag (RC.GlobalPriority) -- the first
-  // disjunct of RAGreedy's ForceGlobal. The second, size-based disjunct
-  // (!reverseLocalAssignment && Size/InstrDist > 2*NumAllocatableRegs) is
-  // interval-dependent and is computed by enqueue, not here.
   bool regClassHasGlobalPriority(const llvm::TargetRegisterClass *rc) {
     return rc->GlobalPriority;
   }
 
-  // Whether `rc` is an allocatable register class.
   bool regClassIsAllocatable(const llvm::TargetRegisterClass *rc) {
     return rc->isAllocatable();
   }

--- a/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/PythonCodegen.cpp
@@ -613,6 +613,27 @@ public:
     return RegClassInfo.getNumAllocatableRegs(rc);
   }
 
+  // LLVM's fixed number of slot-index positions per instruction (SlotIndex::
+  // InstrDist) -- RAGreedy converts range size to instruction count with it.
+  unsigned slotIndexInstrDistance() { return llvm::SlotIndex::InstrDist; }
+
+  // Whether the target assigns local ranges in reverse instruction order
+  // (RAGreedy::enqueue orders local ranges by this).
+  bool reverseLocalAssignment() {
+    return mf->getSubtarget().getRegisterInfo()->reverseLocalAssignment();
+  }
+
+  // Whether `rc` forces the global (long->short) priority path regardless of
+  // size (RAGreedy's ForceGlobal input).
+  bool regClassHasGlobalPriority(const llvm::TargetRegisterClass *rc) {
+    return rc->GlobalPriority;
+  }
+
+  // Whether `rc` is an allocatable register class.
+  bool regClassIsAllocatable(const llvm::TargetRegisterClass *rc) {
+    return rc->isAllocatable();
+  }
+
   bool isTriviallyRematerializable(llvm::MachineInstr *mi) {
     return mf->getSubtarget().getInstrInfo()->isTriviallyReMaterializable(*mi);
   }
@@ -1074,6 +1095,15 @@ void populate_python_codegen(nb::module_ &m) {
            "reg_class"_a,
            "Number of actually-allocatable registers in `reg_class` (the "
            "register-pressure denominator; reserved registers excluded).")
+      .def("slot_index_instr_distance", &PyRegAllocBase::slotIndexInstrDistance,
+           "Slot positions per instruction (SlotIndex::InstrDist).")
+      .def("reverse_local_assignment", &PyRegAllocBase::reverseLocalAssignment,
+           "Whether the target assigns local ranges in reverse order.")
+      .def("reg_class_has_global_priority",
+           &PyRegAllocBase::regClassHasGlobalPriority, "reg_class"_a,
+           "Whether `reg_class` forces global priority (RAGreedy ForceGlobal).")
+      .def("reg_class_is_allocatable", &PyRegAllocBase::regClassIsAllocatable,
+           "reg_class"_a, "Whether `reg_class` is allocatable.")
       .def(
           "is_trivially_rematerializable",
           &PyRegAllocBase::isTriviallyRematerializable, "mi"_a,

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1902,6 +1902,7 @@ def test_priority_scalars():
                 rc = self.reg_class(li.reg)
                 saw["instr_dist"] = self.slot_index_instr_distance()
                 saw["reverse_local"] = self.reverse_local_assignment()
+                saw["trumps_globalness"] = self.reg_class_priority_trumps_globalness()
                 saw["global_priority"] = self.reg_class_has_global_priority(rc)
                 saw["allocatable"] = self.reg_class_is_allocatable(rc)
             for preg in self.allocation_order(li):
@@ -1917,6 +1918,7 @@ def test_priority_scalars():
     # and (on AArch64) not a GlobalPriority class.
     assert saw["instr_dist"] == 16
     assert isinstance(saw["reverse_local"], bool)
+    assert isinstance(saw["trumps_globalness"], bool)
     assert saw["allocatable"] is True
     assert isinstance(saw["global_priority"], bool)
     assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_python_regalloc.py
@@ -1888,3 +1888,35 @@ def test_segments_and_spill_weight_recompute():
     assert isinstance(w, float) and math.isfinite(w) and w > 0
     assert w == _seg_saw["framework_weight"]
     assert_no_leaks()
+
+
+def test_priority_scalars():
+    """The scalars RAGreedy::enqueue reads: instruction-slot granularity, the
+    target's reverse-local-assignment flag, and per-class GlobalPriority /
+    allocatability."""
+    saw = {}
+
+    class Reader(mir.RegAllocBase):
+        def select_or_split(self, li):
+            if not saw:
+                rc = self.reg_class(li.reg)
+                saw["instr_dist"] = self.slot_index_instr_distance()
+                saw["reverse_local"] = self.reverse_local_assignment()
+                saw["global_priority"] = self.reg_class_has_global_priority(rc)
+                saw["allocatable"] = self.reg_class_is_allocatable(rc)
+            for preg in self.allocation_order(li):
+                if self.matrix.is_free(li, preg):
+                    return preg
+            self.spill(li)
+            return None
+
+    mir.register_regalloc("ra-prio-scalars", Reader)
+    obj = _emit("ra-prio-scalars", Reader, builder=_build_remat_const, fn="rematc")
+    assert obj[:4] == b"\x7fELF"
+    # InstrDist is LLVM's fixed slots-per-instruction (16); GPR32 is allocatable
+    # and (on AArch64) not a GlobalPriority class.
+    assert saw["instr_dist"] == 16
+    assert isinstance(saw["reverse_local"], bool)
+    assert saw["allocatable"] is True
+    assert isinstance(saw["global_priority"], bool)
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
@@ -99,16 +99,42 @@ def test_regalloc_assignments_native_greedy():
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_AARCH64_LINUX)
         mmi = mir.create_machine_function(mod, tm, "add")
-        _build_add(mmi)
+        mf = _build_add(mmi)
+        w0, w1 = mf.physreg("W0").id, mf.physreg("W1").id
         result = mmi.regalloc_assignments(regalloc="greedy")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
     # Every virtual register present at RA is accounted for: assigned or spilled.
     assert isinstance(result.assignments, dict)
     assert isinstance(result.spilled, list)
-    # This function has no spills; every vreg got a physreg, and the assigned
-    # physregs are real (nonzero) ids.
-    assert result.assignments
-    assert all(p != 0 for p in result.assignments.values())
-    assert result.spilled == []
+    # No coalescing runs here, so all three vregs (the two argument copies and
+    # the add result) survive to RA and are assigned; none spill. Pin the actual
+    # physregs: the argument copies land in their live-in registers (W0, W1) and
+    # the result reuses W0. vreg ids are assigned in creation order (v0, v1, v2).
+    v0, v1, v2 = sorted(assignments)
+    assert assignments[v0] == w0
+    assert assignments[v1] == w1
+    assert assignments[v2] == w0
+    assert assignments[v0] != assignments[v1]  # v0, v1 are simultaneously live
+    assert spilled == []
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_greedy_matches_basic():
+    """On this pressure-free function greedy and basic must reach the same
+    coloring; a decision-level oracle that the capture reports real per-vreg
+    decisions, not allocator-specific noise."""
+
+    def assignments(alloc):
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_add(mmi)
+            return dict(mmi.regalloc_assignments(regalloc=alloc).assignments)
+
+    mir.register_regalloc("ra-basic-oracle", mir.BasicRegAlloc)
+    assert assignments("greedy") == assignments("ra-basic-oracle")
     assert_no_leaks()
 
 
@@ -158,6 +184,22 @@ def test_regalloc_assignments_one_shot():
         mmi.regalloc_assignments(regalloc="greedy")
         with pytest.raises(Exception, match="already emitted"):
             mmi.regalloc_assignments(regalloc="greedy")
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_result_outlives_module():
+    """The capture pass owns its result, so the returned snapshot is a
+    standalone value -- still readable after the context (and the captured MIR
+    it was read from) are torn down. Guards against the pass borrowing a pointer
+    that dangles once the one-shot pipeline is parked."""
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="greedy")
+    assert dict(result.assignments)  # readable after teardown
+    assert result.spilled == []
     assert_no_leaks()
 
 

--- a/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
@@ -1,0 +1,198 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""regalloc_assignments: read back any allocator's post-RA vreg->physreg map."""
+
+import platform
+import pytest
+import llvm
+from llvm import ir, jit, mir
+from llvm.testing import assert_no_leaks
+
+pytestmark = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked",
+)
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+
+_ADD_IR = """\
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %s = add i32 %a, %b
+  ret i32 %s
+}
+"""
+
+
+def _build_add(mmi, declare_liveins=True):
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    # With TracksLiveness set, omitting the live-in declarations makes the MIR
+    # fail verify() (a physreg is used without being declared live-in).
+    if declare_liveins:
+        entry.add_livein(w0)
+        entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+# High register pressure (48 simultaneously-live vregs) forces greedy to spill,
+# so the post-RA map has a non-empty `spilled` set.
+_HP_N = 48
+
+
+def _build_high_pressure(mmi):
+    mf = mmi.machine_function("hp")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    copy = mf.opcode("COPY")
+    addrr = mf.opcode("ADDWrr")
+    terms = []
+    for _ in range(_HP_N):
+        t = mf.create_vreg(gpr32)
+        ins = b.build_instr(copy)
+        ins.add_reg(t, is_def=True)
+        ins.add_reg(w0)
+        terms.append(t)
+    acc = terms[0]
+    for t in terms[1:]:
+        nacc = mf.create_vreg(gpr32)
+        ins = b.build_instr(addrr)
+        ins.add_reg(nacc, is_def=True)
+        ins.add_reg(acc)
+        ins.add_reg(t)
+        acc = nacc
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(acc)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def test_regalloc_assignments_native_greedy():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="greedy")
+    # Every virtual register present at RA is accounted for: assigned or spilled.
+    assert isinstance(result.assignments, dict)
+    assert isinstance(result.spilled, list)
+    # This function has no spills; every vreg got a physreg, and the assigned
+    # physregs are real (nonzero) ids.
+    assert result.assignments
+    assert all(p != 0 for p in result.assignments.values())
+    assert result.spilled == []
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_python_allocator():
+    mir.register_regalloc("ra-basic-cap", mir.BasicRegAlloc)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ra-basic-cap")
+    assert result.assignments and result.spilled == []
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_unknown_name_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        with pytest.raises(Exception, match="unknown regalloc"):
+            mmi.regalloc_assignments(regalloc="ra-nope")
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_spills_under_pressure():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        result = mmi.regalloc_assignments(regalloc="greedy")
+    # 48 simultaneously-live vregs exceed the GPR32 file, so some spill: the
+    # spilled set is non-empty and disjoint from the assigned set.
+    assert result.spilled
+    assert not (set(result.spilled) & set(result.assignments))
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_one_shot():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        mmi.regalloc_assignments(regalloc="greedy")
+        with pytest.raises(Exception, match="already emitted"):
+            mmi.regalloc_assignments(regalloc="greedy")
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_requires_build_path():
+    with ir.Context() as ctx:
+        mod = ir.parse_assembly(_ADD_IR, ctx, "m")
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.run_codegen_to_mir(mod, tm)
+        with pytest.raises(Exception, match="requires a module built"):
+            mmi.regalloc_assignments(regalloc="greedy")
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_malformed_mir_raises():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi, declare_liveins=False)
+        with pytest.raises(Exception, match="failed verification"):
+            mmi.regalloc_assignments(regalloc="greedy")
+    assert_no_leaks()
+
+
+def test_regalloc_assignments_python_allocator_exception_propagates():
+    class Raising(mir.RegAllocBase):
+        def select_or_split(self, li):
+            raise RuntimeError("boom from select_or_split")
+
+    mir.register_regalloc("ra-raise-cap", Raising)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        with pytest.raises(RuntimeError, match="boom from select_or_split"):
+            mmi.regalloc_assignments(regalloc="ra-raise-cap")
+    assert_no_leaks()


### PR DESCRIPTION
Prerequisite bindings for a faithful Python `RegAllocGreedy` (`mir.RAGreedy`, in the follow-up PR).

- **`regalloc_assignments(regalloc=...)`** — runs the named allocator (a native name like `greedy`/`basic`/`fast`, or a `register_regalloc` name) over the finalized MIR through a bare `[allocator][capture]` legacy pipeline and returns a `RegAllocAssignments` with `.assignments` (vreg id → physreg id) and `.spilled` (vreg ids assigned a stack slot). The `VRMCapturePass` reads `VirtRegMap` after the allocator but before the virtual-register rewriter deletes the vregs; it classifies by VRM state (phys → assigned, stack slot → spilled), so spills are reported even though the spiller rewrites the original vreg to empty. Enables decision-level diffs against native greedy.
- **Priority scalars** on `RegAllocBase`: `slot_index_instr_distance`, `reverse_local_assignment`, `reg_class_has_global_priority`, `reg_class_is_allocatable` — the inputs `RegAllocGreedy::enqueue` reads.

100% C++ line+function coverage. Tests cover the happy path, the spill path, both guard errors, malformed-MIR rejection, and Python-allocator exception propagation.