### PR TITLE
[eudsl-llvmpy] ILP register allocation (2/4): RAILPAssign

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -531,14 +531,17 @@ is a **hard error** (no silent greedy fallback), so a model bug surfaces rather
 than being masked. Register assignments are read back with `regalloc_assignments`
 like any allocator.
 
+- `mir.RAILPAssign` — Goodwin-Wilken 0-1 ILP: `x[v,p]` assignment variables plus
+  `spill[v]`, interference-edge constraints, objective minimizing weighted spill
+  cost less a copy-hint (coalescing) bonus. General over register classes.
 - `mir.RAILPPacking` — 2D no-overlap rectangle packing (time × register), one
   rectangle per live segment; the register variable's domain includes a private
   memory slot so a value in the memory region means spilled. Single register
   class only (the flat register axis cannot model aliasing).
 
 Whole-interval spill decisions ignore reload register pressure and are not
-reliably realizable, so `RAILPPacking` is scoped to register-fitting functions
-and hard-fails cleanly when a function needs spilling.
+reliably realizable, so `RAILPAssign` and `RAILPPacking` are scoped to
+register-fitting functions and hard-fail cleanly when a function needs spilling.
 
 ## Limitations
 

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -31,6 +31,7 @@ from . import mir_greedy as _mir_greedy  # noqa: F401
 # Attaches the ILP register allocators onto the mir submodule. The ortools
 # dependency is imported lazily, so importing llvm never requires it.
 from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
+from . import mir_ilp_assign as _mir_ilp_assign  # noqa: F401
 from . import mir_ilp_packing as _mir_ilp_packing  # noqa: F401
 
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_assign.py
@@ -1,0 +1,127 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RAILPAssign: Goodwin-Wilken 0-1 ILP register allocation on CP-SAT.
+
+Binary x[v,p] (vreg v -> physreg p) plus, for spillable vregs, spill[v]; exactly
+one holds per vreg. Interference edges forbid two overlapping vregs sharing a
+physreg. The objective is lexicographic: first minimize weighted spill cost,
+then, among minimum-spill solutions, honor as many copy hints as possible
+(coalescing). This is realized in a single objective by scaling the spill terms
+above the maximum achievable hint reward, so a hint can never force or prevent a
+spill. The canonical ILP from the literature (report section 2.2); maps directly
+onto eudsl's allocation_order / matrix / live-interval segments. Unspillable
+vregs get no spill variable, so they are always force-assigned (the base never
+spills them).
+"""
+
+import time
+
+from . import mir
+from .mir_ilp_base import (
+    RAILPBase,
+    ILPSolution,
+    stats_from_solver,
+    make_solver,
+    build_interference,
+    candidate_pregs,
+    _require_ortools,
+)
+
+# Objective reward for honoring one copy hint (coalescing). A pure tie-breaker:
+# _solve scales the spill terms above the maximum total hint reward, so no
+# combination of honored hints can ever outweigh a spill.
+HINT_BONUS = 1
+
+
+class RAILPAssign(RAILPBase):
+    # Whole-interval spill decisions ignore reload register pressure and are not
+    # reliably realizable; hard-fail cleanly when a function needs spilling.
+    realizes_spills = False
+
+    def _solve(self, prob):
+        r"""CP-SAT model (Goodwin-Wilken 0-1 assignment):
+
+            variables   x[v, p] in {0, 1}   for each vreg v, legal candidate p
+                        spill[v] in {0, 1}   for each spillable vreg v
+
+            assignment  for each v:  sum_p x[v, p]  (+ spill[v] if spillable) = 1
+                        (exactly-one; an unspillable v with no candidate makes
+                         the model infeasible -> hard error)
+
+            interference for each pair (u, w) of overlapping live ranges and each
+                        shared candidate p:   x[u, p] + x[w, p] <= 1
+
+            objective   minimize  S * sum_v w_v * spill[v]              (spills)
+                                 - HINT_BONUS * sum_v x[v, hint(v)]     (coalesce)
+                        with  S = HINT_BONUS * |{v : hint(v) legal}| + 1
+
+        S scales the spill cost strictly above the maximum achievable hint
+        reward, so the objective is lexicographic: minimize spills first, then
+        (among minimum-spill solutions) honor as many copy hints as possible.
+        """
+        cp = _require_ortools()
+        model = cp.CpModel()
+
+        cands = {
+            v: candidate_pregs(prob.order[v], prob.forbidden[v]) for v in prob.vregs
+        }
+        x = {}
+        spill = {}
+        for v in prob.vregs:
+            literals = []
+            for p in cands[v]:
+                var = model.new_bool_var(f"x_{v}_{p}")
+                x[(v, p)] = var
+                literals.append(var)
+            if prob.spillable[v]:
+                spill[v] = model.new_bool_var(f"spill_{v}")
+                literals.append(spill[v])
+            # Exactly one of {assigned physreg, spill}. For an unspillable vreg
+            # this forces a physreg; an empty literal list (no legal candidate)
+            # is infeasible and the solve fails -- surfaced as a hard error.
+            model.add_exactly_one(literals)
+
+        for edge in build_interference(prob.intervals):
+            u, w = tuple(edge)
+            for p in set(cands[u]) & set(cands[w]):
+                model.add(x[(u, p)] + x[(w, p)] <= 1)
+
+        # Lexicographic objective: spilling always dominates, coalescing only
+        # breaks ties. Each honored copy hint is worth HINT_BONUS, and hints
+        # stack across vregs, so scale every spill term by a factor strictly
+        # greater than the maximum achievable total hint reward. Then adding any
+        # spill (cost >= spill_scale * 1) outweighs all hints combined, so a hint
+        # can never buy a spill -- it only chooses among equal-spill solutions.
+        hinted = [
+            x[(v, prob.hints[v])]
+            for v in prob.vregs
+            if prob.hints[v] and (v, prob.hints[v]) in x
+        ]
+        spill_scale = HINT_BONUS * len(hinted) + 1
+        terms = [
+            spill_scale * prob.weight[v] * spill[v] for v in prob.vregs if v in spill
+        ]
+        terms += [-HINT_BONUS * h for h in hinted]
+        model.minimize(sum(terms))
+
+        solver = make_solver(cp, self.time_limit_s)
+        t0 = time.perf_counter()
+        status = solver.solve(model)
+        wall = time.perf_counter() - t0
+        stats = stats_from_solver(cp, solver, status, wall)
+
+        assignment, spilled = {}, set()
+        if status in (cp.OPTIMAL, cp.FEASIBLE):
+            for v in prob.vregs:
+                if v in spill and solver.value(spill[v]):
+                    spilled.add(v)
+                    continue
+                for p in cands[v]:
+                    if solver.value(x[(v, p)]):
+                        assignment[v] = p
+                        break
+        return ILPSolution(assignment=assignment, spilled=spilled, stats=stats)
+
+
+mir.RAILPAssign = RAILPAssign

--- a/projects/eudsl-llvmpy/tests/mir/ilp_regalloc_compare.py
+++ b/projects/eudsl-llvmpy/tests/mir/ilp_regalloc_compare.py
@@ -85,9 +85,10 @@ _FIXTURES = [("low_pressure", _low_pressure), ("high_pressure", _high_pressure)]
 _ALLOCS = [
     ("greedy", "greedy", False),
     ("basic", "cmp-basic", False),
+    ("ilp-assign", "cmp-assign", True),
     ("ilp-packing", "cmp-pack", True),
 ]
-_ILP_CLASS = {"cmp-pack": "RAILPPacking"}
+_ILP_CLASS = {"cmp-assign": "RAILPAssign", "cmp-pack": "RAILPPacking"}
 
 
 def _run_one(fixture, fname, name, regalloc, is_ilp):
@@ -128,6 +129,7 @@ def main():
         print("AArch64 backend not linked; nothing to compare.")
         return
     mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
+    mir.register_regalloc("cmp-assign", mir.RAILPAssign)
     mir.register_regalloc("cmp-pack", mir.RAILPPacking)
     for fixture_name, fixture in _FIXTURES:
         results = [

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -210,6 +210,32 @@ def test_packing_solve_standalone_multiclass_raises():
         )
 
 
+def test_assign_solve_standalone_spill():
+    # 3 mutually-interfering spillable vregs, 2 pregs -> exactly one spills.
+    sol = mir.RAILPAssign()._solve(_mk_problem())
+    assert sol.stats.status == "OPTIMAL"
+    assert len(sol.spilled) == 1
+    assert len(sol.assignment) == 2
+
+
+def test_assign_solve_standalone_infeasible():
+    # Unspillable vreg with no legal candidate -> infeasible, empty solution.
+    sol = mir.RAILPAssign()._solve(
+        _mk_problem(
+            vregs=[1],
+            intervals={1: [(0, 4)]},
+            order={1: []},
+            forbidden={1: set()},
+            weight={1: 5},
+            hints={1: 0},
+            num_regs={1: 2},
+            spillable={1: False},
+        )
+    )
+    assert sol.stats.status == "INFEASIBLE"
+    assert sol.assignment == {} and sol.spilled == set()
+
+
 def test_packing_solve_standalone_spill_and_degenerate_segment():
     # Three mutually-interfering vregs, 2 pregs -> exactly one spills; vreg 3
     # also carries a zero-length segment (6,6) that must be skipped so it does
@@ -445,6 +471,7 @@ def test_ilp_packing_high_pressure_hard_fails():
 
 
 @aarch64
+@aarch64
 def test_ilp_packing_mixed_class_hard_fails():
     # GPR32 and GPR64 both report 30 allocatable regs, so a count-based gate
     # would wrongly accept this mixed-class function and only fail later with a
@@ -461,10 +488,48 @@ def test_ilp_packing_mixed_class_hard_fails():
 
 
 @aarch64
+def test_ilp_assign_pressure_free_coalesces():
+    # Pressure-free: RAILPAssign fits everything in registers (no spill) and,
+    # since coalescing only breaks ties here, honors the copy hints. v0 (= COPY
+    # W0) and v2 (returned via COPY to W0) both hint W0 and do not interfere, so
+    # they share it; v0 and v1 are simultaneously live and must differ.
+    mir.register_regalloc("ilp-assign-t", mir.RAILPAssign)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-assign-t")
+        asg = dict(result.assignments)
+        spilled = list(result.spilled)
+    v0, v1, v2 = sorted(asg)
+    assert spilled == []
+    assert asg[v0] != asg[v1]  # simultaneously live -> distinct registers
+    assert asg[v0] == asg[v2]  # both coalesced onto their W0 copy hint
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_assign_high_pressure_hard_fails():
+    # Whole-interval spill decisions ignore reload pressure and are not reliably
+    # realizable, so RAILPAssign refuses to spill: it hard-fails cleanly (never
+    # crashes) when a function needs spilling.
+    mir.register_regalloc("ilp-assign-hp", mir.RAILPAssign)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        with pytest.raises(RuntimeError, match="register-fitting"):
+            mmi.regalloc_assignments(regalloc="ilp-assign-hp")
+
+
+@aarch64
 def test_comparison_low_pressure_packing_valid_and_optimal():
     mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
+    mir.register_regalloc("cmp-assign", mir.RAILPAssign)
     mir.register_regalloc("cmp-pack", mir.RAILPPacking)
-    for alloc in ["greedy", "cmp-basic", "cmp-pack"]:
+    for alloc in ["greedy", "cmp-basic", "cmp-assign", "cmp-pack"]:
         with ir.Context() as ctx:
             mod = ir.Module("m", ctx)
             tm = jit.TargetMachine(triple=_AARCH64_LINUX)
@@ -476,10 +541,11 @@ def test_comparison_low_pressure_packing_valid_and_optimal():
         assert spilled == [], f"{alloc} spilled on a pressure-free function"
         v0, v1, _ = sorted(assignments)
         assert assignments[v0] != assignments[v1], f"{alloc} gave a bad coloring"
-    # RAILPPacking proves optimality (gap 0) on this trivial function.
-    stats = RAILPBase.last_stats["RAILPPacking"]
-    assert stats.status in ("OPTIMAL", "FEASIBLE")
-    assert stats.gap == 0.0
+    # The ILP allocators prove optimality (gap 0) on this trivial function.
+    for cls in ("RAILPAssign", "RAILPPacking"):
+        stats = RAILPBase.last_stats[cls]
+        assert stats.status in ("OPTIMAL", "FEASIBLE")
+        assert stats.gap == 0.0
     assert_no_leaks()
 
 


### PR DESCRIPTION
**Stacked PR 2 of 4** — targets `ilp-base-packing` (#671). Review/merge that first.

Adds **`RAILPAssign`**, the canonical Goodwin-Wilken 0-1 ILP:
- Binary `x[v,p]` (vreg → physreg) for each legal candidate plus, for spillable vregs, `spill[v]`; `AddExactlyOne` per vreg. Unspillable vregs get no spill variable (force-assigned).
- Interference-edge constraints `x[u,p] + x[v,p] ≤ 1` for overlapping ranges.
- Objective: minimize weighted spill cost minus a unit copy-hint (coalescing) bonus.

General over register classes (unlike packing/decomp). Like packing, its whole-interval spill decisions ignore reload pressure, so it hard-fails cleanly on functions that need spilling (that's what the per-point RAILPDecomp in PR 3/4 solves).

Wired into the comparison harness (`ilp-assign` row, gap reported).