### PR TITLE
[eudsl-llvmpy] ILP register allocation (3/4): RAILPDecomp (per-point spilling)

### DIFF
--- a/projects/eudsl-llvmpy/README.md
+++ b/projects/eudsl-llvmpy/README.md
@@ -538,10 +538,16 @@ like any allocator.
   rectangle per live segment; the register variable's domain includes a private
   memory slot so a value in the memory region means spilled. Single register
   class only (the flat register axis cannot model aliasing).
+- `mir.RAILPDecomp` — SSA spill-then-color: a per-program-point (Appel-George)
+  ILP chooses a minimum-weight spill set so register pressure ≤ k at every
+  def/use point (a spilled value still needs a register at its uses), then colors
+  the survivors in dominance order. Single register class only.
 
-Whole-interval spill decisions ignore reload register pressure and are not
-reliably realizable, so `RAILPAssign` and `RAILPPacking` are scoped to
-register-fitting functions and hard-fail cleanly when a function needs spilling.
+`RAILPAssign` and `RAILPPacking` decide spills at whole-live-interval
+granularity, which ignores reload register pressure and is not reliably
+realizable; they are scoped to register-fitting functions and hard-fail cleanly
+when a function needs spilling. `RAILPDecomp`'s per-point model accounts for
+reloads and allocates functions that require spilling.
 
 ## Limitations
 

--- a/projects/eudsl-llvmpy/src/llvm/__init__.py
+++ b/projects/eudsl-llvmpy/src/llvm/__init__.py
@@ -33,5 +33,6 @@ from . import mir_greedy as _mir_greedy  # noqa: F401
 from . import mir_ilp_base as _mir_ilp_base  # noqa: F401
 from . import mir_ilp_assign as _mir_ilp_assign  # noqa: F401
 from . import mir_ilp_packing as _mir_ilp_packing  # noqa: F401
+from . import mir_ilp_decomp as _mir_ilp_decomp  # noqa: F401
 
 from .eudslllvm_ext import enable_debug  # noqa: F401

--- a/projects/eudsl-llvmpy/src/llvm/mir_ilp_decomp.py
+++ b/projects/eudsl-llvmpy/src/llvm/mir_ilp_decomp.py
@@ -1,0 +1,187 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""RAILPDecomp: SSA spill-then-color decomposition on CP-SAT (report section 5.9).
+
+Phase 1 (ILP): choose a minimum-weight set of vregs to spill so that at every
+program point the number of values that must occupy a register is at most k.
+This is the per-program-point (Appel-George) model, not whole-interval spilling:
+a spilled value still needs a register *at each of its def/use points* (the store
+source / reload), so those points count toward pressure even when the value is
+spilled; only live-*through* points of a spilled value drop to zero. Pressure is
+checked at every def/use point AND every live-range segment boundary, so a peak
+inside a pass-through (holed) segment -- a point that is neither a def nor a use
+of any value -- is not missed. This is what makes the spill set realizable.
+
+Phase 2 (polynomial): color the survivors first-fit in a perfect elimination
+order (maximum cardinality search). On the chordal (SSA) interference graph,
+per-point pressure <= k guarantees a k-coloring exists and greedy in this order
+finds it; a first-fit failure leaves the vreg unassigned and the base hard-fails,
+surfacing the gap rather than masking it.
+
+Scoped to a single register class (like RAILPPacking): multi-class raises.
+"""
+
+import time
+
+from . import mir
+from .mir_ilp_base import (
+    RAILPBase,
+    ILPSolution,
+    stats_from_solver,
+    make_solver,
+    build_interference,
+    candidate_pregs,
+    single_class_k,
+    _require_ortools,
+)
+
+
+def interval_live_at(segments, point):
+    """True if `point` falls in a half-open [start, end) segment (live-through)."""
+    return any(s <= point < e for s, e in segments)
+
+
+def pressure_constraints(intervals, must_reg, spillable, k):
+    """Yield ``(point, fixed, optional)`` for each program point where more than
+    ``k`` values may need a register at once.
+
+    * ``fixed``    -- values that occupy a register there no matter what: those
+                      with a def/use at the point (``must_reg``; a spilled value
+                      still needs a register for its store source / reload) plus
+                      unspillable values live *through* the point.
+    * ``optional`` -- spillable values live through the point; each frees its
+                      register only if spilled.
+
+    Points checked are every def/use point AND every live-range segment
+    boundary, so a pressure peak inside a pass-through (holed) segment -- a point
+    that is neither a def nor a use of any value -- is not missed. ``intervals``
+    and ``must_reg`` share one coordinate space.
+    """
+    points = {pt for v in intervals for pt in must_reg[v]}
+    points |= {s for v in intervals for s, _e in intervals[v]}
+    for p in sorted(points):
+        fixed = 0
+        optional = []
+        for v in intervals:
+            if p in must_reg[v]:
+                fixed += 1
+            elif interval_live_at(intervals[v], p):
+                if spillable[v]:
+                    optional.append(v)
+                else:
+                    fixed += 1
+        if fixed + len(optional) > k:
+            yield p, fixed, optional
+
+
+def perfect_elimination_order(adjacency):
+    """A maximum-cardinality-search ordering of the interference graph.
+
+    An SSA interference graph is chordal; greedy coloring in this order uses
+    exactly max-clique-many colors, so with per-point pressure <= k the
+    survivors are k-colorable. Ties are broken by vreg id for determinism.
+    """
+    weight = {v: 0 for v in adjacency}
+    unnumbered = set(adjacency)
+    order = []
+    while unnumbered:
+        v = max(unnumbered, key=lambda u: (weight[u], u))
+        order.append(v)
+        unnumbered.remove(v)
+        for n in adjacency[v]:
+            if n in unnumbered:
+                weight[n] += 1
+    return order
+
+
+class RAILPDecomp(RAILPBase):
+    def _solve(self, prob):
+        r"""CP-SAT model (SSA spill-then-color decomposition, report section 5.9):
+
+        Phase 1 (ILP) -- choose the spill set.
+
+            variables   spill[v] in {0, 1}   for each spillable vreg v
+
+            pressure    at each program point p (every def/use and every
+                        live-range segment boundary), with
+                          F(p) = #{v : p is a def/use of v}
+                               + #{unspillable v live-through p}
+                          O(p) = {spillable v live-through p}
+                        require   F(p) + sum_{v in O(p)} (1 - spill[v]) <= k
+                        (a spilled value still needs a register at its def/use,
+                         so it counts in F there; only live-through drops to 0)
+
+            objective   minimize  sum_v  w_v * spill[v]
+
+        Phase 2 (polynomial) -- first-fit color the survivors in a perfect
+        elimination order. On the chordal SSA interference graph, pressure <= k
+        guarantees a k-coloring and greedy in this order finds it; a coloring
+        failure leaves a vreg unassigned and the base hard-fails.
+        """
+        k = single_class_k(prob.reg_class_id, prob.num_regs)
+        if k is None:
+            raise RuntimeError(
+                "RAILPDecomp supports a single register class only; this "
+                "function mixes classes"
+            )
+
+        cp = _require_ortools()
+        model = cp.CpModel()
+
+        # Points where each vreg must be in a register (defs + uses). A spilled
+        # value still needs a register at these points (store source / reload).
+        # `_points_in_register` returns them in the same coordinate space as
+        # prob.intervals, so the per-point pressure counts below line up.
+        must_reg = {
+            v: self._points_in_register(self.lis.interval(v)) for v in prob.vregs
+        }
+
+        spill = {
+            v: model.new_bool_var(f"spill_{v}") for v in prob.vregs if prob.spillable[v]
+        }
+
+        for _p, fixed, optional in pressure_constraints(
+            prob.intervals, must_reg, prob.spillable, k
+        ):
+            model.add(fixed + sum(1 - spill[v] for v in optional) <= k)
+
+        model.minimize(sum(prob.weight[v] * spill[v] for v in spill))
+
+        solver = make_solver(cp, self.time_limit_s)
+        t0 = time.perf_counter()
+        status = solver.solve(model)
+        wall = time.perf_counter() - t0
+        stats = stats_from_solver(cp, solver, status, wall)
+
+        if status not in (cp.OPTIMAL, cp.FEASIBLE):
+            return ILPSolution(assignment={}, spilled=set(), stats=stats)
+
+        spilled = {v for v in spill if solver.value(spill[v])}
+        assignment = self._color_survivors(prob, spilled)
+        return ILPSolution(assignment=assignment, spilled=spilled, stats=stats)
+
+    @staticmethod
+    def _color_survivors(prob, spilled):
+        """First-fit color the non-spilled vregs in a perfect elimination order,
+        respecting interference. On a chordal (SSA) interference graph with
+        per-point pressure <= k this uses <= k colors; a first-fit failure leaves
+        the vreg unassigned and the base hard-fails."""
+        survivors = [v for v in prob.vregs if v not in spilled]
+        adjacency = {v: set() for v in survivors}
+        segs = {v: prob.intervals[v] for v in survivors}
+        for edge in build_interference(segs):
+            a, b = tuple(edge)
+            adjacency[a].add(b)
+            adjacency[b].add(a)
+        assignment = {}
+        for v in perfect_elimination_order(adjacency):
+            used = {assignment[n] for n in adjacency[v] if n in assignment}
+            for preg in candidate_pregs(prob.order[v], prob.forbidden[v]):
+                if preg not in used:
+                    assignment[v] = preg
+                    break
+        return assignment
+
+
+mir.RAILPDecomp = RAILPDecomp

--- a/projects/eudsl-llvmpy/tests/mir/ilp_regalloc_compare.py
+++ b/projects/eudsl-llvmpy/tests/mir/ilp_regalloc_compare.py
@@ -87,8 +87,13 @@ _ALLOCS = [
     ("basic", "cmp-basic", False),
     ("ilp-assign", "cmp-assign", True),
     ("ilp-packing", "cmp-pack", True),
+    ("ilp-decomp", "cmp-decomp", True),
 ]
-_ILP_CLASS = {"cmp-assign": "RAILPAssign", "cmp-pack": "RAILPPacking"}
+_ILP_CLASS = {
+    "cmp-assign": "RAILPAssign",
+    "cmp-pack": "RAILPPacking",
+    "cmp-decomp": "RAILPDecomp",
+}
 
 
 def _run_one(fixture, fname, name, regalloc, is_ilp):
@@ -131,6 +136,7 @@ def main():
     mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
     mir.register_regalloc("cmp-assign", mir.RAILPAssign)
     mir.register_regalloc("cmp-pack", mir.RAILPPacking)
+    mir.register_regalloc("cmp-decomp", mir.RAILPDecomp)
     for fixture_name, fixture in _FIXTURES:
         results = [
             _run_one(fixture, fixture_name, name, regalloc, is_ilp)

--- a/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
+++ b/projects/eudsl-llvmpy/tests/mir/test_ilp_regalloc.py
@@ -7,6 +7,7 @@ import pytest
 import llvm
 from llvm import ir, jit, mir
 from llvm import mir_ilp_base as model
+from llvm import mir_ilp_decomp as decomp
 from llvm.mir_ilp_base import RAILPBase, ILPSolution, ILPStats
 from llvm.testing import assert_no_leaks
 
@@ -83,6 +84,59 @@ def _build_high_pressure(mmi):
     rc.add_reg(acc)
     ret = b.build_instr(mf.opcode("RET_ReallyLR"))
     ret.add_reg(w0, implicit=True)
+    for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
+        mf.set_property(getattr(mir.MachineFunctionProperty, prop))
+    return mf
+
+
+def _build_diamond(mmi, n):
+    """A diamond CFG: the entry block defines `n` values from W0, a conditional
+    branch splits into two arms that each chain-add all `n` values and write the
+    result to W0, and both arms rejoin at an exit. Values defined in entry and
+    used in both arms get multi-segment (holed) live ranges -- the multi-block
+    case the single-block fixtures never produce."""
+    mf = mmi.machine_function("diamond")
+    b = mir.MachineIRBuilder(mf)
+    g32 = mf.reg_class("GPR32")
+    w0 = mf.physreg("W0")
+    entry = mf.blocks[0]
+    els_bb = mf.create_block()  # fallthrough arm (laid out right after entry)
+    then_bb = mf.create_block()  # taken arm
+    exit_bb = mf.create_block()
+    entry.add_livein(w0)
+    copy, addrr = mf.opcode("COPY"), mf.opcode("ADDWrr")
+    b.set_block(entry)
+    vs = []
+    for _ in range(n):
+        v = mf.create_vreg(g32)
+        c = b.build_instr(copy)
+        c.add_reg(v, is_def=True)
+        c.add_reg(w0)
+        vs.append(v)
+    cb = b.build_instr(mf.opcode("CBNZW"))  # branch to `then` if vs[0] != 0
+    cb.add_reg(vs[0])
+    cb.add_mbb(then_bb)
+    entry.add_successor(then_bb)
+    entry.add_successor(els_bb)
+    for blk in (els_bb, then_bb):
+        b.set_block(blk)
+        acc = vs[0]
+        for v in vs[1:]:
+            nacc = mf.create_vreg(g32)
+            a = b.build_instr(addrr)
+            a.add_reg(nacc, is_def=True)
+            a.add_reg(acc)
+            a.add_reg(v)
+            acc = nacc
+        rc = b.build_instr(copy)
+        rc.add_reg(w0, is_def=True)
+        rc.add_reg(acc)
+        br = b.build_instr(mf.opcode("B"))
+        br.add_mbb(exit_bb)
+        blk.add_successor(exit_bb)
+    b.set_block(exit_bb)
+    exit_bb.add_livein(w0)
+    b.build_instr(mf.opcode("RET_ReallyLR")).add_reg(w0, implicit=True)
     for prop in ("IsSSA", "TracksLiveness", "NoPHIs"):
         mf.set_property(getattr(mir.MachineFunctionProperty, prop))
     return mf
@@ -175,6 +229,43 @@ def test_single_class_k():
     assert model.single_class_k({}, {}) is None
 
 
+def test_interval_live_at():
+    assert decomp.interval_live_at([(0, 4)], 0) is True
+    assert decomp.interval_live_at([(0, 4)], 3) is True
+    assert decomp.interval_live_at([(0, 4)], 4) is False  # half-open
+    assert decomp.interval_live_at([(0, 2), (8, 10)], 5) is False  # hole
+
+
+def test_pressure_constraints_checks_segment_boundaries():
+    # v1, v2 (spillable) and v3 (unspillable) all pass through the hole segment
+    # [5, 10). Slot 5 is a segment boundary but neither a def nor a use of any
+    # value, so a def/use-only pressure scan would miss the 3-way peak there;
+    # the segment-boundary scan must still emit a constraint. At slot 5: v3 is
+    # counted as fixed (unspillable live-through), v1/v2 as optional (spillable
+    # live-through).
+    intervals = {1: [(0, 1), (5, 10)], 2: [(2, 3), (5, 10)], 3: [(4, 10)]}
+    must_reg = {1: {0, 1}, 2: {2, 3}, 3: {4}}
+    spillable = {1: True, 2: True, 3: False}
+    cons = {
+        p: (fixed, tuple(opt))
+        for p, fixed, opt in decomp.pressure_constraints(
+            intervals, must_reg, spillable, k=2
+        )
+    }
+    assert 5 in cons  # the holed-segment peak is caught
+    assert cons[5] == (1, (1, 2))  # v3 fixed; v1, v2 optional -> 1 + 2 = 3 > k
+    # A def/use-only scan would not check slot 5 (5 is in no must_reg set).
+    assert all(5 not in pts for pts in must_reg.values())
+
+
+def test_perfect_elimination_order_is_a_permutation():
+    # A 3-clique: MCS returns all three vertices once, highest-id tie-break first.
+    adjacency = {1: {2, 3}, 2: {1, 3}, 3: {1, 2}}
+    order = decomp.perfect_elimination_order(adjacency)
+    assert sorted(order) == [1, 2, 3]
+    assert order[0] == 3  # ties broken by vreg id (max)
+
+
 def test_ilp_stats_gap():
     assert ILPStats(status="INFEASIBLE").gap is None
     assert ILPStats(status="OPTIMAL", objective=0.0).gap == 0.0
@@ -234,6 +325,13 @@ def test_assign_solve_standalone_infeasible():
     )
     assert sol.stats.status == "INFEASIBLE"
     assert sol.assignment == {} and sol.spilled == set()
+
+
+def test_decomp_solve_standalone_multiclass_raises():
+    with pytest.raises(RuntimeError, match="single register class"):
+        mir.RAILPDecomp()._solve(
+            _mk_problem(num_regs={1: 30, 2: 30, 3: 30}, reg_class_id={1: 0, 2: 1, 3: 0})
+        )
 
 
 def test_packing_solve_standalone_spill_and_degenerate_segment():
@@ -589,4 +687,116 @@ def test_points_in_register_aligns_with_intervals():
         end = max(e for _, e in intervals[v])
         assert min(pts) == start
         assert all(start <= p <= end for p in pts)
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_decomp_pressure_free_no_spill():
+    mir.register_regalloc("ilp-decomp-t", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "add")
+        _build_add(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-t")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    v0, v1, v2 = sorted(assignments)
+    assert assignments[v0] != assignments[v1]
+    assert spilled == []
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_decomp_high_pressure_spills_and_is_valid():
+    # The per-point model accounts for reload pressure, so its spill set is
+    # realizable: it actually spills and produces a valid allocation where
+    # whole-interval RAILPAssign/RAILPPacking hard-fail.
+    mir.register_regalloc("ilp-decomp-hp", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "hp")
+        _build_high_pressure(mmi)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-hp")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    assert len(spilled) >= 1  # pressure forces real spilling
+    assert set(assignments) & set(spilled) == set()  # no vreg both assigned and spilled
+    assert all(isinstance(p, int) for p in assignments.values())
+    assert len(set(assignments.values())) >= 2  # a real multi-register coloring
+    # Collision-freedom (no two simultaneously-live vregs share a register) is
+    # guaranteed by the base: select_or_split only returns a matrix.is_free
+    # physreg and hard-fails otherwise, so a completed run cannot contain one.
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_decomp_multiblock_diamond_valid():
+    # A real multi-block CFG (not the single-block fixtures): entry values used
+    # in both arms of a diamond get multi-segment (holed) live ranges, whose
+    # later segment starts are block-rejoin points, not defs -- exactly what the
+    # segment-boundary pressure scan and the PEO coloring must handle. Low
+    # pressure -> no spill; the two entry values are simultaneously live and get
+    # distinct registers.
+    mir.register_regalloc("ilp-decomp-dia", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "diamond")
+        _build_diamond(mmi, 2)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-dia")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    assert spilled == []
+    entry_vals = sorted(assignments)[:2]  # the two entry COPYs (smallest vreg ids)
+    assert assignments[entry_vals[0]] != assignments[entry_vals[1]]
+    assert_no_leaks()
+
+
+@aarch64
+def test_ilp_decomp_multiblock_diamond_spills():
+    # A wide diamond: 40 values live across the conditional branch exceed the
+    # ~30 allocatable GPR32 registers, so RAILPDecomp must spill and still
+    # produce a valid multi-block allocation (coloring the survivors across
+    # blocks in a perfect elimination order).
+    mir.register_regalloc("ilp-decomp-dia-hp", mir.RAILPDecomp)
+    with ir.Context() as ctx:
+        mod = ir.Module("m", ctx)
+        tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+        mmi = mir.create_machine_function(mod, tm, "diamond")
+        _build_diamond(mmi, 40)
+        result = mmi.regalloc_assignments(regalloc="ilp-decomp-dia-hp")
+        assignments = dict(result.assignments)
+        spilled = list(result.spilled)
+    assert len(spilled) >= 1
+    assert set(assignments) & set(spilled) == set()
+    assert all(isinstance(p, int) for p in assignments.values())
+    assert len(set(assignments.values())) >= 2
+    assert_no_leaks()
+
+
+@aarch64
+def test_comparison_low_pressure_all_valid_and_ilp_optimal():
+    mir.register_regalloc("cmp-basic", mir.BasicRegAlloc)
+    mir.register_regalloc("cmp-assign", mir.RAILPAssign)
+    mir.register_regalloc("cmp-pack", mir.RAILPPacking)
+    mir.register_regalloc("cmp-decomp", mir.RAILPDecomp)
+    for alloc in ["greedy", "cmp-basic", "cmp-assign", "cmp-pack", "cmp-decomp"]:
+        with ir.Context() as ctx:
+            mod = ir.Module("m", ctx)
+            tm = jit.TargetMachine(triple=_AARCH64_LINUX)
+            mmi = mir.create_machine_function(mod, tm, "add")
+            _build_add(mmi)
+            result = mmi.regalloc_assignments(regalloc=alloc)
+            assignments = dict(result.assignments)
+            spilled = list(result.spilled)
+        assert spilled == [], f"{alloc} spilled on a pressure-free function"
+        v0, v1, _ = sorted(assignments)
+        assert assignments[v0] != assignments[v1], f"{alloc} gave a bad coloring"
+    # Every ILP allocator proves optimality (gap 0) on this trivial function.
+    for cls in ("RAILPAssign", "RAILPPacking", "RAILPDecomp"):
+        stats = RAILPBase.last_stats[cls]
+        assert stats.status in ("OPTIMAL", "FEASIBLE")
+        assert stats.gap == 0.0
     assert_no_leaks()


### PR DESCRIPTION
**Stacked PR 3 of 4** — targets `ilp-assign` (#672). Review/merge the stack in order.

Adds **`RAILPDecomp`**, the SSA spill-then-color decomposition — the one allocator that handles spilling correctly:

- **Phase 1 (ILP):** minimum-weight spill set such that at every def/use program point the number of values that must occupy a register is ≤ k. Crucially this is the **per-program-point (Appel-George)** model, not whole-interval spilling: a spilled value still needs a register at its def/use points (store source / reload), so those points count toward pressure. That's what makes the spill set realizable — reloads always fit.
- **Phase 2 (polynomial):** color survivors first-fit in definition (dominance) order.
- Uses `VNInfo.def_index` for defs and `SplitAnalysis.get_use_slots()` for uses. Single register class.

This is the headline comparison result: on high-pressure functions `RAILPAssign`/`RAILPPacking` hard-fail (whole-interval spilling ignores reload pressure), while `RAILPDecomp` spills and produces a valid, proven-optimal allocation — matching the literature (Appel-George, report §2.3/§5.4).