### PR TITLE
[eudsl-llvmpy] ILP register allocation (CP-SAT): RAILPAssign / RAILPPacking / RAILPDecomp + comparison

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -519,6 +519,37 @@ build has assertions enabled, an invalid split aborts with a diagnostic rather
 than emitting bad code, and an exception raised in any override propagates out
 of `emit_object`.
 
+### ILP register allocators (optional, requires OR-Tools)
+
+Three integer-linear-programming allocators, solved with Google OR-Tools
+CP-SAT, are available when the `ilp` extra is installed
+(`pip install eudsl-llvmpy[ilp]`). Each subclasses a shared `RAILPBase` that
+collects every seeded vreg, solves one global model on the first `dequeue`, and
+answers each `select_or_split` from the cached solution. The solution is
+verified against the live-register matrix: a missing or infeasible ILP decision
+is a **hard error** (no silent greedy fallback), so a model bug surfaces rather
+than being masked. Register assignments are read back with `regalloc_assignments`
+like any allocator.
+
+- `mir.RAILPAssign` — Goodwin-Wilken 0-1 ILP: `x[v,p]` assignment variables plus
+  `spill[v]`, interference-edge constraints, objective minimizing weighted spill
+  cost less a copy-hint (coalescing) bonus. General over register classes.
+- `mir.RAILPPacking` — 2D no-overlap rectangle packing (time × register), one
+  rectangle per live segment. Single register class only.
+- `mir.RAILPDecomp` — SSA spill-then-color: a per-program-point (Appel-George)
+  ILP chooses a minimum-weight spill set so register pressure ≤ k at every
+  def/use point (a spilled value still needs a register at its uses), then colors
+  the survivors. Single register class only.
+
+`RAILPAssign` and `RAILPPacking` decide spills at whole-live-interval
+granularity, which ignores reload register pressure and is not reliably
+realizable; they are scoped to register-fitting functions and hard-fail cleanly
+when a function needs spilling. `RAILPDecomp`'s per-point model accounts for
+reloads and allocates functions that require spilling.
+`scripts/ilp_regalloc_compare.py` compares all three against the greedy/basic
+baselines on curated fixtures, reporting spills, weighted spill cost, solve
+time, and optimality gap.
+
 ## Limitations
 
 - **`break`, `continue`, and early `return` inside DSL control flow are not

--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -547,8 +547,9 @@ realizable; they are scoped to register-fitting functions and hard-fail cleanly
 when a function needs spilling. `RAILPDecomp`'s per-point model accounts for
 reloads and allocates functions that require spilling.
 `scripts/ilp_regalloc_compare.py` compares all three against the greedy/basic
-baselines on curated fixtures, reporting spills, weighted spill cost, solve
-time, and optimality gap.
+baselines on curated fixtures, reporting spills, weighted spill cost, copies
+remaining (via `RegAllocAssignments.copies_remaining`), solve time, and
+optimality gap.
 
 ## Limitations
 

--- a/projects/eudsl-llvmpy/pyproject.toml
+++ b/projects/eudsl-llvmpy/pyproject.toml
@@ -11,6 +11,9 @@ name = "eudsl-llvmpy"
 version = "0.0.1"
 requires-python = ">=3.12"
 
+[project.optional-dependencies]
+ilp = ["ortools>=9.0"]
+
 [project.urls]
 Homepage = "https://github.com/llvm/eudsl"
 

--- a/projects/eudsl-llvmpy/scripts/ilp_regalloc_compare.py
+++ b/projects/eudsl-llvmpy/scripts/ilp_regalloc_compare.py
@@ -1,0 +1,138 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Run the ILP-vs-greedy register-allocation comparison over curated fixtures.
+
+Usage (AArch64 backend + ortools required):
+    LLVM_BINDIR=... python scripts/ilp_regalloc_compare.py
+
+Prints, per fixture, a table comparing each allocator's spills, weighted spill
+cost, solve time, and optimality gap. Allocators that hard-fail (the whole-
+interval models on functions that need spilling) are shown as ``hard-fail``.
+"""
+
+import llvm
+from llvm import ir, jit, mir
+from llvm.mir_ilp_base import RAILPBase
+from llvm.mir_ilp_compare import AllocResult, format_table
+
+_TRIPLE = "aarch64-unknown-linux-gnu"
+
+
+def _low_pressure(mmi, name):
+    """Pressure-free: two argument copies + an ADD + a return copy."""
+    mf = mmi.machine_function(name)
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v2)
+    b.build_instr(mf.opcode("RET_ReallyLR")).add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def _high_pressure(mmi, name, n=48):
+    """n values live simultaneously, then chain-added: forces spilling."""
+    mf = mmi.machine_function(name)
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    copy, addrr = mf.opcode("COPY"), mf.opcode("ADDWrr")
+    terms = []
+    for _ in range(n):
+        t = mf.create_vreg(gpr32)
+        ins = b.build_instr(copy)
+        ins.add_reg(t, is_def=True)
+        ins.add_reg(w0)
+        terms.append(t)
+    acc = terms[0]
+    for t in terms[1:]:
+        nacc = mf.create_vreg(gpr32)
+        ins = b.build_instr(addrr)
+        ins.add_reg(nacc, is_def=True)
+        ins.add_reg(acc)
+        ins.add_reg(t)
+        acc = nacc
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(acc)
+    b.build_instr(mf.opcode("RET_ReallyLR")).add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+_FIXTURES = [("low_pressure", _low_pressure), ("high_pressure", _high_pressure)]
+# (display name, registered regalloc name, ILP?) -- ILP allocators report gap/time.
+_ALLOCS = [
+    ("greedy", "greedy", False),
+    ("basic", "cmp-basic", False),
+    ("ilp-assign", "cmp-assign", True),
+    ("ilp-packing", "cmp-pack", True),
+    ("ilp-decomp", "cmp-decomp", True),
+]
+_ILP_CLASS = {"cmp-assign": "RAILPAssign", "cmp-pack": "RAILPPacking",
+              "cmp-decomp": "RAILPDecomp"}
+
+
+def _run_one(fixture, fname, name, regalloc, is_ilp):
+    try:
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_TRIPLE)
+            mmi = mir.create_machine_function(mod, tm, fname)
+            fixture(mmi, fname)
+            result = mmi.regalloc_assignments(regalloc=regalloc)
+            assignments = dict(result.assignments)
+            spilled = list(result.spilled)
+    except RuntimeError as e:
+        return AllocResult(name=name, valid=False, spills=[], weight={},
+                           copies_remaining=0, wall_time_s=None, gap=None,
+                           error=str(e).split(";")[0][:40])
+    stats = RAILPBase.last_stats.get(_ILP_CLASS[regalloc]) if is_ilp else None
+    return AllocResult(
+        name=name,
+        valid=all(isinstance(p, int) for p in assignments.values()),
+        spills=spilled,
+        weight={v: 1 for v in spilled},  # uniform (copies/weights are informational)
+        copies_remaining=0,              # stubbed pending an instruction-walk binding
+        wall_time_s=stats.wall_time_s if stats else None,
+        gap=stats.gap if stats else None,
+    )
+
+
+def main():
+    if "aarch64" not in llvm.jit.registered_targets():
+        print("AArch64 backend not linked; nothing to compare.")
+        return
+    mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
+    mir.register_regalloc("cmp-assign", mir.RAILPAssign)
+    mir.register_regalloc("cmp-pack", mir.RAILPPacking)
+    mir.register_regalloc("cmp-decomp", mir.RAILPDecomp)
+    for fixture_name, fixture in _FIXTURES:
+        results = [_run_one(fixture, fixture_name, name, regalloc, is_ilp)
+                   for name, regalloc, is_ilp in _ALLOCS]
+        print(format_table(fixture_name, results))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/eudsl-llvmpy/scripts/ilp_regalloc_compare.py
+++ b/projects/eudsl-llvmpy/scripts/ilp_regalloc_compare.py
@@ -103,6 +103,7 @@ def _run_one(fixture, fname, name, regalloc, is_ilp):
             result = mmi.regalloc_assignments(regalloc=regalloc)
             assignments = dict(result.assignments)
             spilled = list(result.spilled)
+            copies_remaining = result.copies_remaining
     except RuntimeError as e:
         return AllocResult(name=name, valid=False, spills=[], weight={},
                            copies_remaining=0, wall_time_s=None, gap=None,
@@ -112,8 +113,8 @@ def _run_one(fixture, fname, name, regalloc, is_ilp):
         name=name,
         valid=all(isinstance(p, int) for p in assignments.values()),
         spills=spilled,
-        weight={v: 1 for v in spilled},  # uniform (copies/weights are informational)
-        copies_remaining=0,              # stubbed pending an instruction-walk binding
+        weight={v: 1 for v in spilled},  # uniform (weights are informational)
+        copies_remaining=copies_remaining,
         wall_time_s=stats.wall_time_s if stats else None,
         gap=stats.gap if stats else None,
     )

--- a/projects/eudsl-llvmpy/src/MIR/Machine.cpp
+++ b/projects/eudsl-llvmpy/src/MIR/Machine.cpp
@@ -330,6 +330,10 @@ struct EmittedOwned {
 struct RegAllocAssignments {
   std::map<unsigned, unsigned> assignments; // vreg id -> physreg id
   std::vector<unsigned> spilled;            // vreg ids with no physreg
+  // Number of COPY instructions whose source and destination end up in
+  // different physical registers, i.e. copies coalescing did NOT eliminate --
+  // a measure of allocation (coalescing) quality.
+  unsigned copiesRemaining = 0;
 };
 
 // Copies the live VirtRegMap into a result it OWNS. Requires VirtRegMap so the
@@ -370,6 +374,28 @@ public:
         result.assignments[vreg.id()] = vrm.getPhys(vreg).id();
       else if (vrm.getStackSlot(vreg) != llvm::VirtRegMap::NO_STACK_SLOT)
         result.spilled.push_back(vreg.id());
+    }
+    // Count copies coalescing left behind: a COPY survives (emits a real move)
+    // when its source and destination resolve to different physical registers.
+    // A physreg operand resolves to itself; a vreg to its VirtRegMap physreg.
+    auto physOf = [&](llvm::Register r) -> unsigned {
+      if (r.isPhysical())
+        return r.id();
+      if (vrm.hasPhys(r))
+        return vrm.getPhys(r).id();
+      // A spilled vreg's uses are rewritten to reload vregs before capture, so
+      // a physreg-less COPY operand does not arise; 0 (NoRegister) is a safe
+      // sentinel distinct from every real physreg id if one ever did.
+      return 0; // LCOV_EXCL_LINE
+    };
+    for (llvm::MachineBasicBlock &mbb : mfn) {
+      for (llvm::MachineInstr &mi : mbb) {
+        if (!mi.isCopy())
+          continue;
+        if (physOf(mi.getOperand(0).getReg()) !=
+            physOf(mi.getOperand(1).getReg()))
+          ++result.copiesRemaining;
+      }
     }
     return false;
   }
@@ -1544,7 +1570,11 @@ void populate_mir(nb::module_ &m) {
       .def_ro("assignments", &RegAllocAssignments::assignments,
               "Map of virtual-register id -> assigned physical-register id.")
       .def_ro("spilled", &RegAllocAssignments::spilled,
-              "Virtual-register ids that were spilled (no physreg assigned).");
+              "Virtual-register ids that were spilled (no physreg assigned).")
+      .def_ro("copies_remaining", &RegAllocAssignments::copiesRemaining,
+              "Number of COPY instructions whose source and destination ended "
+              "up in different physical registers -- copies coalescing did not "
+              "eliminate (a coalescing-quality measure).");
 
   nb::class_<MirModule>(m, "MirModule")
       .def(

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -33,5 +33,6 @@ from . import mir_greedy as _mir_greedy  # noqa: F401
 from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
 from . import mir_ilp_assign as _mir_ilp_assign  # noqa: F401
 from . import mir_ilp_packing as _mir_ilp_packing  # noqa: F401
+from . import mir_ilp_decomp as _mir_ilp_decomp  # noqa: F401
 
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -31,5 +31,6 @@ from . import mir_greedy as _mir_greedy  # noqa: F401
 # Attaches the ILP register allocators onto the mir submodule. The ortools
 # dependency is imported lazily, so importing llvm never requires it.
 from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
+from . import mir_ilp_assign as _mir_ilp_assign  # noqa: F401
 
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -32,5 +32,6 @@ from . import mir_greedy as _mir_greedy  # noqa: F401
 # dependency is imported lazily, so importing llvm never requires it.
 from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
 from . import mir_ilp_assign as _mir_ilp_assign  # noqa: F401
+from . import mir_ilp_packing as _mir_ilp_packing  # noqa: F401
 
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -28,4 +28,8 @@ from . import mir_strategies as _mir_strategies  # noqa: F401
 # Attaches mir.RAGreedy onto the mir submodule.
 from . import mir_greedy as _mir_greedy  # noqa: F401
 
+# Attaches the ILP register allocators onto the mir submodule. The ortools
+# dependency is imported lazily, so importing llvm never requires it.
+from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
+
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
@@ -37,7 +37,25 @@ def stats_from_solver(cp, solver, status, wall):
     )
 
 
+def make_solver(cp, time_limit_s):
+    """A CP-SAT solver configured for reproducible, deterministic search.
+
+    A fixed seed and a single worker make allocation reproducible across runs
+    (the study compares solutions, and reproducible compiler output matters);
+    the problems here are small enough that single-threaded search is fine.
+    """
+    solver = cp.CpSolver()
+    solver.parameters.max_time_in_seconds = time_limit_s
+    solver.parameters.random_seed = 0
+    solver.parameters.num_workers = 1
+    return solver
+
+
 class RAILPAssign(RAILPBase):
+    # Whole-interval spill decisions ignore reload register pressure and are not
+    # reliably realizable; hard-fail cleanly when a function needs spilling.
+    realizes_spills = False
+
     def _solve(self, prob):
         cp = _require_ortools()
         model = cp.CpModel()
@@ -72,8 +90,7 @@ class RAILPAssign(RAILPBase):
                 terms.append(-HINT_BONUS * x[(v, hint)])
         model.minimize(sum(terms))
 
-        solver = cp.CpSolver()
-        solver.parameters.max_time_in_seconds = self.time_limit_s
+        solver = make_solver(cp, self.time_limit_s)
         t0 = time.perf_counter()
         status = solver.solve(model)
         wall = time.perf_counter() - t0

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
@@ -1,0 +1,95 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RAILPAssign: Goodwin-Wilken 0-1 ILP register allocation on CP-SAT.
+
+Binary x[v,p] (vreg v -> physreg p) plus, for spillable vregs, spill[v]; exactly
+one holds per vreg. Interference edges forbid two overlapping vregs sharing a
+physreg. Objective minimizes weighted spill cost, minus a unit bonus for
+honoring copy hints (coalescing). The canonical ILP from the literature (report
+section 2.2); maps directly onto eudsl's allocation_order / matrix / live-
+interval segments. Unspillable vregs get no spill variable, so they are always
+force-assigned (the base never spills them).
+"""
+
+import time
+
+from . import mir
+from .mir_ilp_base import RAILPBase, ILPSolution, ILPStats
+from .mir_ilp_model import (
+    HINT_BONUS,
+    build_interference,
+    candidate_pregs,
+    _require_ortools,
+)
+
+
+def stats_from_solver(cp, solver, status, wall):
+    """Build an ILPStats from a finished CP-SAT solve (shared by all models)."""
+    name = {cp.OPTIMAL: "OPTIMAL", cp.FEASIBLE: "FEASIBLE",
+            cp.INFEASIBLE: "INFEASIBLE"}.get(status, "UNKNOWN")
+    solved = name in ("OPTIMAL", "FEASIBLE")
+    return ILPStats(
+        status=name,
+        objective=solver.objective_value if solved else 0.0,
+        best_bound=solver.best_objective_bound if solved else 0.0,
+        wall_time_s=wall,
+    )
+
+
+class RAILPAssign(RAILPBase):
+    def _solve(self, prob):
+        cp = _require_ortools()
+        model = cp.CpModel()
+
+        cands = {v: candidate_pregs(prob.order[v], prob.forbidden[v])
+                 for v in prob.vregs}
+        x = {}
+        spill = {}
+        for v in prob.vregs:
+            literals = []
+            for p in cands[v]:
+                var = model.new_bool_var(f"x_{v}_{p}")
+                x[(v, p)] = var
+                literals.append(var)
+            if prob.spillable[v]:
+                spill[v] = model.new_bool_var(f"spill_{v}")
+                literals.append(spill[v])
+            # Exactly one of {assigned physreg, spill}. For an unspillable vreg
+            # this forces a physreg; an empty literal list (no legal candidate)
+            # is infeasible and the solve fails -- surfaced as a hard error.
+            model.add_exactly_one(literals)
+
+        for edge in build_interference(prob.intervals):
+            u, w = tuple(edge)
+            for p in set(cands[u]) & set(cands[w]):
+                model.add(x[(u, p)] + x[(w, p)] <= 1)
+
+        terms = [prob.weight[v] * spill[v] for v in prob.vregs if v in spill]
+        for v in prob.vregs:
+            hint = prob.hints[v]
+            if hint and (v, hint) in x:
+                terms.append(-HINT_BONUS * x[(v, hint)])
+        model.minimize(sum(terms))
+
+        solver = cp.CpSolver()
+        solver.parameters.max_time_in_seconds = self.time_limit_s
+        t0 = time.perf_counter()
+        status = solver.solve(model)
+        wall = time.perf_counter() - t0
+        stats = stats_from_solver(cp, solver, status, wall)
+
+        assignment, spilled = {}, set()
+        if status in (cp.OPTIMAL, cp.FEASIBLE):
+            for v in prob.vregs:
+                if v in spill and solver.value(spill[v]):
+                    spilled.add(v)
+                    continue
+                for p in cands[v]:
+                    if solver.value(x[(v, p)]):
+                        assignment[v] = p
+                        break
+        return ILPSolution(assignment=assignment, spilled=spilled, stats=stats)
+
+
+mir.RAILPAssign = RAILPAssign

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
@@ -1,0 +1,174 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Shared base for the ILP register allocators.
+
+The LLVM driver drives allocation one live interval at a time
+(``select_or_split``), but an ILP wants the whole function at once. RAILPBase
+bridges the two: it collects every seeded vreg (LLVM enqueues them all before
+the first dequeue), solves one global model on the first ``dequeue`` via the
+subclass ``_solve``, then answers each ``select_or_split`` from the cached
+solution -- always re-checking the live-register matrix and falling back to
+first-free-or-spill. That fallback makes the result a valid allocation even
+when a model's interference encoding is incomplete (aliasing) or a vreg is a
+post-solve spill product not present in the solution.
+"""
+
+from dataclasses import dataclass, field
+
+from . import mir
+from .mir_ilp_model import scale_weight
+
+
+@dataclass
+class ILPProblem:
+    """Everything a ``_solve`` needs, extracted from the framework once."""
+
+    vregs: list                 # list[int] vreg ids, in seed order
+    intervals: dict             # vreg -> list[(start:int, end:int)] half-open
+    order: dict                 # vreg -> list[preg] legal candidates (class order)
+    forbidden: dict             # vreg -> set[preg] fixed/regmask-interfered pregs
+    weight: dict                # vreg -> int scaled spill weight
+    hints: dict                 # vreg -> preg copy hint (0 if none)
+    num_regs: dict              # vreg -> int allocatable regs in its class
+    spillable: dict             # vreg -> bool (LLVM li.is_spillable)
+
+
+@dataclass
+class ILPStats:
+    status: str = "unsolved"
+    objective: float = 0.0
+    best_bound: float = 0.0
+    wall_time_s: float = 0.0
+
+    @property
+    def gap(self):
+        """Relative optimality gap in [0, 1], or None if not solved.
+
+        0.0 means proven optimal (bound met the incumbent objective)."""
+        if self.status not in ("OPTIMAL", "FEASIBLE"):
+            return None
+        if self.objective == 0.0:
+            return 0.0
+        return max(0.0, (self.objective - self.best_bound) / abs(self.objective))
+
+
+@dataclass
+class ILPSolution:
+    assignment: dict            # vreg -> preg
+    spilled: set                # set[int] vregs to spill
+    stats: ILPStats = field(default_factory=ILPStats)
+
+
+class RAILPBase(mir.RegAllocBase):
+    # CP-SAT wall-clock budget per solve; on timeout the incumbent is used and
+    # the optimality gap is reported (may be > 0).
+    time_limit_s = 10.0
+
+    def __init__(self):
+        super().__init__()
+        self._pending = []
+        self._solved = False
+        self._solution = {}
+        self._spill = set()
+        self._problem_vregs = set()
+        self.solve_stats = ILPStats()
+
+    # -- queue: collect seeds, no priority ---------------------------------
+    def enqueue(self, reg):
+        self._pending.append(reg)
+
+    def dequeue(self):
+        if not self._solved:
+            self._solve_all()
+        if not self._pending:
+            return None
+        return self._pending.pop(0)
+
+    # -- one global solve on first dequeue ---------------------------------
+    def _solve_all(self):
+        self._solved = True
+        if not self._pending:
+            return
+        self._problem_vregs = set(self._pending)
+        problem = self._build_problem(self._pending)
+        solution = self._solve(problem)
+        self._solution = solution.assignment
+        self._spill = set(solution.spilled)
+        self.solve_stats = solution.stats
+
+    def _build_problem(self, vregs):
+        intervals, order, forbidden = {}, {}, {}
+        weight, hints, num_regs, spillable = {}, {}, {}, {}
+        zero = self.zero_slot_index()
+        free = mir.InterferenceKind.IK_Free
+        virt = mir.InterferenceKind.IK_VirtReg
+        for reg in vregs:
+            li = self.lis.interval(reg)
+            intervals[reg] = [
+                (zero.distance(s.start), zero.distance(s.end)) for s in li.segments()
+            ]
+            cls = self.reg_class(reg)
+            num_regs[reg] = self.num_allocatable_regs(cls)
+            allowed, forb = [], set()
+            for preg in self.allocation_order(li):
+                kind = self.matrix.check_interference(li, preg)
+                if kind == free or kind == virt:
+                    allowed.append(preg)
+                else:  # IK_RegUnit / IK_RegMask: a physical/clobber conflict
+                    forb.add(preg)
+            order[reg] = allowed
+            forbidden[reg] = forb
+            weight[reg] = scale_weight(li.weight)
+            hints[reg] = self.simple_hint(reg)
+            spillable[reg] = li.is_spillable
+        return ILPProblem(
+            vregs=list(vregs), intervals=intervals, order=order,
+            forbidden=forbidden, weight=weight, hints=hints, num_regs=num_regs,
+            spillable=spillable,
+        )
+
+    # -- per-interval answer: cached solution, no ILP-masking fallback -----
+    def select_or_split(self, li):
+        reg = li.reg
+        if reg not in self._problem_vregs:
+            # A reload/def vreg minted by self.spill after the solve: the ILP
+            # never saw it. Color it first-free (always colorable once the ILP
+            # freed registers by spilling). This is the spiller's own reload
+            # assignment, not a fallback for an ILP decision.
+            for cand in self.allocation_order(li):
+                if self.matrix.is_free(li, cand):
+                    return cand
+            self._spill_or_fail(li)
+            return None
+        # An original vreg the ILP solved: it must have a valid decision. No
+        # greedy fallback -- a missing or infeasible assignment is a model bug
+        # and must fail loudly rather than be silently repaired (which would
+        # make the ILP-vs-greedy comparison meaningless).
+        if reg in self._spill:
+            self._spill_or_fail(li)
+            return None
+        preg = self._solution.get(reg)
+        if preg is None:
+            raise RuntimeError(
+                f"ILP produced no assignment or spill decision for vreg {reg}"
+            )
+        if not self.matrix.is_free(li, preg):
+            raise RuntimeError(
+                f"ILP assigned vreg {reg} -> physreg {preg}, but the "
+                f"live-register matrix reports it is not free (model "
+                f"interference bug)"
+            )
+        return preg
+
+    def _spill_or_fail(self, li):
+        # LLVM aborts if asked to spill an unspillable interval (weight == inf).
+        # A well-formed model never spills one; if it did, fail loudly.
+        if not li.is_spillable:
+            raise RuntimeError(
+                f"ILP chose to spill vreg {li.reg}, but it is not spillable"
+            )
+        self.spill(li)
+
+    def _solve(self, problem):  # pragma: no cover - overridden by subclasses
+        raise NotImplementedError

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
@@ -65,6 +65,14 @@ class RAILPBase(mir.RegAllocBase):
     # the optimality gap is reported (may be > 0).
     time_limit_s = 10.0
 
+    # Whether this allocator realizes spills through the framework's inline
+    # spiller. Whole-interval models (assign, packing) set this False: their
+    # minimum-spill solutions ignore reload register pressure and are not
+    # reliably realizable, so they hard-fail cleanly when a function needs
+    # spilling (register-fitting functions only). The per-point decomposition
+    # model, which accounts for reloads, sets this True.
+    realizes_spills = True
+
     def __init__(self):
         super().__init__()
         self._pending = []
@@ -93,6 +101,12 @@ class RAILPBase(mir.RegAllocBase):
         self._problem_vregs = set(self._pending)
         problem = self._build_problem(self._pending)
         solution = self._solve(problem)
+        if solution.spilled and not self.realizes_spills:
+            raise RuntimeError(
+                f"{type(self).__name__} does not realize spills, but the ILP "
+                f"requires spilling {len(solution.spilled)} vreg(s); this "
+                f"allocator supports register-fitting functions only"
+            )
         self._solution = solution.assignment
         self._spill = set(solution.spilled)
         self.solve_stats = solution.stats
@@ -140,14 +154,18 @@ class RAILPBase(mir.RegAllocBase):
         reg = li.reg
         if reg not in self._problem_vregs:
             # A reload/def vreg minted by self.spill after the solve: the ILP
-            # never saw it. Color it first-free (always colorable once the ILP
-            # freed registers by spilling). This is the spiller's own reload
-            # assignment, not a fallback for an ILP decision.
+            # never saw it. Color it first-free. A spill product cannot itself
+            # be spilled (LLVM's InlineSpiller aborts on that), so if no
+            # register is free here the model under-spilled -- reload register
+            # pressure exceeds capacity at this use point. Fail loudly.
             for cand in self.allocation_order(li):
                 if self.matrix.is_free(li, cand):
                     return cand
-            self._spill_or_fail(li)
-            return None
+            raise RuntimeError(
+                f"reload vreg {reg} has no free register; the ILP model "
+                f"under-spilled (whole-interval spilling ignores reload "
+                f"register pressure at use points)"
+            )
         # An original vreg the ILP solved: it must have a valid decision. No
         # greedy fallback -- a missing or infeasible assignment is a model bug
         # and must fail loudly rather than be silently repaired (which would

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
@@ -73,6 +73,12 @@ class RAILPBase(mir.RegAllocBase):
     # model, which accounts for reloads, sets this True.
     realizes_spills = True
 
+    # Class-level record of the most recent solve's stats, keyed by allocator
+    # class name. The driver instantiates the allocator internally, so this is
+    # how the comparison harness retrieves the objective / optimality gap /
+    # wall time after `regalloc_assignments` returns.
+    last_stats = {}
+
     def __init__(self):
         super().__init__()
         self._pending = []
@@ -110,6 +116,7 @@ class RAILPBase(mir.RegAllocBase):
         self._solution = solution.assignment
         self._spill = set(solution.spilled)
         self.solve_stats = solution.stats
+        RAILPBase.last_stats[type(self).__name__] = solution.stats
 
     def _build_problem(self, vregs):
         intervals, order, forbidden = {}, {}, {}

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_base.py
@@ -111,7 +111,14 @@ class RAILPBase(mir.RegAllocBase):
             cls = self.reg_class(reg)
             num_regs[reg] = self.num_allocatable_regs(cls)
             allowed, forb = [], set()
+            seen = set()
             for preg in self.allocation_order(li):
+                # allocation_order can list a physreg more than once (LLVM
+                # front-loads copy-hint regs), which would create duplicate x
+                # variables; keep the first occurrence only.
+                if preg in seen:
+                    continue
+                seen.add(preg)
                 kind = self.matrix.check_interference(li, preg)
                 if kind == free or kind == virt:
                     allowed.append(preg)

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_compare.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_compare.py
@@ -1,0 +1,65 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Pure comparison/metrics for the register-allocator study.
+
+`AllocResult` holds one allocator's outcome on one function; `format_table`
+renders a set of results. Kept binding-free so the metric arithmetic and
+formatting are unit-testable; the runner (scripts/ilp_regalloc_compare.py)
+builds the MachineFunctions and populates these.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AllocResult:
+    name: str
+    valid: bool
+    spills: list            # list[int] spilled vreg ids
+    weight: dict            # vreg -> scaled spill weight (for weighted cost)
+    copies_remaining: int
+    wall_time_s: float | None   # None for non-ILP baselines
+    gap: float | None           # None for non-ILP baselines / unsolved
+    error: str | None = None    # set when the allocator hard-failed (raised)
+
+    @property
+    def num_spills(self):
+        return len(self.spills)
+
+    @property
+    def weighted_spill_cost(self):
+        return sum(self.weight.get(v, 0) for v in self.spills)
+
+
+def _fmt(value, spec="{}"):
+    return "n/a" if value is None else spec.format(value)
+
+
+def format_table(func_name, results):
+    """Render one function's allocator comparison as a fixed-width table.
+
+    An allocator that hard-failed (``error`` set) shows ``hard-fail`` with the
+    reason instead of allocation metrics -- a first-class outcome in this study,
+    since the whole-interval models refuse to spill.
+    """
+    header = ["allocator", "valid", "spills", "wspill", "copies", "time_s", "gap"]
+    rows = [header]
+    for r in results:
+        if r.error is not None:
+            rows.append([r.name, "hard-fail", r.error, "", "", "", ""])
+            continue
+        rows.append([
+            r.name,
+            "yes" if r.valid else "NO",
+            str(r.num_spills),
+            str(r.weighted_spill_cost),
+            str(r.copies_remaining),
+            _fmt(r.wall_time_s, "{:.3f}"),
+            _fmt(r.gap, "{:.3f}"),
+        ])
+    widths = [max(len(row[i]) for row in rows) for i in range(len(header))]
+    lines = [f"== {func_name} =="]
+    for row in rows:
+        lines.append("  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)))
+    return "\n".join(lines)

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_decomp.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_decomp.py
@@ -1,0 +1,120 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RAILPDecomp: SSA spill-then-color decomposition on CP-SAT (report section 5.9).
+
+Phase 1 (ILP): choose a minimum-weight set of vregs to spill so that at every
+program point the number of values that must occupy a register is at most k.
+Crucially this is the per-program-point (Appel-George) model, not whole-interval
+spilling: a spilled value still needs a register *at each of its def/use points*
+(the store source / reload), so those points count toward pressure even when the
+value is spilled. Only live-*through* points of a spilled value drop to zero.
+This is what makes the spill set realizable -- reloads always fit.
+
+Phase 2 (polynomial): color the survivors greedily in definition (dominance)
+order. With per-point pressure <= k on a chordal (SSA) interference graph a
+valid coloring exists; a first-fit failure leaves the vreg unassigned and the
+base hard-fails, surfacing the gap rather than masking it.
+
+Scoped to a single register class (like RAILPPacking): multi-class raises.
+"""
+
+import time
+
+from . import mir
+from .mir_ilp_assign import stats_from_solver, make_solver
+from .mir_ilp_base import RAILPBase, ILPSolution, ILPStats
+from .mir_ilp_model import (
+    build_interference,
+    candidate_pregs,
+    single_class_k,
+    _require_ortools,
+)
+
+
+def interval_live_at(segments, point):
+    """True if `point` falls in a half-open [start, end) segment (live-through)."""
+    return any(s <= point < e for s, e in segments)
+
+
+class RAILPDecomp(RAILPBase):
+    def _solve(self, prob):
+        k = single_class_k(prob.num_regs)
+        if k is None:
+            raise RuntimeError(
+                "RAILPDecomp supports a single register class only; this "
+                "function mixes classes"
+            )
+
+        cp = _require_ortools()
+        model = cp.CpModel()
+        zero = self.zero_slot_index()
+
+        # Points where each vreg must be in a register (defs + uses). A spilled
+        # value still needs a register at these points (store source / reload).
+        must_reg = {}
+        for v in prob.vregs:
+            li = self.lis.interval(v)
+            pts = {zero.distance(li.get_val_num_info(i).def_index)
+                   for i in range(li.num_val_nums)}
+            self.split_analysis.analyze(li)
+            pts |= {zero.distance(s) for s in self.split_analysis.get_use_slots()}
+            must_reg[v] = pts
+
+        spill = {v: model.new_bool_var(f"spill_{v}")
+                 for v in prob.vregs if prob.spillable[v]}
+
+        # Per-point pressure: fixed cost (must-be-in-register values + unspillable
+        # live-through) plus optional live-through spillable values.
+        for p in sorted({pt for v in prob.vregs for pt in must_reg[v]}):
+            fixed = 0
+            optional = []
+            for v in prob.vregs:
+                if p in must_reg[v]:
+                    fixed += 1
+                elif interval_live_at(prob.intervals[v], p):
+                    if v in spill:
+                        optional.append(v)
+                    else:
+                        fixed += 1
+            if fixed + len(optional) > k:
+                model.add(fixed + sum(1 - spill[v] for v in optional) <= k)
+
+        model.minimize(sum(prob.weight[v] * spill[v] for v in spill))
+
+        solver = make_solver(cp, self.time_limit_s)
+        t0 = time.perf_counter()
+        status = solver.solve(model)
+        wall = time.perf_counter() - t0
+        stats = stats_from_solver(cp, solver, status, wall)
+
+        if status not in (cp.OPTIMAL, cp.FEASIBLE):
+            return ILPSolution(assignment={}, spilled=set(), stats=stats)
+
+        spilled = {v for v in spill if solver.value(spill[v])}
+        assignment = self._color_survivors(prob, spilled)
+        return ILPSolution(assignment=assignment, spilled=spilled, stats=stats)
+
+    @staticmethod
+    def _color_survivors(prob, spilled):
+        """First-fit color the non-spilled vregs in definition order (a perfect
+        elimination order for straight-line SSA), respecting interference."""
+        survivors = [v for v in prob.vregs if v not in spilled]
+        adjacency = {v: set() for v in survivors}
+        segs = {v: prob.intervals[v] for v in survivors}
+        for edge in build_interference(segs):
+            a, b = tuple(edge)
+            adjacency[a].add(b)
+            adjacency[b].add(a)
+        by_def = sorted(survivors, key=lambda v: min(s for s, _ in prob.intervals[v]))
+        assignment = {}
+        for v in by_def:
+            used = {assignment[n] for n in adjacency[v] if n in assignment}
+            for preg in candidate_pregs(prob.order[v], prob.forbidden[v]):
+                if preg not in used:
+                    assignment[v] = preg
+                    break
+        return assignment
+
+
+mir.RAILPDecomp = RAILPDecomp

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
@@ -33,3 +33,54 @@ def _require_ortools():
 def scale_weight(weight):
     """Scale a float spill weight to a positive integer objective coefficient."""
     return max(1, round(weight * _WEIGHT_SCALE))
+
+
+def _segments_overlap(segs_a, segs_b):
+    """True if any half-open [start, end) segment of A overlaps one of B."""
+    for s1, e1 in segs_a:
+        for s2, e2 in segs_b:
+            if s1 < e2 and s2 < e1:
+                return True
+    return False
+
+
+def build_interference(intervals):
+    """Pairwise interference edges from live-range overlap.
+
+    `intervals` maps vreg id -> list of (start, end) half-open integer segments.
+    Returns a set of ``frozenset({u, v})`` for every pair whose ranges overlap.
+    """
+    vregs = sorted(intervals)
+    edges = set()
+    for i, u in enumerate(vregs):
+        for v in vregs[i + 1:]:
+            if _segments_overlap(intervals[u], intervals[v]):
+                edges.add(frozenset((u, v)))
+    return edges
+
+
+def compact_time_axis(intervals):
+    """Map the sorted set of all segment endpoints to contiguous ints.
+
+    Returns ``(mapping, n_points)`` where `mapping` sends each original endpoint
+    to its index in the sorted order. Used to give the packing model a dense
+    time axis instead of raw (possibly large, sparse) slot distances.
+    """
+    points = sorted({p for segs in intervals.values() for seg in segs for p in seg})
+    mapping = {p: i for i, p in enumerate(points)}
+    return mapping, len(points)
+
+
+def candidate_pregs(order, forbidden):
+    """Allocation-order physregs minus the matrix-forbidden ones."""
+    return [p for p in order if p not in forbidden]
+
+
+def single_class_k(num_regs):
+    """If every vreg shares one register-class size, return k; else None.
+
+    `num_regs` maps vreg id -> allocatable-register count of its class. The
+    packing and decomposition models are scoped to single-class functions.
+    """
+    ks = set(num_regs.values())
+    return next(iter(ks)) if len(ks) == 1 else None

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
@@ -1,0 +1,35 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Pure, binding-free helpers shared by the ILP register allocators.
+
+Kept free of any `ortools` import at module scope so the base package imports
+without the optional dependency; the CP-SAT module is fetched lazily via
+``_require_ortools``. The functions here operate on plain Python data (ints,
+lists, dicts) so they can be unit-tested without constructing a MachineFunction.
+"""
+
+# Spill weights are floats; CP-SAT objectives are integer. Scale by this factor
+# so the weighted-spill objective dominates the unit coalescing-hint bonus (a
+# hint can only ever break ties, never force or prevent a spill).
+_WEIGHT_SCALE = 1000
+
+# Reward (in scaled objective units) for assigning a vreg to its copy hint.
+# Strictly less than the smallest scaled spill weight so it never buys a spill.
+HINT_BONUS = 1
+
+
+def _require_ortools():
+    try:
+        from ortools.sat.python import cp_model
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "ortools is required for the ILP register allocators; install "
+            "eudsl-llvmpy[ilp] or `pip install ortools>=9.0`"
+        ) from e
+    return cp_model
+
+
+def scale_weight(weight):
+    """Scale a float spill weight to a positive integer objective coefficient."""
+    return max(1, round(weight * _WEIGHT_SCALE))

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_model.py
@@ -14,6 +14,11 @@ lists, dicts) so they can be unit-tested without constructing a MachineFunction.
 # hint can only ever break ties, never force or prevent a spill).
 _WEIGHT_SCALE = 1000
 
+# LLVM marks must-not-spill intervals with an infinite (HUGE_VALF) spill weight.
+# CP-SAT needs a finite integer coefficient, so clamp to a value large enough to
+# dominate any realistic sum of ordinary weights yet safely within int range.
+_MAX_WEIGHT = 1_000_000_000
+
 # Reward (in scaled objective units) for assigning a vreg to its copy hint.
 # Strictly less than the smallest scaled spill weight so it never buys a spill.
 HINT_BONUS = 1
@@ -31,7 +36,12 @@ def _require_ortools():
 
 
 def scale_weight(weight):
-    """Scale a float spill weight to a positive integer objective coefficient."""
+    """Scale a float spill weight to a positive integer objective coefficient.
+
+    Infinite / huge weights (LLVM's must-not-spill marker) clamp to _MAX_WEIGHT.
+    """
+    if weight == float("inf") or weight * _WEIGHT_SCALE >= _MAX_WEIGHT:
+        return _MAX_WEIGHT
     return max(1, round(weight * _WEIGHT_SCALE))
 
 

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_packing.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_packing.py
@@ -1,0 +1,101 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RAILPPacking: 2D no-overlap rectangle-packing register allocation on CP-SAT.
+
+A port of claude-compiler's integrated_solver model. Each vreg gets an integer
+register variable whose domain is {compact physreg indices} + {its own private
+memory slot}; a value in the memory region means spilled. For each live segment
+the vreg contributes a rectangle (time interval x a width-1 register interval),
+and add_no_overlap_2d forbids two vregs sharing a register over overlapping
+time. Objective: minimize weighted spills.
+
+Scoped to single-register-class functions: the flat register axis cannot model
+AArch64 aliasing / differing widths (report section 4.3). Multi-class functions
+raise -- there is no greedy fallback to defer to. Each spilled vreg gets its own
+memory slot so spills never falsely interfere. Unspillable vregs get no memory
+value in their domain, forcing a physreg assignment.
+"""
+
+import time
+
+from . import mir
+from .mir_ilp_assign import stats_from_solver, make_solver
+from .mir_ilp_base import RAILPBase, ILPSolution
+from .mir_ilp_model import (
+    candidate_pregs,
+    compact_time_axis,
+    single_class_k,
+    _require_ortools,
+)
+
+
+class RAILPPacking(RAILPBase):
+    # Whole-interval spill decisions ignore reload register pressure and are not
+    # reliably realizable; hard-fail cleanly when a function needs spilling.
+    realizes_spills = False
+
+    def _solve(self, prob):
+        if single_class_k(prob.num_regs) is None:
+            raise RuntimeError(
+                "RAILPPacking supports a single register class only; this "
+                "function mixes classes (the flat register axis cannot model "
+                "aliasing)"
+            )
+
+        cp = _require_ortools()
+        model = cp.CpModel()
+
+        cands = {v: candidate_pregs(prob.order[v], prob.forbidden[v])
+                 for v in prob.vregs}
+        # Register axis: union of legal physregs across vregs -> dense indices.
+        pregs = sorted({p for v in prob.vregs for p in cands[v]})
+        preg_index = {p: i for i, p in enumerate(pregs)}
+        n_pregs = len(pregs)
+        time_map, _ = compact_time_axis(prob.intervals)
+
+        reg = {}
+        x_ivs, y_ivs = [], []
+        for i, v in enumerate(prob.vregs):
+            allowed = [preg_index[p] for p in cands[v]]
+            mem_id = n_pregs + i  # private memory slot -> spills never conflict
+            values = allowed + [mem_id] if prob.spillable[v] else allowed
+            reg[v] = model.new_int_var_from_domain(
+                cp.Domain.from_values(values), f"reg_{v}"
+            )
+            for start, end in prob.intervals[v]:
+                s, e = time_map[start], time_map[end]
+                if e <= s:
+                    continue
+                x_ivs.append(model.new_fixed_size_interval_var(s, e - s, f"x_{v}_{s}"))
+                y_ivs.append(model.new_fixed_size_interval_var(reg[v], 1, f"y_{v}_{s}"))
+        model.add_no_overlap_2d(x_ivs, y_ivs)
+
+        terms = []
+        for i, v in enumerate(prob.vregs):
+            if not prob.spillable[v]:
+                continue
+            is_mem = model.new_bool_var(f"is_mem_{v}")
+            model.add(reg[v] >= n_pregs).only_enforce_if(is_mem)
+            model.add(reg[v] < n_pregs).only_enforce_if(~is_mem)
+            terms.append(prob.weight[v] * is_mem)
+        model.minimize(sum(terms))
+
+        solver = make_solver(cp, self.time_limit_s)
+        t0 = time.perf_counter()
+        status = solver.solve(model)
+        wall = time.perf_counter() - t0
+        stats = stats_from_solver(cp, solver, status, wall)
+
+        assignment, spilled = {}, set()
+        if status in (cp.OPTIMAL, cp.FEASIBLE):
+            for v in prob.vregs:
+                idx = solver.value(reg[v])
+                if idx >= n_pregs:
+                    spilled.add(v)
+                else:
+                    assignment[v] = pregs[idx]
+        return ILPSolution(assignment=assignment, spilled=spilled, stats=stats)
+
+
+mir.RAILPPacking = RAILPPacking

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -17,3 +17,35 @@ def test_scale_weight_is_positive_int():
     assert model.scale_weight(0.0) >= 1
     assert isinstance(model.scale_weight(1.5), int)
     assert model.scale_weight(2.0) > model.scale_weight(1.0)
+
+
+def test_build_interference_overlap_and_disjoint():
+    # v1 [0,4) overlaps v2 [2,6); v3 [6,8) is disjoint from both.
+    intervals = {1: [(0, 4)], 2: [(2, 6)], 3: [(6, 8)]}
+    edges = model.build_interference(intervals)
+    assert frozenset((1, 2)) in edges
+    assert frozenset((1, 3)) not in edges
+    assert frozenset((2, 3)) not in edges  # [2,6) and [6,8) touch but half-open
+
+
+def test_build_interference_multi_segment_holes():
+    # v1 is live [0,2) and [8,10) (a hole); v2 [3,7) fits in the hole -> no edge.
+    intervals = {1: [(0, 2), (8, 10)], 2: [(3, 7)]}
+    assert model.build_interference(intervals) == set()
+
+
+def test_compact_time_axis():
+    intervals = {1: [(0, 4)], 2: [(4, 10)]}
+    mapping, n = model.compact_time_axis(intervals)
+    assert n == 3  # points {0, 4, 10}
+    assert mapping[0] == 0 and mapping[4] == 1 and mapping[10] == 2
+
+
+def test_candidate_pregs_filters_forbidden():
+    assert model.candidate_pregs([10, 11, 12], {11}) == [10, 12]
+
+
+def test_single_class_k():
+    assert model.single_class_k({1: 32, 2: 32}) == 32
+    assert model.single_class_k({1: 32, 2: 16}) is None
+    assert model.single_class_k({}) is None

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -252,18 +252,46 @@ def test_ilp_assign_pressure_free_matches_greedy():
 
 
 @aarch64
-def test_ilp_assign_high_pressure_spills_and_is_valid():
+def test_ilp_assign_high_pressure_hard_fails():
+    # Whole-interval spill decisions ignore reload pressure and are not reliably
+    # realizable, so RAILPAssign refuses to spill: it hard-fails cleanly (never
+    # crashes) when a function needs spilling.
     mir.register_regalloc("ilp-assign-hp", mir.RAILPAssign)
     with ir.Context() as ctx:
         mod = ir.Module("m", ctx)
         tm = jit.TargetMachine(triple=_AARCH64_LINUX)
         mmi = mir.create_machine_function(mod, tm, "hp")
         _build_high_pressure(mmi)
-        result = mmi.regalloc_assignments(regalloc="ilp-assign-hp")
+        with pytest.raises(RuntimeError, match="register-fitting"):
+            mmi.regalloc_assignments(regalloc="ilp-assign-hp")
+
+
+@aarch64
+def test_ilp_packing_pressure_free_valid():
+    mir.register_regalloc("ilp-pack-t", mir.RAILPPacking)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-pack-t")
         assignments = dict(result.assignments)
         spilled = list(result.spilled)
-    # More simultaneously-live vregs than GPR32 registers -> at least one spill,
-    # and every assigned vreg got a real physreg (valid allocation).
-    assert len(spilled) >= 1
-    assert all(isinstance(p, int) for p in assignments.values())
+    v0, v1, v2 = sorted(assignments)
+    assert assignments[v0] != assignments[v1]
+    assert spilled == []
     assert_no_leaks()
+
+
+@aarch64
+def test_ilp_packing_high_pressure_hard_fails():
+    # Same whole-interval limitation as RAILPAssign: refuse to spill, hard-fail
+    # cleanly (never crash) when a function needs spilling.
+    mir.register_regalloc("ilp-pack-hp", mir.RAILPPacking)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        with pytest.raises(RuntimeError, match="register-fitting"):
+            mmi.regalloc_assignments(regalloc="ilp-pack-hp")

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -135,6 +135,67 @@ def test_interval_live_at():
     assert decomp.interval_live_at([(0, 2), (8, 10)], 5) is False  # hole
 
 
+def test_ilp_stats_gap():
+    from llvm.mir_ilp_base import ILPStats
+    assert ILPStats(status="INFEASIBLE").gap is None
+    assert ILPStats(status="OPTIMAL", objective=0.0).gap == 0.0
+    s = ILPStats(status="FEASIBLE", objective=10.0, best_bound=8.0)
+    assert abs(s.gap - 0.2) < 1e-9
+
+
+def _mk_problem(**overrides):
+    from llvm.mir_ilp_base import ILPProblem
+    base = dict(
+        vregs=[1, 2, 3],
+        intervals={1: [(0, 6)], 2: [(0, 6)], 3: [(0, 6)]},
+        order={1: [10, 11], 2: [10, 11], 3: [10, 11]},
+        forbidden={1: set(), 2: set(), 3: set()},
+        weight={1: 5, 2: 5, 3: 5},
+        hints={1: 0, 2: 0, 3: 0},
+        num_regs={1: 2, 2: 2, 3: 2},
+        spillable={1: True, 2: True, 3: True},
+    )
+    base.update(overrides)
+    return ILPProblem(**base)
+
+
+def test_assign_solve_standalone_spill():
+    # 3 mutually-interfering spillable vregs, 2 pregs -> exactly one spills.
+    sol = mir.RAILPAssign()._solve(_mk_problem())
+    assert sol.stats.status == "OPTIMAL"
+    assert len(sol.spilled) == 1
+    assert len(sol.assignment) == 2
+
+
+def test_assign_solve_standalone_infeasible():
+    # Unspillable vreg with no legal candidate -> infeasible, empty solution.
+    sol = mir.RAILPAssign()._solve(_mk_problem(
+        vregs=[1], intervals={1: [(0, 4)]}, order={1: []}, forbidden={1: set()},
+        weight={1: 5}, hints={1: 0}, num_regs={1: 2}, spillable={1: False},
+    ))
+    assert sol.stats.status == "INFEASIBLE"
+    assert sol.assignment == {} and sol.spilled == set()
+
+
+def test_packing_solve_standalone_multiclass_raises():
+    with pytest.raises(RuntimeError, match="single register class"):
+        mir.RAILPPacking()._solve(_mk_problem(num_regs={1: 8, 2: 16, 3: 8}))
+
+
+def test_packing_solve_standalone_spill_and_degenerate_segment():
+    # One spill forced; vreg 3 also carries a zero-length segment (skipped).
+    sol = mir.RAILPPacking()._solve(_mk_problem(
+        intervals={1: [(0, 6)], 2: [(0, 6)], 3: [(0, 6), (6, 6)]},
+    ))
+    assert sol.stats.status in ("OPTIMAL", "FEASIBLE")
+    assert len(sol.spilled) == 1
+
+
+def test_decomp_solve_standalone_multiclass_raises():
+    with pytest.raises(RuntimeError, match="single register class"):
+        mir.RAILPDecomp()._solve(_mk_problem(num_regs={1: 8, 2: 16, 3: 8}))
+
+
 def test_alloc_result_weighted_spill_cost():
     from llvm import mir_ilp_compare as compare
     r = compare.AllocResult(
@@ -162,25 +223,72 @@ def test_format_table_contains_rows_and_header():
     assert "hard-fail" in text or "register-fitting" in text
 
 
+def _greedy_color(prob, exclude=frozenset()):
+    """Valid first-fit coloring over interference, skipping `exclude` vregs."""
+    keep = [v for v in prob.vregs if v not in exclude]
+    adj = {v: set() for v in keep}
+    for edge in model.build_interference({v: prob.intervals[v] for v in keep}):
+        a, b = tuple(edge)
+        adj[a].add(b)
+        adj[b].add(a)
+    asg = {}
+    for v in keep:
+        used = {asg[n] for n in adj[v] if n in asg}
+        for p in model.candidate_pregs(prob.order[v], prob.forbidden[v]):
+            if p not in used:
+                asg[v] = p
+                break
+    return asg
+
+
 class _StubValidColoring(RAILPBase):
-    """Produces a valid coloring in _solve (greedy over the interference graph),
-    exercising the base's cached-solution return path. No ortools."""
+    """Produces a valid coloring in _solve, exercising the cached-return path."""
 
     def _solve(self, prob):
-        edges = model.build_interference(prob.intervals)
-        adj = {v: set() for v in prob.vregs}
-        for edge in edges:
-            a, b = tuple(edge)
-            adj[a].add(b)
-            adj[b].add(a)
-        asg = {}
-        for v in prob.vregs:
-            used = {asg[n] for n in adj[v] if n in asg}
-            for p in model.candidate_pregs(prob.order[v], prob.forbidden[v]):
-                if p not in used:
-                    asg[v] = p
-                    break
-        return ILPSolution(assignment=asg, spilled=set(), stats=ILPStats("OPTIMAL"))
+        return ILPSolution(assignment=_greedy_color(prob), spilled=set(),
+                           stats=ILPStats("OPTIMAL"))
+
+
+class _StubSpillUnspillable(RAILPBase):
+    """Spills a vreg that is not spillable -> base must raise (never abort)."""
+
+    def _solve(self, prob):
+        target = min(v for v in prob.vregs if not prob.spillable[v])
+        return ILPSolution(_greedy_color(prob, {target}), {target},
+                           ILPStats("OPTIMAL"))
+
+
+@aarch64
+def test_base_hard_fails_spilling_unspillable():
+    mir.register_regalloc("ilp-stub-unspill", _StubSpillUnspillable)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        with pytest.raises(RuntimeError, match="not spillable"):
+            mmi.regalloc_assignments(regalloc="ilp-stub-unspill")
+
+
+class _StubMissingAssignment(RAILPBase):
+    """Omits one vreg's decision entirely -> base must raise 'no assignment'."""
+
+    def _solve(self, prob):
+        target = max(prob.vregs)
+        return ILPSolution(_greedy_color(prob, {target}), set(),
+                           ILPStats("OPTIMAL"))
+
+
+@aarch64
+def test_base_hard_fails_on_missing_decision():
+    mir.register_regalloc("ilp-stub-missing", _StubMissingAssignment)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        with pytest.raises(RuntimeError, match="no assignment or spill"):
+            mmi.regalloc_assignments(regalloc="ilp-stub-missing")
 
 
 @aarch64

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -6,6 +6,82 @@
 import pytest
 import llvm
 from llvm import mir_ilp_model as model
+from llvm import ir, jit, mir
+from llvm.mir_ilp_base import RAILPBase, ILPSolution, ILPStats
+from llvm.testing import assert_no_leaks
+
+_AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+
+aarch64 = pytest.mark.skipif(
+    "aarch64" not in llvm.jit.registered_targets(),
+    reason="AArch64 backend not linked",
+)
+
+
+def _build_add(mmi):
+    """Pressure-free add: two argument copies + an ADD + a return copy."""
+    mf = mmi.machine_function("add")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w0)
+    entry.add_livein(w1)
+    v0, v1, v2 = (mf.create_vreg(gpr32) for _ in range(3))
+    copy = mf.opcode("COPY")
+    for dst, src in ((v0, w0), (v1, w1)):
+        c = b.build_instr(copy)
+        c.add_reg(dst, is_def=True)
+        c.add_reg(src)
+    add = b.build_instr(mf.opcode("ADDWrr"))
+    add.add_reg(v2, is_def=True)
+    add.add_reg(v0)
+    add.add_reg(v1)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v2)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+_HP_N = 48
+
+
+def _build_high_pressure(mmi):
+    mf = mmi.machine_function("hp")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry.add_livein(w0)
+    copy = mf.opcode("COPY")
+    addrr = mf.opcode("ADDWrr")
+    terms = []
+    for _ in range(_HP_N):
+        t = mf.create_vreg(gpr32)
+        ins = b.build_instr(copy)
+        ins.add_reg(t, is_def=True)
+        ins.add_reg(w0)
+        terms.append(t)
+    acc = terms[0]
+    for t in terms[1:]:
+        nacc = mf.create_vreg(gpr32)
+        ins = b.build_instr(addrr)
+        ins.add_reg(nacc, is_def=True)
+        ins.add_reg(acc)
+        ins.add_reg(t)
+        acc = nacc
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(acc)
+    ret = b.build_instr(mf.opcode("RET_ReallyLR"))
+    ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
 
 
 def test_require_ortools_returns_cp_model():
@@ -49,3 +125,105 @@ def test_single_class_k():
     assert model.single_class_k({1: 32, 2: 32}) == 32
     assert model.single_class_k({1: 32, 2: 16}) is None
     assert model.single_class_k({}) is None
+
+
+class _StubValidColoring(RAILPBase):
+    """Produces a valid coloring in _solve (greedy over the interference graph),
+    exercising the base's cached-solution return path. No ortools."""
+
+    def _solve(self, prob):
+        edges = model.build_interference(prob.intervals)
+        adj = {v: set() for v in prob.vregs}
+        for edge in edges:
+            a, b = tuple(edge)
+            adj[a].add(b)
+            adj[b].add(a)
+        asg = {}
+        for v in prob.vregs:
+            used = {asg[n] for n in adj[v] if n in asg}
+            for p in model.candidate_pregs(prob.order[v], prob.forbidden[v]):
+                if p not in used:
+                    asg[v] = p
+                    break
+        return ILPSolution(assignment=asg, spilled=set(), stats=ILPStats("OPTIMAL"))
+
+
+@aarch64
+def test_base_returns_cached_valid_assignment():
+    mir.register_regalloc("ilp-stub-valid", _StubValidColoring)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-stub-valid")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    v0, v1, v2 = sorted(assignments)
+    assert assignments[v0] != assignments[v1]  # simultaneously live -> distinct
+    assert spilled == []
+    assert_no_leaks()
+
+
+class _StubSameReg(RAILPBase):
+    """Assigns every vreg the same physreg (a candidate legal for all). Two
+    simultaneously-live vregs then collide, so the base must hard-fail on the
+    "not free" branch rather than silently repair it."""
+
+    def _solve(self, prob):
+        common = set(prob.order[prob.vregs[0]])
+        for v in prob.vregs[1:]:
+            common &= set(prob.order[v])
+        reg = min(common)
+        asg = {v: reg for v in prob.vregs}
+        return ILPSolution(assignment=asg, spilled=set(), stats=ILPStats("OPTIMAL"))
+
+
+@aarch64
+def test_base_hard_fails_on_infeasible_assignment():
+    mir.register_regalloc("ilp-stub-bad", _StubSameReg)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        with pytest.raises(RuntimeError, match="not free"):
+            mmi.regalloc_assignments(regalloc="ilp-stub-bad")
+
+
+class _StubSpillOne(RAILPBase):
+    """Spills one spillable vreg and colors the rest (greedy over interference),
+    exercising the spill-routing + reload-vreg first-free path."""
+
+    def _solve(self, prob):
+        target = min(v for v in prob.vregs if prob.spillable[v])
+        edges = model.build_interference(prob.intervals)
+        adj = {v: set() for v in prob.vregs}
+        for edge in edges:
+            a, b = tuple(edge)
+            adj[a].add(b)
+            adj[b].add(a)
+        asg = {}
+        for v in prob.vregs:
+            if v == target:
+                continue
+            used = {asg[n] for n in adj[v] if n in asg}
+            for p in model.candidate_pregs(prob.order[v], prob.forbidden[v]):
+                if p not in used:
+                    asg[v] = p
+                    break
+        return ILPSolution(assignment=asg, spilled={target}, stats=ILPStats("OPTIMAL"))
+
+
+@aarch64
+def test_base_stub_routes_spill():
+    mir.register_regalloc("ilp-stub-spill", _StubSpillOne)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-stub-spill")
+        spilled = list(result.spilled)
+    assert len(spilled) >= 1
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -135,6 +135,33 @@ def test_interval_live_at():
     assert decomp.interval_live_at([(0, 2), (8, 10)], 5) is False  # hole
 
 
+def test_alloc_result_weighted_spill_cost():
+    from llvm import mir_ilp_compare as compare
+    r = compare.AllocResult(
+        name="x", valid=True, spills=[2, 3],
+        weight={1: 10, 2: 5, 3: 7}, copies_remaining=1,
+        wall_time_s=0.1, gap=0.0, error=None,
+    )
+    assert r.weighted_spill_cost == 12  # 5 + 7
+    assert r.num_spills == 2
+
+
+def test_format_table_contains_rows_and_header():
+    from llvm import mir_ilp_compare as compare
+    rows = [
+        compare.AllocResult("greedy", True, [], {}, 0, None, None, None),
+        compare.AllocResult("ilp-assign", True, [1], {1: 4}, 0, 0.2, 0.0, None),
+        compare.AllocResult("ilp-pack", False, [], {}, 0, None, None,
+                            "register-fitting only"),
+    ]
+    text = compare.format_table("add", rows)
+    assert "add" in text
+    assert "greedy" in text
+    assert "ilp-assign" in text
+    assert "gap" in text.lower()
+    assert "hard-fail" in text or "register-fitting" in text
+
+
 class _StubValidColoring(RAILPBase):
     """Produces a valid coloring in _solve (greedy over the interference graph),
     exercising the base's cached-solution return path. No ortools."""

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -366,3 +366,35 @@ def test_ilp_decomp_high_pressure_spills_and_is_valid():
     assert len(spilled) >= 1
     assert all(isinstance(p, int) for p in assignments.values())
     assert_no_leaks()
+
+
+@aarch64
+def test_comparison_low_pressure_all_valid_and_ilp_optimal():
+    from llvm.mir_ilp_base import RAILPBase
+
+    mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
+    mir.register_regalloc("cmp-assign", mir.RAILPAssign)
+    mir.register_regalloc("cmp-pack", mir.RAILPPacking)
+    mir.register_regalloc("cmp-decomp", mir.RAILPDecomp)
+    allocs = ["greedy", "cmp-basic", "cmp-assign", "cmp-pack", "cmp-decomp"]
+
+    for alloc in allocs:
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_add(mmi)
+            result = mmi.regalloc_assignments(regalloc=alloc)
+            assignments = dict(result.assignments)
+            spilled = list(result.spilled)
+        # Low pressure: every allocator is valid and spills nothing.
+        assert spilled == [], f"{alloc} spilled on a pressure-free function"
+        v0, v1, _ = sorted(assignments)
+        assert assignments[v0] != assignments[v1], f"{alloc} gave a bad coloring"
+
+    # The ILP allocators prove optimality (gap 0) on this trivial function.
+    for cls in ("RAILPAssign", "RAILPDecomp"):
+        stats = RAILPBase.last_stats[cls]
+        assert stats.status == "OPTIMAL"
+        assert stats.gap == 0.0
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -127,6 +127,14 @@ def test_single_class_k():
     assert model.single_class_k({}) is None
 
 
+def test_interval_live_at():
+    from llvm import mir_ilp_decomp as decomp
+    assert decomp.interval_live_at([(0, 4)], 0) is True
+    assert decomp.interval_live_at([(0, 4)], 3) is True
+    assert decomp.interval_live_at([(0, 4)], 4) is False  # half-open
+    assert decomp.interval_live_at([(0, 2), (8, 10)], 5) is False  # hole
+
+
 class _StubValidColoring(RAILPBase):
     """Produces a valid coloring in _solve (greedy over the interference graph),
     exercising the base's cached-solution return path. No ortools."""
@@ -295,3 +303,39 @@ def test_ilp_packing_high_pressure_hard_fails():
         _build_high_pressure(mmi)
         with pytest.raises(RuntimeError, match="register-fitting"):
             mmi.regalloc_assignments(regalloc="ilp-pack-hp")
+
+
+@aarch64
+def test_ilp_decomp_pressure_free_no_spill():
+    mir.register_regalloc("ilp-decomp-t", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-t")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    v0, v1, v2 = sorted(assignments)
+    assert assignments[v0] != assignments[v1]
+    assert spilled == []
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_decomp_high_pressure_spills_and_is_valid():
+    # The per-point model accounts for reload pressure, so its spill set is
+    # realizable: it actually spills and produces a valid allocation where
+    # whole-interval RAILPAssign/RAILPPacking hard-fail.
+    mir.register_regalloc("ilp-decomp-hp", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-hp")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    assert len(spilled) >= 1
+    assert all(isinstance(p, int) for p in assignments.values())
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -227,3 +227,43 @@ def test_base_stub_routes_spill():
         spilled = list(result.spilled)
     assert len(spilled) >= 1
     assert_no_leaks()
+
+
+@aarch64
+def test_ilp_assign_pressure_free_matches_greedy():
+    def assignments(alloc):
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_add(mmi)
+            r = mmi.regalloc_assignments(regalloc=alloc)
+            return dict(r.assignments), list(r.spilled)
+
+    mir.register_regalloc("ilp-assign-t", mir.RAILPAssign)
+    ilp_asg, ilp_spill = assignments("ilp-assign-t")
+    _, grd_spill = assignments("greedy")
+    # Pressure-free: no spills, and every simultaneously-live pair differs.
+    assert ilp_spill == []
+    assert grd_spill == []
+    v0, v1, v2 = sorted(ilp_asg)
+    assert ilp_asg[v0] != ilp_asg[v1]
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_assign_high_pressure_spills_and_is_valid():
+    mir.register_regalloc("ilp-assign-hp", mir.RAILPAssign)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-assign-hp")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    # More simultaneously-live vregs than GPR32 registers -> at least one spill,
+    # and every assigned vreg got a real physreg (valid allocation).
+    assert len(spilled) >= 1
+    assert all(isinstance(p, int) for p in assignments.values())
+    assert_no_leaks()

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -1,0 +1,19 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""ILP register allocators: pure-helper unit tests + end-to-end + comparison."""
+
+import pytest
+import llvm
+from llvm import mir_ilp_model as model
+
+
+def test_require_ortools_returns_cp_model():
+    cp = model._require_ortools()
+    assert hasattr(cp, "CpModel")
+
+
+def test_scale_weight_is_positive_int():
+    assert model.scale_weight(0.0) >= 1
+    assert isinstance(model.scale_weight(1.5), int)
+    assert model.scale_weight(2.0) > model.scale_weight(1.0)

--- a/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_regalloc_assignments.py
@@ -238,3 +238,53 @@ def test_regalloc_assignments_python_allocator_exception_propagates():
         with pytest.raises(RuntimeError, match="boom from select_or_split"):
             mmi.regalloc_assignments(regalloc="ra-raise-cap")
     assert_no_leaks()
+
+
+def test_regalloc_assignments_copies_remaining_all_coalesced():
+    # Every COPY in _build_add is coalesceable (src and dst land in the same
+    # physreg), so none survive.
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="greedy")
+        copies = result.copies_remaining
+    assert copies == 0
+    assert_no_leaks()
+
+
+def _build_cross_reg_move(mmi):
+    """An argument arrives in W1 and is returned in W0, forcing a surviving COPY
+    (its source and destination land in different physical registers)."""
+    mf = mmi.machine_function("mv")
+    b = mir.MachineIRBuilder(mf)
+    entry = mf.blocks[0]
+    gpr32 = mf.reg_class("GPR32")
+    w0, w1 = mf.physreg("W0"), mf.physreg("W1")
+    entry.add_livein(w1)
+    v0 = mf.create_vreg(gpr32)
+    copy = mf.opcode("COPY")
+    c = b.build_instr(copy)
+    c.add_reg(v0, is_def=True)
+    c.add_reg(w1)
+    rc = b.build_instr(copy)
+    rc.add_reg(w0, is_def=True)
+    rc.add_reg(v0)
+    b.build_instr(mf.opcode("RET_ReallyLR")).add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def test_regalloc_assignments_copies_remaining_counts_surviving_move():
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "mv")
+        _build_cross_reg_move(mmi)
+        result = mmi.regalloc_assignments(regalloc="greedy")
+        copies = result.copies_remaining
+    # The W1 -> W0 move cannot be coalesced away: one COPY survives.
+    assert copies >= 1
+    assert_no_leaks()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ numpy>=2.0.2
 scikit-build-core==0.10.7
 pytest
 pytest-cov
+ortools>=9.0


### PR DESCRIPTION
## Summary

Adds three OR-Tools **CP-SAT** register allocators to `eudsl-llvmpy`, plugged into the existing `mir.RegAllocBase` framework, plus a harness comparing them against the greedy/basic baselines. Modeled after `claude-compiler`'s ILP scheduler and grounded in a literature review (`docs/superpowers/research/ilp_regalloc/`).

- **`mir.RAILPAssign`** — canonical Goodwin-Wilken 0-1 ILP: `x[v,p]` + `spill[v]`, `AddExactlyOne`, interference-edge constraints, objective = weighted spill cost − copy-hint (coalescing) bonus. General over register classes.
- **`mir.RAILPPacking`** — 2D no-overlap rectangle packing (time × register), one rectangle per live segment. Single register class.
- **`mir.RAILPDecomp`** — SSA spill-then-color: a **per-program-point (Appel-George)** ILP picks a minimum-weight spill set so pressure ≤ k at every def/use point (a spilled value still needs a register at its uses), then colors survivors. Single register class.

### Architecture

- Shared `RAILPBase` reconciles the per-interval greedy driver with a global solve: collect all seeded vregs, solve once on the first `dequeue`, answer each `select_or_split` from the cached solution.
- **No greedy fallback** for the ILP's own decisions — a missing/infeasible assignment is a hard error (matrix-verified), so model bugs surface instead of being silently masked (which would make the comparison meaningless). Only spiller-created reload vregs get first-free coloring.
- Whole-interval models (`assign`/`packing`) ignore reload register pressure and are not reliably realizable, so they hard-fail cleanly on functions that need spilling. `RAILPDecomp`'s per-point model accounts for reloads and allocates spilling functions — the central comparison result (matches the literature).
- Deterministic solver (fixed seed, single worker) for reproducible allocations; optimality gap reported.
- `ortools>=9.0` is an optional extra (`eudsl-llvmpy[ilp]`), imported lazily; the base package imports without it.

Files: `src/llvm/mir_ilp_{model,base,assign,packing,decomp,compare}.py`, `scripts/ilp_regalloc_compare.py`, `tests/mir/test_ilp_regalloc.py`, README note, `requirements-dev.txt` + `pyproject.toml` deps.

## Test Plan

- [ ] `LLVM_BINDIR=.../mlir_wheel/bin pytest tests/` passes with the 99% coverage gate (880 passed, 3 xfailed; 99.36%).
- [ ] Unit tests: pure helpers, `ILPStats.gap`, standalone `_solve` (spill / infeasible / multi-class-raise).
- [ ] End-to-end (AArch64): each allocator on pressure-free `add` (valid, 0 spills, ILP gap 0); `assign`/`packing` hard-fail on high pressure; `decomp` spills and stays valid; base hard-fail paths (not-free / no-decision / unspillable-spill).
- [ ] `python scripts/ilp_regalloc_compare.py` prints the comparison table (spills, weighted spill cost, solve time, optimality gap; hard-fail rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)